### PR TITLE
Fix AllowReadOperation always evaluating to True

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
@@ -172,7 +172,7 @@ export class ApiGatewayToSqs extends Construct {
             readRequestTemplate = props.readRequestTemplate;
         }
 
-        if (!props.allowReadOperation || props.allowReadOperation === true) {
+        if (props.allowReadOperation && props.allowReadOperation === true) {
             this.addActionToPolicy("sqs:ReceiveMessage");
             defaults.addProxyMethodToApiResource({
                 service: "sqs",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change will fix bug on how allowReadOperation is always being evaluated to true

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.