### PR TITLE
fix (Eliminate name collision for Security Groups on VPC Endpoints)

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/test/__snapshots__/aws-lambda-sagemakerendpoint.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/test/__snapshots__/aws-lambda-sagemakerendpoint.test.js.snap
@@ -568,7 +568,7 @@ Object {
     },
   },
   "Resources": Object {
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": Object {
+    "DefaultSAGEMAKERRUNTIMEsecuritygroup32609E8C": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -584,7 +584,7 @@ Object {
         },
       },
       "Properties": Object {
-        "GroupDescription": "Default/ReplaceEndpointDefaultSecurityGroup-security-group",
+        "GroupDescription": "Default/Default-SAGEMAKER_RUNTIME-security-group",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -783,7 +783,7 @@ Object {
         "SecurityGroupIds": Array [
           Object {
             "Fn::GetAtt": Array [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "DefaultSAGEMAKERRUNTIMEsecuritygroup32609E8C",
               "GroupId",
             ],
           },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/integ.deployFunctionWithExistingVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/integ.deployFunctionWithExistingVpc.expected.json
@@ -674,7 +674,7 @@
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "deployFunctionWithExistingVpcSECRETSMANAGERsecuritygroupB20BA3EB",
               "GroupId"
             ]
           }
@@ -956,10 +956,10 @@
         }
       }
     },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": {
+    "deployFunctionWithExistingVpcSECRETSMANAGERsecuritygroupB20BA3EB": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "deployFunctionWithExistingVpc/ReplaceEndpointDefaultSecurityGroup-security-group",
+        "GroupDescription": "deployFunctionWithExistingVpc/deployFunctionWithExistingVpc-SECRETS_MANAGER-security-group",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/integ.deployFunctionWithVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/integ.deployFunctionWithVpc.expected.json
@@ -558,7 +558,7 @@
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "deployFunctionWithVpcSECRETSMANAGERsecuritygroup140A8C59",
               "GroupId"
             ]
           }
@@ -577,10 +577,10 @@
         "VpcEndpointType": "Interface"
       }
     },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": {
+    "deployFunctionWithVpcSECRETSMANAGERsecuritygroup140A8C59": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "deployFunctionWithVpc/ReplaceEndpointDefaultSecurityGroup-security-group",
+        "GroupDescription": "deployFunctionWithVpc/deployFunctionWithVpc-SECRETS_MANAGER-security-group",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/test/integ.deployFunctionWithVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/test/integ.deployFunctionWithVpc.expected.json
@@ -650,7 +650,7 @@
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "deployFunctionWithVpcSNSsecuritygroup5E54C413",
               "GroupId"
             ]
           }
@@ -669,10 +669,10 @@
         "VpcEndpointType": "Interface"
       }
     },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": {
+    "deployFunctionWithVpcSNSsecuritygroup5E54C413": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "deployFunctionWithVpc/ReplaceEndpointDefaultSecurityGroup-security-group",
+        "GroupDescription": "deployFunctionWithVpc/deployFunctionWithVpc-SNS-security-group",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.deployFunctionWithVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.deployFunctionWithVpc.expected.json
@@ -707,7 +707,7 @@
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "deployFunctionWithVpcSQSsecuritygroup2E4E2685",
               "GroupId"
             ]
           }
@@ -726,10 +726,10 @@
         "VpcEndpointType": "Interface"
       }
     },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": {
+    "deployFunctionWithVpcSQSsecuritygroup2E4E2685": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "deployFunctionWithVpc/ReplaceEndpointDefaultSecurityGroup-security-group",
+        "GroupDescription": "deployFunctionWithVpc/deployFunctionWithVpc-SQS-security-group",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/integ.deployFunctionWithExistingVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/integ.deployFunctionWithExistingVpc.expected.json
@@ -674,7 +674,7 @@
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "deployFunctionWithExistingVpcSSMsecuritygroupC287F479",
               "GroupId"
             ]
           }
@@ -967,10 +967,10 @@
         "Value": "test-string-value"
       }
     },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": {
+    "deployFunctionWithExistingVpcSSMsecuritygroupC287F479": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "deployFunctionWithExistingVpc/ReplaceEndpointDefaultSecurityGroup-security-group",
+        "GroupDescription": "deployFunctionWithExistingVpc/deployFunctionWithExistingVpc-SSM-security-group",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/integ.deployFunctionWithVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/integ.deployFunctionWithVpc.expected.json
@@ -569,7 +569,7 @@
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "deployFunctionWithVpcSSMsecuritygroup918CB15C",
               "GroupId"
             ]
           }
@@ -588,10 +588,10 @@
         "VpcEndpointType": "Interface"
       }
     },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": {
+    "deployFunctionWithVpcSSMsecuritygroup918CB15C": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "deployFunctionWithVpc/ReplaceEndpointDefaultSecurityGroup-security-group",
+        "GroupDescription": "deployFunctionWithVpc/deployFunctionWithVpc-SSM-security-group",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",

--- a/source/patterns/@aws-solutions-constructs/core/lib/vpc-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/vpc-helper.ts
@@ -49,10 +49,7 @@ export function buildVpc(scope: Construct, props: BuildVpcProps): ec2.IVpc {
   }
 
   if (props?.constructVpcProps) {
-    cumulativeProps = overrideProps(
-      cumulativeProps,
-      props?.constructVpcProps
-    );
+    cumulativeProps = overrideProps(cumulativeProps, props?.constructVpcProps);
   }
 
   const vpc = new ec2.Vpc(scope, "Vpc", cumulativeProps);
@@ -172,7 +169,7 @@ export function AddAwsServiceEndpoint(
 
       const endpointDefaultSecurityGroup = buildSecurityGroup(
         scope,
-        "ReplaceEndpointDefaultSecurityGroup",
+        `${scope.node.id}-${service.endpointName}`,
         {
           vpc,
           allowAllOutbound: true,

--- a/source/patterns/@aws-solutions-constructs/core/test/__snapshots__/sagemaker-helper.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/core/test/__snapshots__/sagemaker-helper.test.js.snap
@@ -3,6 +3,64 @@
 exports[`Test deployment of Sagemaker Inference Endpoint with properties overwrite 1`] = `
 Object {
   "Resources": Object {
+    "DefaultSAGEMAKERRUNTIMEsecuritygroup32609E8C": Object {
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W5",
+              "reason": "Egress of 0.0.0.0/0 is default and generally considered OK",
+            },
+            Object {
+              "id": "W40",
+              "reason": "Egress IPProtocol of -1 is default and generally considered OK",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "GroupDescription": "Default/Default-SAGEMAKER_RUNTIME-security-group",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": Object {
+              "Fn::GetAtt": Array [
+                "Vpc8378EB38",
+                "CidrBlock",
+              ],
+            },
+            "Description": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "from ",
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "Vpc8378EB38",
+                      "CidrBlock",
+                    ],
+                  },
+                  ":443",
+                ],
+              ],
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
     "MyEndpointConfigEncryptionKey42E27FFC": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
@@ -53,64 +111,6 @@ Object {
       },
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
-    },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": Object {
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W5",
-              "reason": "Egress of 0.0.0.0/0 is default and generally considered OK",
-            },
-            Object {
-              "id": "W40",
-              "reason": "Egress IPProtocol of -1 is default and generally considered OK",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "GroupDescription": "Default/ReplaceEndpointDefaultSecurityGroup-security-group",
-        "SecurityGroupEgress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": Object {
-              "Fn::GetAtt": Array [
-                "Vpc8378EB38",
-                "CidrBlock",
-              ],
-            },
-            "Description": Object {
-              "Fn::Join": Array [
-                "",
-                Array [
-                  "from ",
-                  Object {
-                    "Fn::GetAtt": Array [
-                      "Vpc8378EB38",
-                      "CidrBlock",
-                    ],
-                  },
-                  ":443",
-                ],
-              ],
-            },
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "Vpc8378EB38",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "ReplaceModelDefaultSecurityGroup38936A39": Object {
       "Metadata": Object {
@@ -658,7 +658,7 @@ Object {
         "SecurityGroupIds": Array [
           Object {
             "Fn::GetAtt": Array [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "DefaultSAGEMAKERRUNTIMEsecuritygroup32609E8C",
               "GroupId",
             ],
           },
@@ -3346,6 +3346,64 @@ Object {
 exports[`Test minimal deployment of Sagemaker Inference Endpoint with VPC 1`] = `
 Object {
   "Resources": Object {
+    "DefaultSAGEMAKERRUNTIMEsecuritygroup32609E8C": Object {
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W5",
+              "reason": "Egress of 0.0.0.0/0 is default and generally considered OK",
+            },
+            Object {
+              "id": "W40",
+              "reason": "Egress IPProtocol of -1 is default and generally considered OK",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "GroupDescription": "Default/Default-SAGEMAKER_RUNTIME-security-group",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": Object {
+              "Fn::GetAtt": Array [
+                "Vpc8378EB38",
+                "CidrBlock",
+              ],
+            },
+            "Description": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "from ",
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "Vpc8378EB38",
+                      "CidrBlock",
+                    ],
+                  },
+                  ":443",
+                ],
+              ],
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
     "EncryptionKey1B843E66": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
@@ -3397,64 +3455,6 @@ Object {
       },
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
-    },
-    "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF": Object {
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W5",
-              "reason": "Egress of 0.0.0.0/0 is default and generally considered OK",
-            },
-            Object {
-              "id": "W40",
-              "reason": "Egress IPProtocol of -1 is default and generally considered OK",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "GroupDescription": "Default/ReplaceEndpointDefaultSecurityGroup-security-group",
-        "SecurityGroupEgress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": Object {
-              "Fn::GetAtt": Array [
-                "Vpc8378EB38",
-                "CidrBlock",
-              ],
-            },
-            "Description": Object {
-              "Fn::Join": Array [
-                "",
-                Array [
-                  "from ",
-                  Object {
-                    "Fn::GetAtt": Array [
-                      "Vpc8378EB38",
-                      "CidrBlock",
-                    ],
-                  },
-                  ":443",
-                ],
-              ],
-            },
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "Vpc8378EB38",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "ReplaceModelDefaultSecurityGroup38936A39": Object {
       "Metadata": Object {
@@ -4000,7 +4000,7 @@ Object {
         "SecurityGroupIds": Array [
           Object {
             "Fn::GetAtt": Array [
-              "ReplaceEndpointDefaultSecurityGroupsecuritygroupB97DD1AF",
+              "DefaultSAGEMAKERRUNTIMEsecuritygroup32609E8C",
               "GroupId",
             ],
           },

--- a/source/patterns/@aws-solutions-constructs/core/test/vpc-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/vpc-helper.test.ts
@@ -36,7 +36,7 @@ test('Test minimal deployment with no properties', () => {
 // --------------------------------------------------------------
 // Test minimal Isolated deployment with no properties
 // --------------------------------------------------------------
-test('Test minimal deployment with no properties', () => {
+test("Test minimal deployment with no properties", () => {
   // Stack
   const stack = new Stack();
   // Build VPC
@@ -213,11 +213,17 @@ test('Test adding Gateway Endpoint', () => {
   });
 
   AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.DYNAMODB);
+  AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.SQS);
+  AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.SNS);
 
   // Assertion
   expect(stack).toHaveResource('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Gateway',
   });
+  expect(stack).toHaveResource('AWS::EC2::VPCEndpoint', {
+    VpcEndpointType: 'Interface',
+  });
+  expect(stack).toCountResources('AWS::EC2::VPCEndpoint', 3);
 });
 
 // --------------------------------------------------------------
@@ -269,6 +275,7 @@ test('Test adding a second Endpoint of same service', () => {
     defaultVpcProps: DefaultPublicPrivateVpcProps(),
   });
 
+  AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.SNS);
   AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.SNS);
 
   // Assertion


### PR DESCRIPTION
*Issue #, if available:*
210

*Description of changes:*
Change the name given to SecurityGroups assigned to VPC Endpoints to include construct ID and endpoint service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.