### PR TITLE
Fix Sqs lambda doesn't work for FIFO queue

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/README.md
@@ -60,6 +60,7 @@ _Parameters_
 |existingLambdaObj?|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|An optional, existing Lambda function.|
 |lambdaFunctionProps?|[`lambda.FunctionProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.FunctionProps.html)|Optional user-provided props to override the default props for the Lambda function.|
 |queueProps?|[`sqs.QueueProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-sqs.QueueProps.html)|Optional user-provided props to override the default props for the SQS queue.|
+|dLQueueProps?|[`sqs.QueueProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-sqs.QueueProps.html)|Optional user-provided props to override the default props for the dead letter SQS queue.|
 |deployDeadLetterQueue?|`boolean`|Whether to create a secondary queue to be used as a dead letter queue. Defaults to true.|
 |maxReceiveCount?|`number`|The number of times a message can be unsuccessfully dequeued before being moved to the dead letter queue. Defaults to 15.|
 

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/lib/index.ts
@@ -50,6 +50,12 @@ export interface SqsToLambdaProps {
      */
     readonly queueProps?: sqs.QueueProps | any
     /**
+     * Optional user provided properties for the dead letter queue
+     *
+     * @default - Default props are used
+     */
+    readonly dlQueueProps?: sqs.QueueProps | any
+    /**
      * Whether to deploy a secondary queue to be used as a dead letter queue.
      *
      * @default - true.
@@ -92,7 +98,7 @@ export class SqsToLambda extends Construct {
         let dlqi: sqs.DeadLetterQueue | undefined;
         if (props.deployDeadLetterQueue || props.deployDeadLetterQueue === undefined) {
             const dlq: sqs.Queue = defaults.buildQueue(this, 'deadLetterQueue', {
-                queueProps: props.queueProps
+                queueProps: props.dlQueueProps
             });
             dlqi = defaults.buildDeadLetterQueue({
                 deadLetterQueue: dlq,


### PR DESCRIPTION
Fixes https://github.com/awslabs/aws-solutions-constructs/issues/12

*Description of changes:*
The dead letter queue becomes its own property

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I tried to add some unit tests and integration tests to check if they now have different names but source/tools/cdk-integ-tools/README.md confuses me. Is that still up to date? Can you point me for how to run the jest and integration tests in that repo?