### PR TITLE
Fix bug in s3BucketWithLogging function 

### DIFF
--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
@@ -67,7 +67,7 @@ function s3BucketWithLogging(scope: cdk.Construct, s3BucketProps?: s3.BucketProp
     const _loggingBucketId = bucketId ? bucketId + 'S3LoggingBucket' : 'S3LoggingBucket';
 
     if (s3BucketProps?.serverAccessLogsBucket) {
-        bucketprops = DefaultS3Props;
+        bucketprops = DefaultS3Props();
     } else {
         // Create the Logging Bucket
         const loggingBucket: s3.Bucket = new s3.Bucket(scope, _loggingBucketId, DefaultS3Props());


### PR DESCRIPTION
In the s3BucketWithLogging function, bucketprops gets passed a function instead of the function's output, which is an object.

*Issue #, if available:*
I think this is what is causing the following issue:
https://github.com/awslabs/aws-solutions-constructs/issues/5

*Description of changes:*
Called the DefaultS3Props helper function instead of passing the function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.