### PR TITLE
T047 - Fix CloudWatch Log Policy Size in Step Functions construct

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/__snapshots__/events-rule-step-function.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/__snapshots__/events-rule-step-function.test.js.snap
@@ -174,6 +174,9 @@ Object {
           ],
         },
       },
+      "Properties": Object {
+        "LogGroupName": "/aws/vendedlogs/states/defaulttesteventsrulestepfunctionstatemachinelog5bd198c8f277",
+      },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-no-argument.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-no-argument.expected.json
@@ -1,9 +1,12 @@
 {
   "Resources": {
-    "testeventsrulestepfunctionstackStateMachineLogGroupC3B398D4": {
+    "testeventsrulestepfunctionconstructStateMachineLogGroup9F23A0FB": {
       "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/vendedlogs/states/testeventsrulestepfunctionstacktesteventsrulestepfunctionconstructstatemachinelogdd33737e030e"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
         "cfn_nag": {
           "rules_to_suppress": [
@@ -19,7 +22,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionstackStateMachineRoleA5C98F35": {
+    "testeventsrulestepfunctionconstructStateMachineRoleBC40499F": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -47,7 +50,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionstackStateMachineRoleDefaultPolicyC51897AF": {
+    "testeventsrulestepfunctionconstructStateMachineRoleDefaultPolicy121FE5E3": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -94,10 +97,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulestepfunctionstackStateMachineRoleDefaultPolicyC51897AF",
+        "PolicyName": "testeventsrulestepfunctionconstructStateMachineRoleDefaultPolicy121FE5E3",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionstackStateMachineRoleA5C98F35"
+            "Ref": "testeventsrulestepfunctionconstructStateMachineRoleBC40499F"
           }
         ]
       },
@@ -112,12 +115,12 @@
         }
       }
     },
-    "testeventsrulestepfunctionstackStateMachine48534048": {
+    "testeventsrulestepfunctionconstructStateMachineEC649FB0": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testeventsrulestepfunctionstackStateMachineRoleA5C98F35",
+            "testeventsrulestepfunctionconstructStateMachineRoleBC40499F",
             "Arn"
           ]
         },
@@ -128,7 +131,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testeventsrulestepfunctionstackStateMachineLogGroupC3B398D4",
+                    "testeventsrulestepfunctionconstructStateMachineLogGroup9F23A0FB",
                     "Arn"
                   ]
                 }
@@ -139,11 +142,11 @@
         }
       },
       "DependsOn": [
-        "testeventsrulestepfunctionstackStateMachineRoleDefaultPolicyC51897AF",
-        "testeventsrulestepfunctionstackStateMachineRoleA5C98F35"
+        "testeventsrulestepfunctionconstructStateMachineRoleDefaultPolicy121FE5E3",
+        "testeventsrulestepfunctionconstructStateMachineRoleBC40499F"
       ]
     },
-    "testeventsrulestepfunctionstackEventsRuleRole6AD4C16A": {
+    "testeventsrulestepfunctionconstructEventsRuleRole17E8002D": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -160,7 +163,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionstackEventsRuleRoleDefaultPolicy9F3CC359": {
+    "testeventsrulestepfunctionconstructEventsRuleRoleDefaultPolicy0E65F6F0": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -169,21 +172,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testeventsrulestepfunctionstackStateMachine48534048"
+                "Ref": "testeventsrulestepfunctionconstructStateMachineEC649FB0"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulestepfunctionstackEventsRuleRoleDefaultPolicy9F3CC359",
+        "PolicyName": "testeventsrulestepfunctionconstructEventsRuleRoleDefaultPolicy0E65F6F0",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionstackEventsRuleRole6AD4C16A"
+            "Ref": "testeventsrulestepfunctionconstructEventsRuleRole17E8002D"
           }
         ]
       }
     },
-    "testeventsrulestepfunctionstackEventsRuleF510C733": {
+    "testeventsrulestepfunctionconstructEventsRule4ACA1995": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -191,12 +194,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testeventsrulestepfunctionstackStateMachine48534048"
+              "Ref": "testeventsrulestepfunctionconstructStateMachineEC649FB0"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulestepfunctionstackEventsRuleRole6AD4C16A",
+                "testeventsrulestepfunctionconstructEventsRuleRole17E8002D",
                 "Arn"
               ]
             }
@@ -204,7 +207,7 @@
         ]
       }
     },
-    "testeventsrulestepfunctionstackExecutionFailedAlarm865F1B9B": {
+    "testeventsrulestepfunctionconstructExecutionFailedAlarm9BA37D4B": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -214,7 +217,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionstackStateMachine48534048"
+              "Ref": "testeventsrulestepfunctionconstructStateMachineEC649FB0"
             }
           }
         ],
@@ -225,7 +228,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionstackExecutionThrottledAlarm25CE7A69": {
+    "testeventsrulestepfunctionconstructExecutionThrottledAlarmF36B7E20": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -235,7 +238,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionstackStateMachine48534048"
+              "Ref": "testeventsrulestepfunctionconstructStateMachineEC649FB0"
             }
           }
         ],
@@ -246,7 +249,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionstackExecutionAbortedAlarmADD2893F": {
+    "testeventsrulestepfunctionconstructExecutionAbortedAlarm4EC52091": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -256,7 +259,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionstackStateMachine48534048"
+              "Ref": "testeventsrulestepfunctionconstructStateMachineEC649FB0"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-no-argument.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-no-argument.ts
@@ -12,7 +12,7 @@
  */
 
 /// !cdk-integ *
-import { App, Stack } from "@aws-cdk/core";
+import { App, Stack, RemovalPolicy } from "@aws-cdk/core";
 import { EventsRuleToStepFunction, EventsRuleToStepFunctionProps } from "../lib";
 import { Duration } from '@aws-cdk/core';
 import * as stepfunctions from '@aws-cdk/aws-stepfunctions';
@@ -29,8 +29,11 @@ const props: EventsRuleToStepFunctionProps = {
   },
   eventRuleProps: {
     schedule: events.Schedule.rate(Duration.minutes(5))
-  }
+  },
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY
+  },
 };
 
-new EventsRuleToStepFunction(stack, 'test-events-rule-step-function-stack', props);
+new EventsRuleToStepFunction(stack, 'test-events-rule-step-function-construct', props);
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-with-lambda.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-with-lambda.expected.json
@@ -130,19 +130,19 @@
             ]
           }
         },
-        "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
             "LambdaFunctionServiceRole0C4CDE0B",
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
         "Environment": {
           "Variables": {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },
+        "Handler": "index.handler",
+        "Runtime": "nodejs12.x",
         "TracingConfig": {
           "Mode": "Active"
         }
@@ -170,10 +170,13 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdastackStateMachineLogGroup5FA8F5A3": {
+    "testeventsrulestepfunctionandlambdaconstructStateMachineLogGroupCDF3947B": {
       "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/vendedlogs/states/testeventsrulestepfunctionandlambdastacktesteventsrulestepfunctionandlambdaconstructstatemachinelog079073f21429"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
         "cfn_nag": {
           "rules_to_suppress": [
@@ -189,7 +192,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdastackStateMachineRole77040795": {
+    "testeventsrulestepfunctionandlambdaconstructStateMachineRole0801735F": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -217,7 +220,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdastackStateMachineRoleDefaultPolicy7FB04121": {
+    "testeventsrulestepfunctionandlambdaconstructStateMachineRoleDefaultPolicy8DDF0413": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -274,10 +277,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulestepfunctionandlambdastackStateMachineRoleDefaultPolicy7FB04121",
+        "PolicyName": "testeventsrulestepfunctionandlambdaconstructStateMachineRoleDefaultPolicy8DDF0413",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionandlambdastackStateMachineRole77040795"
+            "Ref": "testeventsrulestepfunctionandlambdaconstructStateMachineRole0801735F"
           }
         ]
       },
@@ -292,12 +295,12 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdastackStateMachine3BC6D432": {
+    "testeventsrulestepfunctionandlambdaconstructStateMachine891F12F0": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testeventsrulestepfunctionandlambdastackStateMachineRole77040795",
+            "testeventsrulestepfunctionandlambdaconstructStateMachineRole0801735F",
             "Arn"
           ]
         },
@@ -323,7 +326,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testeventsrulestepfunctionandlambdastackStateMachineLogGroup5FA8F5A3",
+                    "testeventsrulestepfunctionandlambdaconstructStateMachineLogGroupCDF3947B",
                     "Arn"
                   ]
                 }
@@ -334,11 +337,11 @@
         }
       },
       "DependsOn": [
-        "testeventsrulestepfunctionandlambdastackStateMachineRoleDefaultPolicy7FB04121",
-        "testeventsrulestepfunctionandlambdastackStateMachineRole77040795"
+        "testeventsrulestepfunctionandlambdaconstructStateMachineRoleDefaultPolicy8DDF0413",
+        "testeventsrulestepfunctionandlambdaconstructStateMachineRole0801735F"
       ]
     },
-    "testeventsrulestepfunctionandlambdastackEventsRuleRole1FC528B4": {
+    "testeventsrulestepfunctionandlambdaconstructEventsRuleRole137FAF2D": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -355,7 +358,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdastackEventsRuleRoleDefaultPolicyCA432EB7": {
+    "testeventsrulestepfunctionandlambdaconstructEventsRuleRoleDefaultPolicyB4FE732D": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -364,21 +367,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testeventsrulestepfunctionandlambdastackStateMachine3BC6D432"
+                "Ref": "testeventsrulestepfunctionandlambdaconstructStateMachine891F12F0"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulestepfunctionandlambdastackEventsRuleRoleDefaultPolicyCA432EB7",
+        "PolicyName": "testeventsrulestepfunctionandlambdaconstructEventsRuleRoleDefaultPolicyB4FE732D",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionandlambdastackEventsRuleRole1FC528B4"
+            "Ref": "testeventsrulestepfunctionandlambdaconstructEventsRuleRole137FAF2D"
           }
         ]
       }
     },
-    "testeventsrulestepfunctionandlambdastackEventsRule5C68D98F": {
+    "testeventsrulestepfunctionandlambdaconstructEventsRuleA71CE991": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -386,12 +389,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testeventsrulestepfunctionandlambdastackStateMachine3BC6D432"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructStateMachine891F12F0"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulestepfunctionandlambdastackEventsRuleRole1FC528B4",
+                "testeventsrulestepfunctionandlambdaconstructEventsRuleRole137FAF2D",
                 "Arn"
               ]
             }
@@ -399,7 +402,7 @@
         ]
       }
     },
-    "testeventsrulestepfunctionandlambdastackExecutionFailedAlarm1E10C548": {
+    "testeventsrulestepfunctionandlambdaconstructExecutionFailedAlarmE37F086B": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -409,7 +412,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionandlambdastackStateMachine3BC6D432"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructStateMachine891F12F0"
             }
           }
         ],
@@ -420,7 +423,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionandlambdastackExecutionThrottledAlarm19B70D6A": {
+    "testeventsrulestepfunctionandlambdaconstructExecutionThrottledAlarm19D72AE9": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -430,7 +433,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionandlambdastackStateMachine3BC6D432"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructStateMachine891F12F0"
             }
           }
         ],
@@ -441,7 +444,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionandlambdastackExecutionAbortedAlarm8EC0918C": {
+    "testeventsrulestepfunctionandlambdaconstructExecutionAbortedAlarm4AE9E1B5": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -451,7 +454,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionandlambdastackStateMachine3BC6D432"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructStateMachine891F12F0"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-with-lambda.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-with-lambda.ts
@@ -12,7 +12,7 @@
  */
 
 /// !cdk-integ *
-import { App, Stack } from "@aws-cdk/core";
+import { App, Stack, RemovalPolicy } from "@aws-cdk/core";
 import { EventsRuleToStepFunction, EventsRuleToStepFunctionProps } from "../lib";
 import { Duration } from '@aws-cdk/core';
 import * as tasks from '@aws-cdk/aws-stepfunctions-tasks';
@@ -43,8 +43,11 @@ const props: EventsRuleToStepFunctionProps = {
   },
   eventRuleProps: {
     schedule: events.Schedule.rate(Duration.minutes(5))
-  }
+  },
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY
+  },
 };
 
-new EventsRuleToStepFunction(stack, 'test-events-rule-step-function-and-lambda-stack', props);
+new EventsRuleToStepFunction(stack, 'test-events-rule-step-function-and-lambda-construct', props);
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/__snapshots__/lambda-step-function.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/__snapshots__/lambda-step-function.test.js.snap
@@ -84,7 +84,7 @@ Object {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "LAMBDA_NAME": "existing-function",
             "STATE_MACHINE_ARN": Object {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9",
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD",
             },
           },
         },
@@ -183,7 +183,7 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "testlambdastepfunctionstackStateMachine373C0BB9",
+                "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD",
               },
             },
           ],
@@ -198,7 +198,7 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testlambdastepfunctionstackExecutionAbortedAlarmFF10BB21": Object {
+    "testlambdastepfunctionconstructExecutionAbortedAlarmC2BA974A": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -206,7 +206,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9",
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD",
             },
           },
         ],
@@ -219,7 +219,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testlambdastepfunctionstackExecutionFailedAlarm15D73A68": Object {
+    "testlambdastepfunctionconstructExecutionFailedAlarmC55FFDEE": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -227,7 +227,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9",
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD",
             },
           },
         ],
@@ -240,7 +240,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testlambdastepfunctionstackExecutionThrottledAlarmB7EC1213": Object {
+    "testlambdastepfunctionconstructExecutionThrottledAlarm8C5110D9": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -248,7 +248,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9",
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD",
             },
           },
         ],
@@ -261,10 +261,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testlambdastepfunctionstackStateMachine373C0BB9": Object {
+    "testlambdastepfunctionconstructStateMachine3D4830AD": Object {
       "DependsOn": Array [
-        "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1",
-        "testlambdastepfunctionstackStateMachineRoleF5EE1C78",
+        "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6",
+        "testlambdastepfunctionconstructStateMachineRoleC3777C02",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -274,7 +274,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "testlambdastepfunctionstackStateMachineLogGroup42D53E65",
+                    "testlambdastepfunctionconstructStateMachineLogGroup08972C3B",
                     "Arn",
                   ],
                 },
@@ -285,14 +285,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "testlambdastepfunctionstackStateMachineRoleF5EE1C78",
+            "testlambdastepfunctionconstructStateMachineRoleC3777C02",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "testlambdastepfunctionstackStateMachineLogGroup42D53E65": Object {
+    "testlambdastepfunctionconstructStateMachineLogGroup08972C3B": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -308,10 +308,41 @@ Object {
           ],
         },
       },
+      "Properties": Object {
+        "LogGroupName": "/aws/vendedlogs/states/defaulttestlambdastepfunctionconstructstatemachinelog548fb554106f",
+      },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1": Object {
+    "testlambdastepfunctionconstructStateMachineRoleC3777C02": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "states.",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ".amazonaws.com",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -367,42 +398,14 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1",
+        "PolicyName": "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6",
         "Roles": Array [
           Object {
-            "Ref": "testlambdastepfunctionstackStateMachineRoleF5EE1C78",
+            "Ref": "testlambdastepfunctionconstructStateMachineRoleC3777C02",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "testlambdastepfunctionstackStateMachineRoleF5EE1C78": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "states.",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ".amazonaws.com",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
     },
   },
 }
@@ -715,6 +718,9 @@ Object {
             },
           ],
         },
+      },
+      "Properties": Object {
+        "LogGroupName": "/aws/vendedlogs/states/defaultlambdatostepfunctionstackstatemachinelog8f3fc802765e",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deploy-lambda.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deploy-lambda.expected.json
@@ -1,9 +1,12 @@
 {
   "Resources": {
-    "testlambdastepfunctionstackStateMachineLogGroup42D53E65": {
+    "testlambdastepfunctionconstructStateMachineLogGroup08972C3B": {
       "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/vendedlogs/states/testlambdastepfunctionstacktestlambdastepfunctionconstructstatemachinelog2d6f164db466"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
         "cfn_nag": {
           "rules_to_suppress": [
@@ -19,7 +22,7 @@
         }
       }
     },
-    "testlambdastepfunctionstackStateMachineRoleF5EE1C78": {
+    "testlambdastepfunctionconstructStateMachineRoleC3777C02": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -47,7 +50,7 @@
         }
       }
     },
-    "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1": {
+    "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -94,10 +97,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1",
+        "PolicyName": "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionstackStateMachineRoleF5EE1C78"
+            "Ref": "testlambdastepfunctionconstructStateMachineRoleC3777C02"
           }
         ]
       },
@@ -112,12 +115,12 @@
         }
       }
     },
-    "testlambdastepfunctionstackStateMachine373C0BB9": {
+    "testlambdastepfunctionconstructStateMachine3D4830AD": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionstackStateMachineRoleF5EE1C78",
+            "testlambdastepfunctionconstructStateMachineRoleC3777C02",
             "Arn"
           ]
         },
@@ -128,7 +131,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testlambdastepfunctionstackStateMachineLogGroup42D53E65",
+                    "testlambdastepfunctionconstructStateMachineLogGroup08972C3B",
                     "Arn"
                   ]
                 }
@@ -139,11 +142,11 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1",
-        "testlambdastepfunctionstackStateMachineRoleF5EE1C78"
+        "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6",
+        "testlambdastepfunctionconstructStateMachineRoleC3777C02"
       ]
     },
-    "testlambdastepfunctionstackLambdaFunctionServiceRoleA27C24DF": {
+    "testlambdastepfunctionconstructLambdaFunctionServiceRole57BEAADE": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -198,7 +201,7 @@
         ]
       }
     },
-    "testlambdastepfunctionstackLambdaFunctionServiceRoleDefaultPolicy0CE366B0": {
+    "testlambdastepfunctionconstructLambdaFunctionServiceRoleDefaultPolicyE27F2D22": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -215,16 +218,16 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+                "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionstackLambdaFunctionServiceRoleDefaultPolicy0CE366B0",
+        "PolicyName": "testlambdastepfunctionconstructLambdaFunctionServiceRoleDefaultPolicyE27F2D22",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionstackLambdaFunctionServiceRoleA27C24DF"
+            "Ref": "testlambdastepfunctionconstructLambdaFunctionServiceRole57BEAADE"
           }
         ]
       },
@@ -239,7 +242,7 @@
         }
       }
     },
-    "testlambdastepfunctionstackLambdaFunctionF3ADF992": {
+    "testlambdastepfunctionconstructLambdaFunction50F66B71": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -282,7 +285,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionstackLambdaFunctionServiceRoleA27C24DF",
+            "testlambdastepfunctionconstructLambdaFunctionServiceRole57BEAADE",
             "Arn"
           ]
         },
@@ -290,7 +293,7 @@
           "Variables": {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "STATE_MACHINE_ARN": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         },
@@ -301,8 +304,8 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionstackLambdaFunctionServiceRoleDefaultPolicy0CE366B0",
-        "testlambdastepfunctionstackLambdaFunctionServiceRoleA27C24DF"
+        "testlambdastepfunctionconstructLambdaFunctionServiceRoleDefaultPolicyE27F2D22",
+        "testlambdastepfunctionconstructLambdaFunctionServiceRole57BEAADE"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -323,7 +326,7 @@
         }
       }
     },
-    "testlambdastepfunctionstackExecutionFailedAlarm15D73A68": {
+    "testlambdastepfunctionconstructExecutionFailedAlarmC55FFDEE": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -333,7 +336,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         ],
@@ -344,7 +347,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionstackExecutionThrottledAlarmB7EC1213": {
+    "testlambdastepfunctionconstructExecutionThrottledAlarm8C5110D9": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -354,7 +357,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         ],
@@ -365,7 +368,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionstackExecutionAbortedAlarmFF10BB21": {
+    "testlambdastepfunctionconstructExecutionAbortedAlarmC2BA974A": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -375,7 +378,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deploy-lambda.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deploy-lambda.ts
@@ -12,7 +12,7 @@
  */
 
 /// !cdk-integ *
-import { App, Stack } from "@aws-cdk/core";
+import { App, Stack, RemovalPolicy } from "@aws-cdk/core";
 import { LambdaToStepFunction, LambdaToStepFunctionProps } from "../lib";
 import * as lambda from '@aws-cdk/aws-lambda';
 import * as stepfunctions from '@aws-cdk/aws-stepfunctions';
@@ -33,11 +33,14 @@ const props: LambdaToStepFunctionProps = {
   },
   stateMachineProps: {
     definition: startState
-  }
+  },
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY
+  },
 };
 
 // Add the pattern
-new LambdaToStepFunction(stack, 'test-lambda-step-function-stack', props);
+new LambdaToStepFunction(stack, 'test-lambda-step-function-construct', props);
 
 // Synth the app
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.existing-function.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.existing-function.expected.json
@@ -72,7 +72,7 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+                "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
               }
             }
           ],
@@ -147,7 +147,7 @@
           "Variables": {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "STATE_MACHINE_ARN": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         },
@@ -180,10 +180,13 @@
         }
       }
     },
-    "testlambdastepfunctionstackStateMachineLogGroup42D53E65": {
+    "testlambdastepfunctionconstructStateMachineLogGroup08972C3B": {
       "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/vendedlogs/states/testlambdastepfunctionstacktestlambdastepfunctionconstructstatemachinelog2d6f164db466"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
         "cfn_nag": {
           "rules_to_suppress": [
@@ -199,7 +202,7 @@
         }
       }
     },
-    "testlambdastepfunctionstackStateMachineRoleF5EE1C78": {
+    "testlambdastepfunctionconstructStateMachineRoleC3777C02": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -227,7 +230,7 @@
         }
       }
     },
-    "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1": {
+    "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -274,10 +277,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1",
+        "PolicyName": "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionstackStateMachineRoleF5EE1C78"
+            "Ref": "testlambdastepfunctionconstructStateMachineRoleC3777C02"
           }
         ]
       },
@@ -292,12 +295,12 @@
         }
       }
     },
-    "testlambdastepfunctionstackStateMachine373C0BB9": {
+    "testlambdastepfunctionconstructStateMachine3D4830AD": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionstackStateMachineRoleF5EE1C78",
+            "testlambdastepfunctionconstructStateMachineRoleC3777C02",
             "Arn"
           ]
         },
@@ -308,7 +311,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testlambdastepfunctionstackStateMachineLogGroup42D53E65",
+                    "testlambdastepfunctionconstructStateMachineLogGroup08972C3B",
                     "Arn"
                   ]
                 }
@@ -319,11 +322,11 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionstackStateMachineRoleDefaultPolicy1FFD5CB1",
-        "testlambdastepfunctionstackStateMachineRoleF5EE1C78"
+        "testlambdastepfunctionconstructStateMachineRoleDefaultPolicy226F91C6",
+        "testlambdastepfunctionconstructStateMachineRoleC3777C02"
       ]
     },
-    "testlambdastepfunctionstackExecutionFailedAlarm15D73A68": {
+    "testlambdastepfunctionconstructExecutionFailedAlarmC55FFDEE": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -333,7 +336,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         ],
@@ -344,7 +347,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionstackExecutionThrottledAlarmB7EC1213": {
+    "testlambdastepfunctionconstructExecutionThrottledAlarm8C5110D9": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -354,7 +357,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         ],
@@ -365,7 +368,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionstackExecutionAbortedAlarmFF10BB21": {
+    "testlambdastepfunctionconstructExecutionAbortedAlarmC2BA974A": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -375,7 +378,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstackStateMachine373C0BB9"
+              "Ref": "testlambdastepfunctionconstructStateMachine3D4830AD"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.existing-function.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.existing-function.ts
@@ -12,7 +12,7 @@
  */
 
 /// !cdk-integ *
-import { App, Stack } from "@aws-cdk/core";
+import { App, Stack, RemovalPolicy } from "@aws-cdk/core";
 import { LambdaToStepFunction, LambdaToStepFunctionProps } from "../lib";
 import * as lambda from '@aws-cdk/aws-lambda';
 import * as stepfunctions from '@aws-cdk/aws-stepfunctions';
@@ -40,11 +40,14 @@ const props: LambdaToStepFunctionProps = {
   existingLambdaObj: fn,
   stateMachineProps: {
     definition: startState
-  }
+  },
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY
+  },
 };
 
 // Add the pattern
-new LambdaToStepFunction(stack, 'test-lambda-step-function-stack', props);
+new LambdaToStepFunction(stack, 'test-lambda-step-function-construct', props);
 
 // Synth the app
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/lambda-step-function.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/lambda-step-function.test.ts
@@ -74,7 +74,7 @@ test('Test deployment with existing Lambda function', () => {
   };
   const fn = defaults.deployLambdaFunction(stack, lambdaFunctionProps);
   // Add the pattern
-  new LambdaToStepFunction(stack, 'test-lambda-step-function-stack', {
+  new LambdaToStepFunction(stack, 'test-lambda-step-function-construct', {
     existingLambdaObj: fn,
     stateMachineProps: {
       definition: startState

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
@@ -141,7 +141,7 @@ export class S3ToStepFunction extends Construct {
       };
     }
 
-    const eventsRuleToStepFunction = new EventsRuleToStepFunction(this, 'test-events-rule-step-function-stack', {
+    const eventsRuleToStepFunction = new EventsRuleToStepFunction(this, `${id}-event-rule-step-function-construct`, {
       stateMachineProps: props.stateMachineProps,
       eventRuleProps: _eventRuleProps,
       createCloudWatchAlarms: props.createCloudWatchAlarms,

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/__snapshots__/s3-step-function.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/__snapshots__/s3-step-function.test.js.snap
@@ -392,7 +392,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackEventsRule05BF80D3": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructEventsRule4CC9BDCA": Object {
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -421,12 +421,12 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "tests3stepfunctiontesteventsrulestepfunctionstackStateMachine5A6C0DFF",
+              "Ref": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineA4D4F2B0",
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "tests3stepfunctiontesteventsrulestepfunctionstackEventsRuleRoleF447A174",
+                "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructEventsRuleRole07FD7EC1",
                 "Arn",
               ],
             },
@@ -435,30 +435,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackEventsRuleRoleDefaultPolicy9B31B120": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "states:StartExecution",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "tests3stepfunctiontesteventsrulestepfunctionstackStateMachine5A6C0DFF",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "tests3stepfunctiontesteventsrulestepfunctionstackEventsRuleRoleDefaultPolicy9B31B120",
-        "Roles": Array [
-          Object {
-            "Ref": "tests3stepfunctiontesteventsrulestepfunctionstackEventsRuleRoleF447A174",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "tests3stepfunctiontesteventsrulestepfunctionstackEventsRuleRoleF447A174": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructEventsRuleRole07FD7EC1": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -475,7 +452,30 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackExecutionAbortedAlarm2467E717": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructEventsRuleRoleDefaultPolicyC6A243E9": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineA4D4F2B0",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructEventsRuleRoleDefaultPolicyC6A243E9",
+        "Roles": Array [
+          Object {
+            "Ref": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructEventsRuleRole07FD7EC1",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructExecutionAbortedAlarmD4ED8C15": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -483,7 +483,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "tests3stepfunctiontesteventsrulestepfunctionstackStateMachine5A6C0DFF",
+              "Ref": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineA4D4F2B0",
             },
           },
         ],
@@ -496,7 +496,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackExecutionFailedAlarmABAAA96A": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructExecutionFailedAlarmE48142D4": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -504,7 +504,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "tests3stepfunctiontesteventsrulestepfunctionstackStateMachine5A6C0DFF",
+              "Ref": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineA4D4F2B0",
             },
           },
         ],
@@ -517,7 +517,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackExecutionThrottledAlarm1D666C22": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructExecutionThrottledAlarmE9CD423E": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -525,7 +525,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "tests3stepfunctiontesteventsrulestepfunctionstackStateMachine5A6C0DFF",
+              "Ref": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineA4D4F2B0",
             },
           },
         ],
@@ -538,10 +538,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackStateMachine5A6C0DFF": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineA4D4F2B0": Object {
       "DependsOn": Array [
-        "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineRoleDefaultPolicy4B8FDFDA",
-        "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineRole9C9F9AAC",
+        "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineRoleDefaultPolicy0163149E",
+        "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineRole97FB7201",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -551,7 +551,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineLogGroupDA892B18",
+                    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineLogGroup5A6ABD22",
                     "Arn",
                   ],
                 },
@@ -562,14 +562,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineRole9C9F9AAC",
+            "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineRole97FB7201",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineLogGroupDA892B18": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineLogGroup5A6ABD22": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -585,10 +585,13 @@ Object {
           ],
         },
       },
+      "Properties": Object {
+        "LogGroupName": "/aws/vendedlogs/states/defaulttests3stepfunctioneventrulestepfunctionconstructstatemachinelog2d5375f14660",
+      },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineRole9C9F9AAC": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineRole97FB7201": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -616,7 +619,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineRoleDefaultPolicy4B8FDFDA": Object {
+    "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineRoleDefaultPolicy0163149E": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -672,10 +675,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineRoleDefaultPolicy4B8FDFDA",
+        "PolicyName": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineRoleDefaultPolicy0163149E",
         "Roles": Array [
           Object {
-            "Ref": "tests3stepfunctiontesteventsrulestepfunctionstackStateMachineRole9C9F9AAC",
+            "Ref": "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineRole97FB7201",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.expected.json
@@ -23,7 +23,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstackCloudTrailS3LoggingBucketB176B631": {
+    "tests3stepfunctionpreexistingbucketconstructCloudTrailS3LoggingBucket4FB012B4": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -56,11 +56,11 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstackCloudTrailS3LoggingBucketPolicy11FB1416": {
+    "tests3stepfunctionpreexistingbucketconstructCloudTrailS3LoggingBucketPolicy0A8FBF4D": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionpreexistingbucketstackCloudTrailS3LoggingBucketB176B631"
+          "Ref": "tests3stepfunctionpreexistingbucketconstructCloudTrailS3LoggingBucket4FB012B4"
         },
         "PolicyDocument": {
           "Statement": [
@@ -79,7 +79,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionpreexistingbucketstackCloudTrailS3LoggingBucketB176B631",
+                        "tests3stepfunctionpreexistingbucketconstructCloudTrailS3LoggingBucket4FB012B4",
                         "Arn"
                       ]
                     },
@@ -94,7 +94,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstackCloudTrailS3Bucket5827CCF5": {
+    "tests3stepfunctionpreexistingbucketconstructCloudTrailS3Bucket51B89B99": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -121,7 +121,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "tests3stepfunctionpreexistingbucketstackCloudTrailS3LoggingBucketB176B631"
+            "Ref": "tests3stepfunctionpreexistingbucketconstructCloudTrailS3LoggingBucket4FB012B4"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -137,11 +137,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "tests3stepfunctionpreexistingbucketstackCloudTrailS3BucketPolicyD64F28B9": {
+    "tests3stepfunctionpreexistingbucketconstructCloudTrailS3BucketPolicy791F8B41": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionpreexistingbucketstackCloudTrailS3Bucket5827CCF5"
+          "Ref": "tests3stepfunctionpreexistingbucketconstructCloudTrailS3Bucket51B89B99"
         },
         "PolicyDocument": {
           "Statement": [
@@ -160,7 +160,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionpreexistingbucketstackCloudTrailS3Bucket5827CCF5",
+                        "tests3stepfunctionpreexistingbucketconstructCloudTrailS3Bucket51B89B99",
                         "Arn"
                       ]
                     },
@@ -178,7 +178,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "tests3stepfunctionpreexistingbucketstackCloudTrailS3Bucket5827CCF5",
+                  "tests3stepfunctionpreexistingbucketconstructCloudTrailS3Bucket51B89B99",
                   "Arn"
                 ]
               }
@@ -200,7 +200,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionpreexistingbucketstackCloudTrailS3Bucket5827CCF5",
+                        "tests3stepfunctionpreexistingbucketconstructCloudTrailS3Bucket51B89B99",
                         "Arn"
                       ]
                     },
@@ -218,12 +218,12 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstackS3EventsTrailD8887331": {
+    "tests3stepfunctionpreexistingbucketconstructS3EventsTrail36C5D664": {
       "Type": "AWS::CloudTrail::Trail",
       "Properties": {
         "IsLogging": true,
         "S3BucketName": {
-          "Ref": "tests3stepfunctionpreexistingbucketstackCloudTrailS3Bucket5827CCF5"
+          "Ref": "tests3stepfunctionpreexistingbucketconstructCloudTrailS3Bucket51B89B99"
         },
         "EnableLogFileValidation": true,
         "EventSelectors": [
@@ -259,13 +259,16 @@
         "IsMultiRegionTrail": true
       },
       "DependsOn": [
-        "tests3stepfunctionpreexistingbucketstackCloudTrailS3BucketPolicyD64F28B9"
+        "tests3stepfunctionpreexistingbucketconstructCloudTrailS3BucketPolicy791F8B41"
       ]
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineLogGroupDD523B41": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineLogGroup9E1E4D8F": {
       "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/vendedlogs/states/tests3stepfunctionpreexistingbucketstacktests3stepfunctionpreexistingbucketconstructeventrulestepfunctstatemachinelog6779da86b0db"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
         "cfn_nag": {
           "rules_to_suppress": [
@@ -281,7 +284,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineRole791273F9": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineRole1538A928": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -309,7 +312,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineRoleDefaultPolicy744F0942": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineRoleDefaultPolicy6F3D61F5": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -356,10 +359,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineRoleDefaultPolicy744F0942",
+        "PolicyName": "ngbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineRoleDefaultPolicy6F3D61F5",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineRole791273F9"
+            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineRole1538A928"
           }
         ]
       },
@@ -374,12 +377,12 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineF70F20BC": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachine8A25FD7E": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineRole791273F9",
+            "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineRole1538A928",
             "Arn"
           ]
         },
@@ -390,7 +393,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineLogGroupDD523B41",
+                    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineLogGroup9E1E4D8F",
                     "Arn"
                   ]
                 }
@@ -401,11 +404,11 @@
         }
       },
       "DependsOn": [
-        "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineRoleDefaultPolicy744F0942",
-        "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineRole791273F9"
+        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineRoleDefaultPolicy6F3D61F5",
+        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachineRole1538A928"
       ]
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackEventsRuleRole996C80AB": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructEventsRuleRole196D0D34": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -422,7 +425,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackEventsRuleRoleDefaultPolicy20EC3FF3": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy7897C947": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -431,21 +434,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineF70F20BC"
+                "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachine8A25FD7E"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackEventsRuleRoleDefaultPolicy20EC3FF3",
+        "PolicyName": "tingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy7897C947",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackEventsRuleRole996C80AB"
+            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructEventsRuleRole196D0D34"
           }
         ]
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackEventsRule1611972D": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructEventsRule921109ED": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
@@ -475,12 +478,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineF70F20BC"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachine8A25FD7E"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackEventsRuleRole996C80AB",
+                "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructEventsRuleRole196D0D34",
                 "Arn"
               ]
             }
@@ -488,7 +491,7 @@
         ]
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackExecutionFailedAlarm0155D2F3": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructExecutionFailedAlarmACB47134": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -498,7 +501,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineF70F20BC"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachine8A25FD7E"
             }
           }
         ],
@@ -509,7 +512,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackExecutionThrottledAlarm58EE5178": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructExecutionThrottledAlarm2891E7CD": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -519,7 +522,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineF70F20BC"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachine8A25FD7E"
             }
           }
         ],
@@ -530,7 +533,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackExecutionAbortedAlarm4C041F26": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructExecutionAbortedAlarm6BA8005C": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -540,7 +543,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionpreexistingbucketstacktesteventsrulestepfunctionstackStateMachineF70F20BC"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructeventrulestepfunctionconstructStateMachine8A25FD7E"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.ts
@@ -33,8 +33,11 @@ const props: S3ToStepFunctionProps = {
   },
   bucketProps: {
     removalPolicy: RemovalPolicy.DESTROY,
-  }
+  },
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY
+  },
 };
 
-new S3ToStepFunction(stack, 'test-s3-step-function-pre-existing-bucket-stack', props);
+new S3ToStepFunction(stack, 'test-s3-step-function-pre-existing-bucket-construct', props);
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.s3-step-function-no-argument.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.s3-step-function-no-argument.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "tests3stepfunctionstackS3LoggingBucket740A14C5": {
+    "tests3stepfunctionconstructS3LoggingBucketE65663A6": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -33,11 +33,11 @@
         }
       }
     },
-    "tests3stepfunctionstackS3LoggingBucketPolicy8549C1CC": {
+    "tests3stepfunctionconstructS3LoggingBucketPolicy6D0EBFC8": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionstackS3LoggingBucket740A14C5"
+          "Ref": "tests3stepfunctionconstructS3LoggingBucketE65663A6"
         },
         "PolicyDocument": {
           "Statement": [
@@ -56,7 +56,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionstackS3LoggingBucket740A14C5",
+                        "tests3stepfunctionconstructS3LoggingBucketE65663A6",
                         "Arn"
                       ]
                     },
@@ -71,7 +71,7 @@
         }
       }
     },
-    "tests3stepfunctionstackS3Bucket8CC704E9": {
+    "tests3stepfunctionconstructS3BucketE9791EAE": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -98,7 +98,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "tests3stepfunctionstackS3LoggingBucket740A14C5"
+            "Ref": "tests3stepfunctionconstructS3LoggingBucketE65663A6"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -114,11 +114,11 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "tests3stepfunctionstackS3BucketPolicy7BDF618E": {
+    "tests3stepfunctionconstructS3BucketPolicyF485D2A9": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionstackS3Bucket8CC704E9"
+          "Ref": "tests3stepfunctionconstructS3BucketE9791EAE"
         },
         "PolicyDocument": {
           "Statement": [
@@ -137,7 +137,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionstackS3Bucket8CC704E9",
+                        "tests3stepfunctionconstructS3BucketE9791EAE",
                         "Arn"
                       ]
                     },
@@ -152,7 +152,7 @@
         }
       }
     },
-    "tests3stepfunctionstackCloudTrailS3LoggingBucketC8E8D35B": {
+    "tests3stepfunctionconstructCloudTrailS3LoggingBucket9F91E5B8": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -185,11 +185,11 @@
         }
       }
     },
-    "tests3stepfunctionstackCloudTrailS3LoggingBucketPolicyA0C182AE": {
+    "tests3stepfunctionconstructCloudTrailS3LoggingBucketPolicyFEFD6915": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionstackCloudTrailS3LoggingBucketC8E8D35B"
+          "Ref": "tests3stepfunctionconstructCloudTrailS3LoggingBucket9F91E5B8"
         },
         "PolicyDocument": {
           "Statement": [
@@ -208,7 +208,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionstackCloudTrailS3LoggingBucketC8E8D35B",
+                        "tests3stepfunctionconstructCloudTrailS3LoggingBucket9F91E5B8",
                         "Arn"
                       ]
                     },
@@ -223,7 +223,7 @@
         }
       }
     },
-    "tests3stepfunctionstackCloudTrailS3Bucket9CD2A45F": {
+    "tests3stepfunctionconstructCloudTrailS3Bucket5720C055": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -250,7 +250,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "tests3stepfunctionstackCloudTrailS3LoggingBucketC8E8D35B"
+            "Ref": "tests3stepfunctionconstructCloudTrailS3LoggingBucket9F91E5B8"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -266,11 +266,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "tests3stepfunctionstackCloudTrailS3BucketPolicyE88DD0A5": {
+    "tests3stepfunctionconstructCloudTrailS3BucketPolicy1F9D9BDB": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionstackCloudTrailS3Bucket9CD2A45F"
+          "Ref": "tests3stepfunctionconstructCloudTrailS3Bucket5720C055"
         },
         "PolicyDocument": {
           "Statement": [
@@ -289,7 +289,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionstackCloudTrailS3Bucket9CD2A45F",
+                        "tests3stepfunctionconstructCloudTrailS3Bucket5720C055",
                         "Arn"
                       ]
                     },
@@ -307,7 +307,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "tests3stepfunctionstackCloudTrailS3Bucket9CD2A45F",
+                  "tests3stepfunctionconstructCloudTrailS3Bucket5720C055",
                   "Arn"
                 ]
               }
@@ -329,7 +329,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionstackCloudTrailS3Bucket9CD2A45F",
+                        "tests3stepfunctionconstructCloudTrailS3Bucket5720C055",
                         "Arn"
                       ]
                     },
@@ -347,12 +347,12 @@
         }
       }
     },
-    "tests3stepfunctionstackS3EventsTrailE9BE674D": {
+    "tests3stepfunctionconstructS3EventsTrail1D9B4A4E": {
       "Type": "AWS::CloudTrail::Trail",
       "Properties": {
         "IsLogging": true,
         "S3BucketName": {
-          "Ref": "tests3stepfunctionstackCloudTrailS3Bucket9CD2A45F"
+          "Ref": "tests3stepfunctionconstructCloudTrailS3Bucket5720C055"
         },
         "EnableLogFileValidation": true,
         "EventSelectors": [
@@ -367,7 +367,7 @@
                       [
                         {
                           "Fn::GetAtt": [
-                            "tests3stepfunctionstackS3Bucket8CC704E9",
+                            "tests3stepfunctionconstructS3BucketE9791EAE",
                             "Arn"
                           ]
                         },
@@ -386,13 +386,16 @@
         "IsMultiRegionTrail": true
       },
       "DependsOn": [
-        "tests3stepfunctionstackCloudTrailS3BucketPolicyE88DD0A5"
+        "tests3stepfunctionconstructCloudTrailS3BucketPolicy1F9D9BDB"
       ]
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineLogGroupB72DF7A1": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineLogGroupEA0C99B8": {
       "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/vendedlogs/states/tests3stepfunctionstacktests3stepfunctionconstructeventrulestepfunctionconstructstatemachineloga6c75e57392e"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
         "cfn_nag": {
           "rules_to_suppress": [
@@ -408,7 +411,7 @@
         }
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineRoleC204E28A": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineRoleF1F934A9": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -436,7 +439,7 @@
         }
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineRoleDefaultPolicyCF5075D2": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineRoleDefaultPolicyCFADC36C": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -483,10 +486,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineRoleDefaultPolicyCF5075D2",
+        "PolicyName": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineRoleDefaultPolicyCFADC36C",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineRoleC204E28A"
+            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineRoleF1F934A9"
           }
         ]
       },
@@ -501,12 +504,12 @@
         }
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachine03BA781C": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachine968625EF": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineRoleC204E28A",
+            "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineRoleF1F934A9",
             "Arn"
           ]
         },
@@ -517,7 +520,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineLogGroupB72DF7A1",
+                    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineLogGroupEA0C99B8",
                     "Arn"
                   ]
                 }
@@ -528,11 +531,11 @@
         }
       },
       "DependsOn": [
-        "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineRoleDefaultPolicyCF5075D2",
-        "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachineRoleC204E28A"
+        "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineRoleDefaultPolicyCFADC36C",
+        "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachineRoleF1F934A9"
       ]
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackEventsRuleRole7F5DCB98": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructEventsRuleRole67D168EC": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -549,7 +552,7 @@
         }
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackEventsRuleRoleDefaultPolicy7B926713": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy20E07350": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -558,21 +561,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachine03BA781C"
+                "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachine968625EF"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tests3stepfunctionstacktesteventsrulestepfunctionstackEventsRuleRoleDefaultPolicy7B926713",
+        "PolicyName": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy20E07350",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionstacktesteventsrulestepfunctionstackEventsRuleRole7F5DCB98"
+            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructEventsRuleRole67D168EC"
           }
         ]
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackEventsRule617230F2": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructEventsRuleC06E4B63": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
@@ -592,7 +595,7 @@
             "requestParameters": {
               "bucketName": [
                 {
-                  "Ref": "tests3stepfunctionstackS3Bucket8CC704E9"
+                  "Ref": "tests3stepfunctionconstructS3BucketE9791EAE"
                 }
               ]
             }
@@ -602,12 +605,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachine03BA781C"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachine968625EF"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "tests3stepfunctionstacktesteventsrulestepfunctionstackEventsRuleRole7F5DCB98",
+                "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructEventsRuleRole67D168EC",
                 "Arn"
               ]
             }
@@ -615,7 +618,7 @@
         ]
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackExecutionFailedAlarmFB9B3517": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructExecutionFailedAlarm3832215E": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -625,7 +628,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachine03BA781C"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachine968625EF"
             }
           }
         ],
@@ -636,7 +639,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackExecutionThrottledAlarmF000208D": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructExecutionThrottledAlarm77A13593": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -646,7 +649,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachine03BA781C"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachine968625EF"
             }
           }
         ],
@@ -657,7 +660,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionstacktesteventsrulestepfunctionstackExecutionAbortedAlarmE5C0507E": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructExecutionAbortedAlarm6671CC90": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -667,7 +670,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionstacktesteventsrulestepfunctionstackStateMachine03BA781C"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructeventrulestepfunctionconstructStateMachine968625EF"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.s3-step-function-no-argument.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.s3-step-function-no-argument.ts
@@ -27,8 +27,11 @@ const props: S3ToStepFunctionProps = {
   },
   bucketProps: {
     removalPolicy: RemovalPolicy.DESTROY,
-  }
+  },
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY
+  },
 };
 
-new S3ToStepFunction(stack, 'test-s3-step-function-stack', props);
+new S3ToStepFunction(stack, 'test-s3-step-function-construct', props);
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/s3-step-function.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/s3-step-function.test.ts
@@ -116,12 +116,12 @@ test('override eventRuleProps', () => {
     Targets: [
       {
         Arn: {
-          Ref: "tests3stepfunctiontesteventsrulestepfunctionstackStateMachine5A6C0DFF"
+          Ref: "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructStateMachineA4D4F2B0"
         },
         Id: "Target0",
         RoleArn: {
           "Fn::GetAtt": [
-            "tests3stepfunctiontesteventsrulestepfunctionstackEventsRuleRoleF447A174",
+            "tests3stepfunctiontests3stepfunctioneventrulestepfunctionconstructEventsRuleRole07FD7EC1",
             "Arn"
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/core/lib/step-function-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/step-function-helper.ts
@@ -16,7 +16,7 @@ import * as logs from '@aws-cdk/aws-logs';
 import * as cdk from '@aws-cdk/core';
 import * as smDefaults from './step-function-defaults';
 import * as sfn from '@aws-cdk/aws-stepfunctions';
-import { overrideProps } from './utils';
+import { overrideProps, generateResourceName } from './utils';
 import * as iam from '@aws-cdk/aws-iam';
 import * as cloudwatch from '@aws-cdk/aws-cloudwatch';
 import { buildLogGroup } from './cloudwatch-log-group-helper';
@@ -29,8 +29,30 @@ import { buildLogGroup } from './cloudwatch-log-group-helper';
 export function buildStateMachine(scope: cdk.Construct, stateMachineProps: sfn.StateMachineProps,
   logGroupProps?: logs.LogGroupProps): [sfn.StateMachine, logs.LogGroup] {
 
+  let consolidatedLogGroupProps = logGroupProps;
+
+  // Three possibilities
+  // 1) logGroupProps not provided - create logGroupProps with just logGroupName
+  // 2) logGroupProps provided with no logGroupName - override logGroupProps.logGroupName
+  // 3) logGroupProps provided with logGroupName - pass unaltered logGroupProps
+  if (!consolidatedLogGroupProps) {
+    consolidatedLogGroupProps = {};
+  }
+  if (!consolidatedLogGroupProps?.logGroupName) {
+    const logGroupPrefix = '/aws/vendedlogs/states/';
+    const maxResourceNameLength = 255 - logGroupPrefix.length;
+    const nameParts: string[] = [
+      cdk.Stack.of(scope).stackName, // Name of the stack
+      scope.node.id,                 // Construct ID
+      'StateMachineLog'              // Literal string for log group name portion
+    ];
+
+    const logGroupName = logGroupPrefix + generateResourceName(nameParts, maxResourceNameLength);
+    consolidatedLogGroupProps = overrideProps(consolidatedLogGroupProps, { logGroupName });
+  }
+
   // Configure Cloudwatch log group for Step function State Machine
-  const logGroup = buildLogGroup(scope, 'StateMachineLogGroup', logGroupProps);
+  const logGroup = buildLogGroup(scope, 'StateMachineLogGroup', consolidatedLogGroupProps);
 
   // Override the defaults with the user provided props
   const _smProps = overrideProps(smDefaults.DefaultStateMachineProps(logGroup), stateMachineProps);

--- a/source/patterns/@aws-solutions-constructs/core/test/__snapshots__/step-function-helper.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/core/test/__snapshots__/step-function-helper.test.js.snap
@@ -50,6 +50,9 @@ Object {
           ],
         },
       },
+      "Properties": Object {
+        "LogGroupName": "/aws/vendedlogs/states/defaultdefaultstatemachinelogc54daeb0a037",
+      },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },

--- a/source/patterns/@aws-solutions-constructs/core/test/utils.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/utils.test.ts
@@ -1,0 +1,52 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+// Imports
+import * as defaults from '../';
+
+// Need 2 parts, but they can't overlap
+// so we can explicitly find them in the results.
+const parts = [ 'firstportionislong', 'secondsection'];
+const nonAlphaParts = [ 'part-one', 'part-two'];
+
+// --------------------------------------------------------------
+// Test with a truncated part
+// --------------------------------------------------------------
+test('Test with a truncated part', () => {
+  const result = defaults.generateResourceName(parts, 38);
+
+  expect(result).toContain(parts[1]);
+  expect(result).not.toContain(parts[0]);
+  expect(result).toContain(parts[0].slice(0, 13));
+
+});
+
+// --------------------------------------------------------------
+// Test with no truncated parts
+// --------------------------------------------------------------
+test('Test with no truncated parts', () => {
+  const result = defaults.generateResourceName(parts, 100);
+
+  expect(result).toContain(parts[1]);
+  expect(result).toContain(parts[0]);
+  expect(result.length).toEqual(parts[0].length + parts[1].length + 12);
+});
+
+// --------------------------------------------------------------
+// Test with non Aphanumeric
+// --------------------------------------------------------------
+test('Test with non Aphanumeric', () => {
+  const result = defaults.generateResourceName(nonAlphaParts, 100);
+
+  expect(result).toContain('partoneparttwo');
+});


### PR DESCRIPTION
*Issue #, if available:* T047 (internal)

*Description of changes:*
Log groups used by Step Functions must start with /aws/vendedlog/states or the policy generated to access the logs is too long. But each log file must have a unique name. Formerly we used to let CFN assign a random name, but that stopped working in the past 6 months. We can't instruct CFN to create a random name with a fixed prefix, so the PR creates a unique, but not random, name for each CloudWatch Logs group using a very similar method to the CDK - concatenating a portion of all the IDs in the construct tree and appending a hash created using all of the IDs in the construct tree.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.