### PR TITLE
feat(aws-kinesisstreams-lambda): Add ability to bring-your-own stream

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/README.md
@@ -62,7 +62,8 @@ _Parameters_
 |existingLambdaObj?|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|Existing instance of Lambda Function object, if this is set then the lambdaFunctionProps is ignored.|
 |lambdaFunctionProps?|[`lambda.FunctionProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.FunctionProps.html)|User provided props to override the default props for the Lambda function.|
 |kinesisStreamProps?|[`kinesis.StreamProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-kinesis.StreamProps.html)|Optional user-provided props to override the default props for the Kinesis stream.|
-|eventSourceProps?|[`lambda.EventSourceMappingOptions`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.EventSourceMappingOptions.html)|Optional user-provided props to override the default props for the Lambda event source mapping.|
+|existingStreamObj?|[`kinesis.Stream`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-kinesis.Stream.html)|Existing instance of Kinesis Stream, if this is set then kinesisStreamProps is ignored.|
+|kinesisEventSourceProps?|[`aws-lambda-event-sources.KinesisEventSourceProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda-event-sources.KinesisEventSourceProps.html)|Optional user-provided props to override the default props for the Lambda event source mapping.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
@@ -57,6 +57,7 @@
     "@aws-cdk/aws-kinesis": "~1.62.0",
     "@aws-cdk/aws-kms": "~1.62.0",
     "@aws-cdk/aws-lambda": "~1.62.0",
+    "@aws-cdk/aws-lambda-event-sources": "~1.62.0",
     "@aws-cdk/core": "~1.62.0",
     "@aws-solutions-constructs/core": "~1.62.0",
     "constructs": "^3.0.4"
@@ -76,6 +77,7 @@
     "@aws-cdk/aws-kinesis": "~1.62.0",
     "@aws-cdk/aws-kms": "~1.62.0",
     "@aws-cdk/aws-lambda": "~1.62.0",
+    "@aws-cdk/aws-lambda-event-sources": "~1.62.0",
     "@aws-cdk/core": "~1.62.0",
     "@aws-solutions-constructs/core": "~1.62.0",
     "constructs": "^3.0.4"

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/__snapshots__/test.kinesisstreams-lambda.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/__snapshots__/test.kinesisstreams-lambda.test.js.snap
@@ -101,8 +101,10 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "testkinesisstreamslambdaLambdaFunctionLambdaKinesisEventSourceMapping06EA601A": Object {
+    "testkinesisstreamslambdaLambdaFunctionKinesisEventSourcetestkinesisstreamslambdaKinesisStreamE01CADBD221E7379": Object {
       "Properties": Object {
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
             "testkinesisstreamslambdaKinesisStream76FFCAB1",
@@ -112,6 +114,7 @@ Object {
         "FunctionName": Object {
           "Ref": "testkinesisstreamslambdaLambdaFunction02E4DD2D",
         },
+        "StartingPosition": "TRIM_HORIZON",
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -249,6 +252,16 @@ Object {
                 ],
               },
             },
+            Object {
+              "Action": "kinesis:DescribeStream",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "testkinesisstreamslambdaKinesisStream76FFCAB1",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -260,6 +273,225 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+  },
+}
+`;
+
+exports[`Test existing resources 1`] = `
+Object {
+  "Parameters": Object {
+    "AssetParametersdfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcdArtifactHashEA3A5944": Object {
+      "Description": "Artifact hash for asset \\"dfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcd\\"",
+      "Type": "String",
+    },
+    "AssetParametersdfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcdS3BucketA460830B": Object {
+      "Description": "S3 bucket for asset \\"dfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcd\\"",
+      "Type": "String",
+    },
+    "AssetParametersdfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcdS3VersionKey58FEB9E6": Object {
+      "Description": "S3 key for asset version \\"dfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcd\\"",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "testfn76BCC25C": Object {
+      "DependsOn": Array [
+        "testfnServiceRoleDefaultPolicy63AA2D42",
+        "testfnServiceRoleC30E0817",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParametersdfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcdS3BucketA460830B",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParametersdfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcdS3VersionKey58FEB9E6",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParametersdfe828a7d00b0da7a6e92dc1decf39ec907e4edc6006faea8631d4dabd7f4fcdS3VersionKey58FEB9E6",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "testfnServiceRoleC30E0817",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs10.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "testfnKinesisEventSourceteststreamE93A322D": Object {
+      "Properties": Object {
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": true,
+        "EventSourceArn": Object {
+          "Fn::GetAtt": Array [
+            "teststream04374A09",
+            "Arn",
+          ],
+        },
+        "FunctionName": Object {
+          "Ref": "testfn76BCC25C",
+        },
+        "StartingPosition": "TRIM_HORIZON",
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "testfnServiceRoleC30E0817": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testfnServiceRoleDefaultPolicy63AA2D42": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:DescribeStreamSummary",
+                "kinesis:GetRecords",
+                "kinesis:GetShardIterator",
+                "kinesis:ListShards",
+                "kinesis:SubscribeToShard",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "teststream04374A09",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "kinesis:DescribeStream",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "teststream04374A09",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testfnServiceRoleDefaultPolicy63AA2D42",
+        "Roles": Array [
+          Object {
+            "Ref": "testfnServiceRoleC30E0817",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "testkinesisstreamslambdaLambdaFunctionPolicyF7EF016E": Object {
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W12",
+              "reason": "The kinesis:ListStreams action requires a wildcard resource.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:GetRecords",
+                "kinesis:GetShardIterator",
+                "kinesis:DescribeStream",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "teststream04374A09",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "kinesis:ListStreams",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testkinesisstreamslambdaLambdaFunctionPolicyF7EF016E",
+        "Roles": Array [
+          Object {
+            "Ref": "testfnServiceRoleC30E0817",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "teststream04374A09": Object {
+      "Properties": Object {
+        "Name": "existing-stream",
+        "RetentionPeriodHours": 48,
+        "ShardCount": 5,
+      },
+      "Type": "AWS::Kinesis::Stream",
     },
   },
 }

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/integ.deployFunction.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/integ.deployFunction.ts
@@ -24,7 +24,7 @@ stack.templateOptions.description = 'Integration Test for aws-kinesisstreams-lam
 // Definitions
 const props: KinesisStreamsToLambdaProps = {
     kinesisStreamProps: {},
-    eventSourceProps: {
+    kinesisEventSourceProps: {
         startingPosition: lambda.StartingPosition.TRIM_HORIZON,
         batchSize: 1
     },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/integ.existing.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/integ.existing.expected.json
@@ -1,18 +1,7 @@
 {
   "Description": "Integration Test for aws-kinesisstreams-lambda",
   "Resources": {
-    "testkslambdaKinesisStreamE607D575": {
-      "Type": "AWS::Kinesis::Stream",
-      "Properties": {
-        "ShardCount": 1,
-        "RetentionPeriodHours": 24,
-        "StreamEncryption": {
-          "EncryptionType": "KMS",
-          "KeyId": "alias/aws/kinesis"
-        }
-      }
-    },
-    "testkslambdaLambdaFunctionServiceRole329F6464": {
+    "testroleB50A37BE": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -63,19 +52,11 @@
         ]
       }
     },
-    "testkslambdaLambdaFunctionServiceRoleDefaultPolicy06A105D0": {
+    "testroleDefaultPolicy884631E2": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
           "Statement": [
-            {
-              "Action": [
-                "xray:PutTraceSegments",
-                "xray:PutTelemetryRecords"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            },
             {
               "Action": [
                 "kinesis:DescribeStreamSummary",
@@ -87,7 +68,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testkslambdaKinesisStreamE607D575",
+                  "teststream04374A09",
                   "Arn"
                 ]
               }
@@ -97,7 +78,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testkslambdaKinesisStreamE607D575",
+                  "teststream04374A09",
                   "Arn"
                 ]
               }
@@ -105,25 +86,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testkslambdaLambdaFunctionServiceRoleDefaultPolicy06A105D0",
+        "PolicyName": "testroleDefaultPolicy884631E2",
         "Roles": [
           {
-            "Ref": "testkslambdaLambdaFunctionServiceRole329F6464"
+            "Ref": "testroleB50A37BE"
           }
         ]
-      },
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "W12",
-              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray."
-            }
-          ]
-        }
       }
     },
-    "testkslambdaLambdaFunction995A7276": {
+    "testfn76BCC25C": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -167,50 +138,43 @@
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "testkslambdaLambdaFunctionServiceRole329F6464",
+            "testroleB50A37BE",
             "Arn"
           ]
         },
-        "Runtime": "nodejs10.x",
-        "Environment": {
-          "Variables": {
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
-          }
-        },
-        "TracingConfig": {
-          "Mode": "Active"
-        }
+        "Runtime": "nodejs10.x"
       },
       "DependsOn": [
-        "testkslambdaLambdaFunctionServiceRoleDefaultPolicy06A105D0",
-        "testkslambdaLambdaFunctionServiceRole329F6464"
-      ],
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "W58",
-              "reason": "Lambda functions has the required permission to write CloudWatch Logs. It uses custom policy instead of arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole with more tighter permissions."
-            }
-          ]
-        }
-      }
+        "testroleDefaultPolicy884631E2",
+        "testroleB50A37BE"
+      ]
     },
-    "testkslambdaLambdaFunctionKinesisEventSourcetestkslambdastacktestkslambdaKinesisStream34D4E9A7E70CF520": {
+    "testfnKinesisEventSourcetestkslambdastackteststream0CD251F02AE6CC2F": {
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "EventSourceArn": {
           "Fn::GetAtt": [
-            "testkslambdaKinesisStreamE607D575",
+            "teststream04374A09",
             "Arn"
           ]
         },
         "FunctionName": {
-          "Ref": "testkslambdaLambdaFunction995A7276"
+          "Ref": "testfn76BCC25C"
         },
         "BatchSize": 1,
         "BisectBatchOnFunctionError": true,
-        "StartingPosition": "TRIM_HORIZON"
+        "StartingPosition": "LATEST"
+      }
+    },
+    "teststream04374A09": {
+      "Type": "AWS::Kinesis::Stream",
+      "Properties": {
+        "ShardCount": 2,
+        "RetentionPeriodHours": 24,
+        "StreamEncryption": {
+          "EncryptionType": "KMS",
+          "KeyId": "alias/aws/kinesis"
+        }
       }
     },
     "testkslambdaLambdaFunctionPolicyDC40446F": {
@@ -227,7 +191,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testkslambdaKinesisStreamE607D575",
+                  "teststream04374A09",
                   "Arn"
                 ]
               }
@@ -243,7 +207,7 @@
         "PolicyName": "testkslambdaLambdaFunctionPolicyDC40446F",
         "Roles": [
           {
-            "Ref": "testkslambdaLambdaFunctionServiceRole329F6464"
+            "Ref": "testroleB50A37BE"
           }
         ]
       },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/integ.existing.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/integ.existing.ts
@@ -1,0 +1,67 @@
+/**
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+// Imports
+import { KinesisStreamsToLambda, KinesisStreamsToLambdaProps } from '../lib';
+import { Stack, App, Aws } from '@aws-cdk/core';
+import * as kinesis from '@aws-cdk/aws-kinesis';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as iam from '@aws-cdk/aws-iam';
+
+// Setup
+const app = new App();
+const stack = new Stack(app, 'test-ks-lambda-stack');
+stack.templateOptions.description = 'Integration Test for aws-kinesisstreams-lambda';
+
+const lambdaRole = new iam.Role(stack, 'test-role', {
+    assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    inlinePolicies: {
+        LambdaFunctionServiceRolePolicy: new iam.PolicyDocument({
+            statements: [new iam.PolicyStatement({
+                actions: [
+                    'logs:CreateLogGroup',
+                    'logs:CreateLogStream',
+                    'logs:PutLogEvents'
+                ],
+                resources: [`arn:aws:logs:${Aws.REGION}:${Aws.ACCOUNT_ID}:log-group:/aws/lambda/*`]
+            })]
+        })
+    }
+});
+
+const lambdaFn = new lambda.Function(stack, 'test-fn', {
+    runtime: lambda.Runtime.NODEJS_10_X,
+    handler: 'index.handler',
+    code: lambda.Code.asset(`${__dirname}/lambda`),
+    role: lambdaRole,
+});
+
+const stream = new kinesis.Stream(stack, 'test-stream', {
+    shardCount: 2,
+    encryption: kinesis.StreamEncryption.MANAGED
+});
+
+// Definitions
+const props: KinesisStreamsToLambdaProps = {
+    existingStreamObj: stream,
+    existingLambdaObj: lambdaFn,
+    kinesisEventSourceProps: {
+        startingPosition: lambda.StartingPosition.LATEST,
+        batchSize: 1
+    },
+};
+
+new KinesisStreamsToLambda(stack, 'test-ks-lambda', props);
+
+// Synth
+app.synth();

--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-event-source-mapping-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-event-source-mapping-defaults.ts
@@ -13,15 +13,8 @@
 
 import * as lambda from '@aws-cdk/aws-lambda';
 import { overrideProps } from './utils';
-import { DynamoEventSourceProps, S3EventSourceProps } from '@aws-cdk/aws-lambda-event-sources';
+import { DynamoEventSourceProps, S3EventSourceProps, KinesisEventSourceProps } from '@aws-cdk/aws-lambda-event-sources';
 import * as s3 from '@aws-cdk/aws-s3';
-
-export function DefaultKinesisEventSourceProps(_eventSourceArn: string) {
-    const defaultEventSourceProps: lambda.EventSourceMappingOptions = {
-        eventSourceArn: _eventSourceArn
-    };
-    return defaultEventSourceProps;
-}
 
 export function DynamoEventSourceProps(_dynamoEventSourceProps?: DynamoEventSourceProps) {
 
@@ -46,5 +39,18 @@ export function S3EventSourceProps(_s3EventSourceProps?: S3EventSourceProps) {
         return overrideProps(defaultS3EventSourceProps, _s3EventSourceProps, false);
     } else {
         return defaultS3EventSourceProps;
+    }
+}
+
+export function KinesisEventSourceProps(_kinesisEventSourceProps?: KinesisEventSourceProps) {
+    const defaultKinesisEventSourceProps = {
+        startingPosition: lambda.StartingPosition.TRIM_HORIZON,
+        bisectBatchOnError: true
+    };
+
+    if (_kinesisEventSourceProps) {
+        return overrideProps(defaultKinesisEventSourceProps, _kinesisEventSourceProps, false);
+    } else {
+        return defaultKinesisEventSourceProps;
     }
 }

--- a/source/patterns/@aws-solutions-constructs/core/test/lambda-event-source.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/lambda-event-source.test.ts
@@ -12,7 +12,7 @@
  */
 
 import * as defaults from '../index';
-import { DynamoEventSourceProps } from '@aws-cdk/aws-lambda-event-sources';
+import { DynamoEventSourceProps, KinesisEventSourceProps } from '@aws-cdk/aws-lambda-event-sources';
 import * as lambda from '@aws-cdk/aws-lambda';
 import * as s3 from '@aws-cdk/aws-s3';
 import '@aws-cdk/assert/jest';
@@ -39,14 +39,6 @@ test('test DynamoEventSourceProps override', () => {
   });
 });
 
-test('test KinesisEventSourceProps', () => {
-  const streamArn = 'xyz';
-  const props = defaults.DefaultKinesisEventSourceProps(streamArn);
-  expect(props).toEqual({
-      eventSourceArn: "xyz"
-  });
-});
-
 test('test S3EventSourceProps w/ default props', () => {
   const props = defaults.S3EventSourceProps();
   expect(props).toEqual({
@@ -63,5 +55,31 @@ test('test S3EventSourceProps w/ user props', () => {
   const props = defaults.S3EventSourceProps(s3EventSourceProps);
   expect(props).toEqual({
     events: ["s3:ObjectCreated:Post"]
+  });
+});
+
+test('test KinesisEventSourceProps', () => {
+  const props = defaults.KinesisEventSourceProps();
+
+  expect(props).toEqual({
+    startingPosition: "TRIM_HORIZON",
+    bisectBatchOnError: true
+  });
+});
+
+test('test KinesisEventSourceProps override', () => {
+  const myProps: KinesisEventSourceProps = {
+    startingPosition: lambda.StartingPosition.LATEST,
+    batchSize: 5,
+    retryAttempts: 3
+  };
+
+  const props = defaults.KinesisEventSourceProps(myProps);
+
+  expect(props).toEqual({
+    batchSize: 5,
+    startingPosition: "LATEST",
+    bisectBatchOnError: true,
+    retryAttempts: 3
   });
 });


### PR DESCRIPTION
*Issue #, if available:* #58 

*Description of changes:* This PR adds the ability to bring an existing Kinesis stream to the `aws-kinesisstreams-lambda` pattern. There's also a breaking change in the pattern interface (described below).

**BREAKING CHANGE**: DefaultKinesisEventSourceProps was removed from lambda-event-source-mapping-defaults and replaced with KinesisEventSourceProps. This now follows the same behavior as the aws-dynamodb-stream-lambda and aws-s3-lambda patterns (which use DynamoEventSourceProps and S3EventSourceProps instead of EventSourceMappingOptions)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.