### PR TITLE
T131 - Logging buckets

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/lib/index.ts
@@ -67,6 +67,10 @@ export class CloudFrontToS3 extends Construct {
       super(scope, id);
       let bucket: s3.Bucket;
 
+      if (props.existingBucketObj && props.bucketProps) {
+        throw new Error('Cannot specify both bucket properties and an existing bucket');
+      }
+
       if (!props.existingBucketObj) {
         [this.s3Bucket, this.s3LoggingBucket] = defaults.buildS3Bucket(this, {
           bucketProps: props.bucketProps

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.existing-bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.existing-bucket.ts
@@ -25,13 +25,10 @@ const app = new App();
 const stack = new Stack(app, 'test-cloudfront-s3-existing-bucket-stack');
 
 let mybucket: s3.Bucket;
-mybucket = defaults.CreateScrapBucket(stack, {});
+mybucket = defaults.CreateScrapBucket(stack, { removalPolicy: RemovalPolicy.DESTROY });
 
 const _construct = new CloudFrontToS3(stack, 'test-cloudfront-s3', {
   existingBucketObj: mybucket,
-  bucketProps: {
-    removalPolicy: RemovalPolicy.DESTROY,
-  }
 });
 
 // Add Cache Policy

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
@@ -77,6 +77,10 @@ export class EventsRuleToKinesisFirehoseToS3 extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToKinesisFirehoseToS3Props) {
     super(scope, id);
 
+    if (props.existingBucketObj && props.bucketProps) {
+      throw new Error('Cannot specify both bucket properties and an existing bucket');
+    }
+
     // Set up the Kinesis Firehose using KinesisFirehoseToS3 construct
     const firehoseToS3 = new KinesisFirehoseToS3(this, 'KinesisFirehoseToS3', {
       kinesisFirehoseProps: props.kinesisFirehoseProps,

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/lib/index.ts
@@ -77,6 +77,10 @@ export class IotToKinesisFirehoseToS3 extends Construct {
   constructor(scope: Construct, id: string, props: IotToKinesisFirehoseToS3Props) {
     super(scope, id);
 
+    if (props.existingBucketObj && props.bucketProps) {
+      throw new Error('Cannot specify both bucket properties and an existing bucket');
+    }
+
     const firehoseToS3 = new KinesisFirehoseToS3(this, 'KinesisFirehoseToS3', {
       kinesisFirehoseProps: props.kinesisFirehoseProps,
       existingBucketObj: props.existingBucketObj,

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/lib/index.ts
@@ -79,6 +79,10 @@ export class KinesisFirehoseToAnalyticsAndS3 extends Construct {
   constructor(scope: Construct, id: string, props: KinesisFirehoseToAnalyticsAndS3Props) {
     super(scope, id);
 
+    if (props.existingBucketObj && props.bucketProps) {
+      throw new Error('Cannot specify both bucket properties and an existing bucket');
+    }
+
     // Setup the kinesisfirehose-s3 pattern
     const kinesisFirehoseToS3Props: KinesisFirehoseToS3Props = {
       kinesisFirehoseProps: props.kinesisFirehoseProps,

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
@@ -78,6 +78,10 @@ export class KinesisFirehoseToS3 extends Construct {
 
     let bucket: s3.IBucket;
 
+    if (props.existingBucketObj && props.bucketProps) {
+      throw new Error('Cannot specify both bucket properties and an existing bucket');
+    }
+
     // Setup S3 Bucket
     if (!props.existingBucketObj) {
       let { bucketProps } = props;

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/lib/index.ts
@@ -98,6 +98,10 @@ export class KinesisStreamsToKinesisFirehoseToS3 extends Construct {
   constructor(scope: Construct, id: string, props: KinesisStreamsToKinesisFirehoseToS3Props) {
     super(scope, id);
 
+    if (props.existingBucketObj && props.bucketProps) {
+      throw new Error('Cannot specify both bucket properties and an existing bucket');
+    }
+
     // Setup the Kinesis Stream
     this.kinesisStream = defaults.buildKinesisStream(this, {
       existingStreamObj: props.existingStreamObj,

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/test/integ.existing-bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/test/integ.existing-bucket.ts
@@ -22,13 +22,10 @@ const app = new App();
 const stack = new Stack(app, 'test-existing-bucket-firehose-s3-stack');
 stack.templateOptions.description = 'Integration Test for aws-kinesisstreams-kinesisfirehose-s3';
 
-const existingBucket = CreateScrapBucket(stack, {});
+const existingBucket = CreateScrapBucket(stack, { removalPolicy: RemovalPolicy.DESTROY });
 const mybucket: s3.IBucket = s3.Bucket.fromBucketName(stack, 'mybucket', existingBucket.bucketName);
 new KinesisStreamsToKinesisFirehoseToS3(stack, 'test-existing-bucket-firehose-s3-stack', {
   existingBucketObj: mybucket,
-  bucketProps: {
-    removalPolicy: RemovalPolicy.DESTROY,
-  }
 });
 
 // Synth

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/lib/index.ts
@@ -96,6 +96,10 @@ export class LambdaToS3 extends Construct {
       super(scope, id);
       let bucket: s3.IBucket;
 
+      if (props.existingBucketObj && props.bucketProps) {
+        throw new Error('Cannot specify both bucket properties and an existing bucket');
+      }
+
       if (props.deployVpc || props.existingVpc) {
         if (props.deployVpc && props.existingVpc) {
           throw new Error("More than 1 VPC specified in the properties");

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/test/integ.pre-existing-bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/test/integ.pre-existing-bucket.ts
@@ -22,7 +22,7 @@ import { CreateScrapBucket } from '@aws-solutions-constructs/core';
 const app = new App();
 const stack = new Stack(app, 'test-lambda-s3-pre-existing-bucket');
 stack.templateOptions.description = 'Integration Test for aws-lambda-s3';
-const existingBucket = CreateScrapBucket(stack, {});
+const existingBucket = CreateScrapBucket(stack, { removalPolicy: RemovalPolicy.DESTROY });
 
 const mybucket: s3.IBucket = s3.Bucket.fromBucketName(stack, 'mybucket', existingBucket.bucketName);
 // Definitions
@@ -33,9 +33,6 @@ const props: LambdaToS3Props = {
     handler: 'index.handler',
     code: lambda.Code.fromAsset(`${__dirname}/lambda`)
   },
-  bucketProps: {
-    removalPolicy: RemovalPolicy.DESTROY,
-  }
 };
 
 new LambdaToS3(stack, 'test-lambda-s3-pre-existing-bucket', props);

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/lib/index.ts
@@ -71,6 +71,10 @@ export class S3ToLambda extends Construct {
     super(scope, id);
     let bucket: s3.Bucket;
 
+    if (props.existingBucketObj && props.bucketProps) {
+      throw new Error('Cannot specify both bucket properties and an existing bucket');
+    }
+
     this.lambdaFunction = defaults.buildLambdaFunction(this, {
       existingLambdaObj: props.existingLambdaObj,
       lambdaFunctionProps: props.lambdaFunctionProps

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/lib/index.ts
@@ -122,6 +122,10 @@ export class S3ToSqs extends Construct {
       let bucket: s3.Bucket;
       let enableEncryptionParam = props.enableEncryptionWithCustomerManagedKey;
 
+      if (props.existingBucketObj && props.bucketProps) {
+        throw new Error('Cannot specify both bucket properties and an existing bucket');
+      }
+
       if (props.enableEncryptionWithCustomerManagedKey === undefined ||
           props.enableEncryptionWithCustomerManagedKey === true) {
         enableEncryptionParam = true;

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/integ.existingS3Bucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/integ.existingS3Bucket.expected.json
@@ -20,8 +20,8 @@
           "RestrictPublicBuckets": true
         }
       },
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
         "cfn_nag": {
           "rules_to_suppress": [
@@ -111,8 +111,8 @@
           "Status": "Enabled"
         }
       },
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain"
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "S3BucketNotifications58B5AD06": {
       "Type": "Custom::S3BucketNotifications",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/integ.existingS3Bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/integ.existingS3Bucket.ts
@@ -19,15 +19,12 @@ const app = new App();
 
 const stack = new Stack(app, 'test-s3-sqs-existing-bucket');
 
-const [myBucket] = defaults.buildS3Bucket(stack, {});
+const [myBucket] = defaults.buildS3Bucket(stack, { bucketProps: { removalPolicy: RemovalPolicy.DESTROY }, });
 
 // Currently there is no way to customize the logging bucket, so this
 // test will leave a bucket behind
 const props: S3ToSqsProps = {
   existingBucketObj: myBucket,
-  bucketProps: {
-    removalPolicy: RemovalPolicy.DESTROY,
-  }
 };
 
 new S3ToSqs(stack, 'test-s3-sqs', props);

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
@@ -91,6 +91,10 @@ export class S3ToStepFunction extends Construct {
     super(scope, id);
     let bucket: s3.IBucket;
 
+    if (props.existingBucketObj && props.bucketProps) {
+      throw new Error('Cannot specify both bucket properties and an existing bucket');
+    }
+
     if (!props.existingBucketObj) {
       [this.s3Bucket, this.s3LoggingBucket] = defaults.buildS3Bucket(this, {
         bucketProps: props.bucketProps

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.ts
@@ -31,9 +31,6 @@ const props: S3ToStepFunctionProps = {
   stateMachineProps: {
     definition: startState
   },
-  bucketProps: {
-    removalPolicy: RemovalPolicy.DESTROY,
-  },
   logGroupProps: {
     removalPolicy: RemovalPolicy.DESTROY
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* some integration tests created an existing bucket using our core/BuildBucket() function - this then created a logging bucket when it created the existingBucket, not within our construct.

* Some tests passed the existing bucket into the construct, but also passed a bucketProps objects (with a removal policy). This confused the construct so it apparently created extra bucket(s) and left some behind after cleanup.
So the solution to the issue is to add a check to the construct to fail if both existing bucket and bucket props are provided and ensure the integration tests all send the proper combination of inputs.