### PR TITLE
fix(allow ITable for dynamodb stream patterns)

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/README.md
@@ -63,7 +63,7 @@ _Parameters_
 |existingLambdaObj?|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|Existing instance of Lambda Function object, providing both this and `lambdaFunctionProps` will cause an error.|
 |lambdaFunctionProps?|[`lambda.FunctionProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.FunctionProps.html)|User provided props to override the default props for the Lambda function.|
 |dynamoTableProps?|[`dynamodb.TableProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.TableProps.html)|Optional user provided props to override the default props for DynamoDB Table|
-|existingTableObj?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Existing instance of DynamoDB table object, providing both this and `dynamoTableProps` will cause an error.|
+|existingTableInterface?|[`dynamodb.ITable`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.ITable.html)|Existing instance of DynamoDB table object or interface, providing both this and `dynamoTableProps` will cause an error.|
 |dynamoEventSourceProps?|[`aws-lambda-event-sources.DynamoEventSourceProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda-event-sources.DynamoEventSourceProps.html)|Optional user provided props to override the default props for DynamoDB Event Source|
 |esDomainProps?|[`elasticsearch.CfnDomainProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-elasticsearch.CfnDomainProps.html)|Optional user provided props to override the default props for the Elasticsearch Service|
 |domainName|`string`|Domain name for the Cognito and the Elasticsearch Service|
@@ -73,7 +73,8 @@ _Parameters_
 
 | **Name**     | **Type**        | **Description** |
 |:-------------|:----------------|-----------------|
-|dynamoTable|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct|
+|dynamoTableInterface|[`dynamodb.ITable`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.ITable.html)|Returns an instance of dynamodb.ITable created by the construct|
+|dynamoTable?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct|
 |lambdaFunction|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|Returns an instance of lambda.Function created by the construct|
 |userPool|[`cognito.UserPool`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cognito.UserPool.html)|Returns an instance of cognito.UserPool created by the construct|
 |userPoolClient|[`cognito.UserPoolClient`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cognito.UserPoolClient.html)|Returns an instance of cognito.UserPoolClient created by the construct|

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/README.md
@@ -74,7 +74,7 @@ _Parameters_
 | **Name**     | **Type**        | **Description** |
 |:-------------|:----------------|-----------------|
 |dynamoTableInterface|[`dynamodb.ITable`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.ITable.html)|Returns an instance of dynamodb.ITable created by the construct|
-|dynamoTable?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct|
+|dynamoTable?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct. IMPORTANT: If existingTableInterface was provided in Pattern Construct Props, this property will be `undefined`|
 |lambdaFunction|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|Returns an instance of lambda.Function created by the construct|
 |userPool|[`cognito.UserPool`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cognito.UserPool.html)|Returns an instance of cognito.UserPool created by the construct|
 |userPoolClient|[`cognito.UserPoolClient`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cognito.UserPoolClient.html)|Returns an instance of cognito.UserPoolClient created by the construct|

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
@@ -51,7 +51,7 @@ export interface DynamoDBStreamToLambdaToElasticSearchAndKibanaProps {
    *
    * @default - None
    */
-  readonly existingTableObj?: dynamodb.Table,
+  readonly existingTableObj?: dynamodb.ITable,
   /**
    * Optional user provided props to override the default props
    *
@@ -101,7 +101,7 @@ export class DynamoDBStreamToLambdaToElasticSearchAndKibana extends Construct {
   private dynamoDBStreamToLambda: DynamoDBStreamToLambda;
   private lambdaToElasticSearchAndKibana: LambdaToElasticSearchAndKibana;
   public readonly lambdaFunction: lambda.Function;
-  public readonly dynamoTable: dynamodb.Table;
+  public readonly dynamoTable?: dynamodb.Table;
   public readonly userPool: cognito.UserPool;
   public readonly userPoolClient: cognito.UserPoolClient;
   public readonly identityPool: cognito.CfnIdentityPool;

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
@@ -51,7 +51,7 @@ export interface DynamoDBStreamToLambdaToElasticSearchAndKibanaProps {
    *
    * @default - None
    */
-  readonly existingTableObj?: dynamodb.ITable,
+  readonly existingTableInterface?: dynamodb.ITable,
   /**
    * Optional user provided props to override the default props
    *
@@ -101,6 +101,7 @@ export class DynamoDBStreamToLambdaToElasticSearchAndKibana extends Construct {
   private dynamoDBStreamToLambda: DynamoDBStreamToLambda;
   private lambdaToElasticSearchAndKibana: LambdaToElasticSearchAndKibana;
   public readonly lambdaFunction: lambda.Function;
+  public readonly dynamoTableInterface: dynamodb.ITable;
   public readonly dynamoTable?: dynamodb.Table;
   public readonly userPool: cognito.UserPool;
   public readonly userPoolClient: cognito.UserPoolClient;
@@ -126,7 +127,7 @@ export class DynamoDBStreamToLambdaToElasticSearchAndKibana extends Construct {
       lambdaFunctionProps: props.lambdaFunctionProps,
       dynamoEventSourceProps: props.dynamoEventSourceProps,
       dynamoTableProps: props.dynamoTableProps,
-      existingTableObj: props.existingTableObj,
+      existingTableInterface: props.existingTableInterface,
       deploySqsDlqQueue: props.deploySqsDlqQueue,
       sqsDlqQueueProps: props.sqsDlqQueueProps
     };
@@ -146,6 +147,7 @@ export class DynamoDBStreamToLambdaToElasticSearchAndKibana extends Construct {
     this.lambdaToElasticSearchAndKibana = new LambdaToElasticSearchAndKibana(this, 'LambdaToElasticSearch', _props2);
 
     this.dynamoTable = this.dynamoDBStreamToLambda.dynamoTable;
+    this.dynamoTableInterface = this.dynamoDBStreamToLambda.dynamoTableInterface;
     this.userPool = this.lambdaToElasticSearchAndKibana.userPool;
     this.userPoolClient = this.lambdaToElasticSearchAndKibana.userPoolClient;
     this.identityPool = this.lambdaToElasticSearchAndKibana.identityPool;

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/README.md
@@ -66,7 +66,7 @@ _Parameters_
 | **Name**     | **Type**        | **Description** |
 |:-------------|:----------------|-----------------|
 |dynamoTableInterface|[`dynamodb.ITable`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.ITable.html)|Returns an instance of dynamodb.ITable created by the construct|
-|dynamoTable?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct|
+|dynamoTable?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct. IMPORTANT: If existingTableInterface was provided in Pattern Construct Props, this property will be `undefined`|
 |lambdaFunction|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|Returns an instance of lambda.Function created by the construct|
 
 ## Lambda Function

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/README.md
@@ -58,14 +58,15 @@ _Parameters_
 |existingLambdaObj?|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|Existing instance of Lambda Function object, providing both this and `lambdaFunctionProps` will cause an error.|
 |lambdaFunctionProps?|[`lambda.FunctionProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.FunctionProps.html)|User provided props to override the default props for the Lambda function.|
 |dynamoTableProps?|[`dynamodb.TableProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.TableProps.html)|Optional user provided props to override the default props for DynamoDB Table|
-|existingTableObj?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Existing instance of DynamoDB table object, providing both this and `dynamoTableProps` will cause an error.|
+|existingTableInterface?|[`dynamodb.ITable`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.ITable.html)|Existing instance of DynamoDB table object or interface, providing both this and `dynamoTableProps` will cause an error.|
 |dynamoEventSourceProps?|[`aws-lambda-event-sources.DynamoEventSourceProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda-event-sources.DynamoEventSourceProps.html)|Optional user provided props to override the default props for DynamoDB Event Source|
 
 ## Pattern Properties
 
 | **Name**     | **Type**        | **Description** |
 |:-------------|:----------------|-----------------|
-|dynamoTable|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct|
+|dynamoTableInterface|[`dynamodb.ITable`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.ITable.html)|Returns an instance of dynamodb.ITable created by the construct|
+|dynamoTable?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct|
 |lambdaFunction|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html)|Returns an instance of lambda.Function created by the construct|
 
 ## Lambda Function

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
@@ -45,7 +45,7 @@ export interface DynamoDBStreamToLambdaProps {
    *
    * @default - None
    */
-  readonly existingTableObj?: dynamodb.ITable,
+  readonly existingTableInterface?: dynamodb.ITable,
   /**
    * Optional user provided props to override the default props
    *
@@ -69,6 +69,7 @@ export interface DynamoDBStreamToLambdaProps {
 
 export class DynamoDBStreamToLambda extends Construct {
   public readonly lambdaFunction: lambda.Function;
+  public readonly dynamoTableInterface: dynamodb.ITable;
   public readonly dynamoTable?: dynamodb.Table;
 
   /**
@@ -90,11 +91,12 @@ export class DynamoDBStreamToLambda extends Construct {
 
     const table: dynamodb.ITable = defaults.buildDynamoDBTableWithStream(this, {
       dynamoTableProps: props.dynamoTableProps,
-      existingTableObj: props.existingTableObj
+      existingTableInterface: props.existingTableInterface
     });
 
-    if (table instanceof dynamodb.Table) {
-      this.dynamoTable = table;
+    this.dynamoTableInterface = table;
+    if (!props.existingTableInterface) {
+      this.dynamoTable = table as dynamodb.Table;
     }
 
     // Grant DynamoDB Stream read perimssion for lambda function

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
@@ -89,18 +89,13 @@ export class DynamoDBStreamToLambda extends Construct {
       lambdaFunctionProps: props.lambdaFunctionProps
     });
 
-    const table: dynamodb.ITable = defaults.buildDynamoDBTableWithStream(this, {
+    [this.dynamoTableInterface, this.dynamoTable] = defaults.buildDynamoDBTableWithStream(this, {
       dynamoTableProps: props.dynamoTableProps,
       existingTableInterface: props.existingTableInterface
     });
 
-    this.dynamoTableInterface = table;
-    if (!props.existingTableInterface) {
-      this.dynamoTable = table as dynamodb.Table;
-    }
-
     // Grant DynamoDB Stream read perimssion for lambda function
-    table.grantStreamRead(this.lambdaFunction.grantPrincipal);
+    this.dynamoTableInterface.grantStreamRead(this.lambdaFunction.grantPrincipal);
 
     // Add the Lambda event source mapping
     const eventSourceProps = defaults.DynamoEventSourceProps(this, {
@@ -108,6 +103,6 @@ export class DynamoDBStreamToLambda extends Construct {
       deploySqsDlqQueue: props.deploySqsDlqQueue,
       sqsDlqQueueProps: props.sqsDlqQueueProps
     });
-    this.lambdaFunction.addEventSource(new DynamoEventSource(table, eventSourceProps));
+    this.lambdaFunction.addEventSource(new DynamoEventSource(this.dynamoTableInterface, eventSourceProps));
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.expected.json
@@ -15,9 +15,12 @@
             "AttributeType": "S"
           }
         ],
-        "ProvisionedThroughput": {
-          "ReadCapacityUnits": 5,
-          "WriteCapacityUnits": 5
+        "BillingMode": "PAY_PER_REQUEST",
+        "PointInTimeRecoverySpecification": {
+          "PointInTimeRecoveryEnabled": true
+        },
+        "SSESpecification": {
+          "SSEEnabled": true
         },
         "StreamSpecification": {
           "StreamViewType": "NEW_AND_OLD_IMAGES"

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.expected.json
@@ -1,0 +1,353 @@
+{
+  "Resources": {
+    "mytable0FC8E698": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5
+        },
+        "StreamSpecification": {
+          "StreamViewType": "NEW_AND_OLD_IMAGES"
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "testdynamodbstreamlambdaLambdaFunctionServiceRole034E525C": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":logs:",
+                        {
+                          "Ref": "AWS::Region"
+                        },
+                        ":",
+                        {
+                          "Ref": "AWS::AccountId"
+                        },
+                        ":log-group:/aws/lambda/*"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "LambdaFunctionServiceRolePolicy"
+          }
+        ]
+      }
+    },
+    "testdynamodbstreamlambdaLambdaFunctionServiceRoleDefaultPolicy90B64ABB": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {
+              "Action": "dynamodb:ListStreams",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "dynamodb:DescribeStream",
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "mytable0FC8E698",
+                  "StreamArn"
+                ]
+              }
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testdynamodbstreamlambdaSqsDlqQueueF47B6B9A",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "testdynamodbstreamlambdaLambdaFunctionServiceRoleDefaultPolicy90B64ABB",
+        "Roles": [
+          {
+            "Ref": "testdynamodbstreamlambdaLambdaFunctionServiceRole034E525C"
+          }
+        ]
+      },
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W12",
+              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC."
+            }
+          ]
+        }
+      }
+    },
+    "testdynamodbstreamlambdaLambdaFunction99034597": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8S3Bucket9E1964CB"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8S3VersionKey7153CEE7"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8S3VersionKey7153CEE7"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "testdynamodbstreamlambdaLambdaFunctionServiceRole034E525C",
+            "Arn"
+          ]
+        },
+        "Environment": {
+          "Variables": {
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
+          }
+        },
+        "Handler": "index.handler",
+        "Runtime": "nodejs12.x",
+        "TracingConfig": {
+          "Mode": "Active"
+        }
+      },
+      "DependsOn": [
+        "testdynamodbstreamlambdaLambdaFunctionServiceRoleDefaultPolicy90B64ABB",
+        "testdynamodbstreamlambdaLambdaFunctionServiceRole034E525C"
+      ],
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W58",
+              "reason": "Lambda functions has the required permission to write CloudWatch Logs. It uses custom policy instead of arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole with tighter permissions."
+            },
+            {
+              "id": "W89",
+              "reason": "This is not a rule for the general case, just for specific use cases/industries"
+            },
+            {
+              "id": "W92",
+              "reason": "Impossible for us to define the correct concurrency for clients"
+            }
+          ]
+        }
+      }
+    },
+    "testdynamodbstreamlambdaLambdaFunctionDynamoDBEventSourceexistingtablemytable8CDC3452F37CA6A7": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "testdynamodbstreamlambdaLambdaFunction99034597"
+        },
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": true,
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": {
+              "Fn::GetAtt": [
+                "testdynamodbstreamlambdaSqsDlqQueueF47B6B9A",
+                "Arn"
+              ]
+            }
+          }
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "mytable0FC8E698",
+            "StreamArn"
+          ]
+        },
+        "MaximumRecordAgeInSeconds": 86400,
+        "MaximumRetryAttempts": 500,
+        "StartingPosition": "TRIM_HORIZON"
+      }
+    },
+    "testdynamodbstreamlambdaSqsDlqQueueF47B6B9A": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "KmsMasterKeyId": "alias/aws/sqs"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testdynamodbstreamlambdaSqsDlqQueuePolicy6BA0E667": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:ReceiveMessage",
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:RemovePermission",
+                "sqs:AddPermission",
+                "sqs:SetQueueAttributes"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testdynamodbstreamlambdaSqsDlqQueueF47B6B9A",
+                  "Arn"
+                ]
+              },
+              "Sid": "QueueOwnerOnlyAccess"
+            },
+            {
+              "Action": "SQS:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testdynamodbstreamlambdaSqsDlqQueueF47B6B9A",
+                  "Arn"
+                ]
+              },
+              "Sid": "HttpsOnly"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "testdynamodbstreamlambdaSqsDlqQueueF47B6B9A"
+          }
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "AssetParameters0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8S3Bucket9E1964CB": {
+      "Type": "String",
+      "Description": "S3 bucket for asset \"0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8\""
+    },
+    "AssetParameters0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8S3VersionKey7153CEE7": {
+      "Type": "String",
+      "Description": "S3 key for asset version \"0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8\""
+    },
+    "AssetParameters0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8ArtifactHash8D9AD644": {
+      "Type": "String",
+      "Description": "Artifact hash for asset \"0c3255e93ffe7a906c7422e9f0e9cc4c7fd86ee996ee3bb302e2f134b38463c8\""
+    }
+  }
+}

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.ts
@@ -23,6 +23,9 @@ const app = new App();
 const stack = new Stack(app, generateIntegStackName(__filename));
 
 const table = new dynamodb.Table(stack, 'mytable', {
+  billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  encryption: dynamodb.TableEncryption.AWS_MANAGED,
+  pointInTimeRecovery: true,
   partitionKey: {
     name: 'id',
     type: dynamodb.AttributeType.STRING

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.ts
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+/// !cdk-integ *
+import { App, Stack } from "@aws-cdk/core";
+import { DynamoDBStreamToLambdaProps, DynamoDBStreamToLambda } from "../lib";
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as dynamodb from '@aws-cdk/aws-dynamodb';
+import { generateIntegStackName } from '@aws-solutions-constructs/core';
+
+const app = new App();
+
+const stack = new Stack(app, generateIntegStackName(__filename));
+
+const table = new dynamodb.Table(stack, 'mytable', {
+  partitionKey: {
+    name: 'id',
+    type: dynamodb.AttributeType.STRING
+  },
+  stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES
+});
+
+const props: DynamoDBStreamToLambdaProps = {
+  lambdaFunctionProps: {
+    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+    runtime: lambda.Runtime.NODEJS_12_X,
+    handler: 'index.handler'
+  },
+  existingTableInterface: table
+};
+
+new DynamoDBStreamToLambda(stack, 'test-dynamodb-stream-lambda', props);
+
+app.synth();

--- a/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
@@ -63,18 +63,20 @@ export function buildDynamoDBTable(scope: cdk.Construct, props: BuildDynamoDBTab
   }
 }
 
-export function buildDynamoDBTableWithStream(scope: cdk.Construct, props: BuildDynamoDBTableWithStreamProps): dynamodb.Table | dynamodb.ITable {
+export function buildDynamoDBTableWithStream(scope: cdk.Construct, props: BuildDynamoDBTableWithStreamProps): [dynamodb.ITable, dynamodb.Table?] {
   // Conditional DynamoDB Table creation
   if (!props.existingTableInterface) {
     // Set the default props for DynamoDB table
     if (props.dynamoTableProps) {
       const dynamoTableProps = overrideProps(DefaultTableWithStreamProps, props.dynamoTableProps);
-      return new dynamodb.Table(scope, 'DynamoTable', dynamoTableProps);
+      const dynamoTable: dynamodb.Table = new dynamodb.Table(scope, 'DynamoTable', dynamoTableProps);
+      return [dynamoTable as dynamodb.ITable, dynamoTable];
     } else {
-      return new dynamodb.Table(scope, 'DynamoTable', DefaultTableWithStreamProps);
+      const dynamoTable: dynamodb.Table = new dynamodb.Table(scope, 'DynamoTable', DefaultTableWithStreamProps);
+      return [dynamoTable as dynamodb.ITable, dynamoTable];
     }
   } else {
-    return props.existingTableInterface;
+    return [props.existingTableInterface, undefined];
   }
 }
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
@@ -45,7 +45,7 @@ export interface BuildDynamoDBTableWithStreamProps {
    *
    * @default - None
    */
-  readonly existingTableObj?: dynamodb.ITable
+  readonly existingTableInterface?: dynamodb.ITable
 }
 
 export function buildDynamoDBTable(scope: cdk.Construct, props: BuildDynamoDBTableProps): dynamodb.Table {
@@ -63,9 +63,9 @@ export function buildDynamoDBTable(scope: cdk.Construct, props: BuildDynamoDBTab
   }
 }
 
-export function buildDynamoDBTableWithStream(scope: cdk.Construct, props: BuildDynamoDBTableWithStreamProps): dynamodb.ITable {
+export function buildDynamoDBTableWithStream(scope: cdk.Construct, props: BuildDynamoDBTableWithStreamProps): dynamodb.Table | dynamodb.ITable {
   // Conditional DynamoDB Table creation
-  if (!props.existingTableObj) {
+  if (!props.existingTableInterface) {
     // Set the default props for DynamoDB table
     if (props.dynamoTableProps) {
       const dynamoTableProps = overrideProps(DefaultTableWithStreamProps, props.dynamoTableProps);
@@ -74,7 +74,7 @@ export function buildDynamoDBTableWithStream(scope: cdk.Construct, props: BuildD
       return new dynamodb.Table(scope, 'DynamoTable', DefaultTableWithStreamProps);
     }
   } else {
-    return props.existingTableObj;
+    return props.existingTableInterface;
   }
 }
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
@@ -32,6 +32,22 @@ export interface BuildDynamoDBTableProps {
   readonly existingTableObj?: dynamodb.Table
 }
 
+export interface BuildDynamoDBTableWithStreamProps {
+  /**
+   * Optional user provided props to override the default props
+   *
+   * @default - Default props are used
+   */
+  readonly dynamoTableProps?: dynamodb.TableProps,
+  /**
+   * Existing instance of dynamodb table object.
+   * Providing both this and `dynamoTableProps` will cause an error.
+   *
+   * @default - None
+   */
+  readonly existingTableObj?: dynamodb.ITable
+}
+
 export function buildDynamoDBTable(scope: cdk.Construct, props: BuildDynamoDBTableProps): dynamodb.Table {
   // Conditional DynamoDB Table creation
   if (!props.existingTableObj) {
@@ -47,7 +63,7 @@ export function buildDynamoDBTable(scope: cdk.Construct, props: BuildDynamoDBTab
   }
 }
 
-export function buildDynamoDBTableWithStream(scope: cdk.Construct, props: BuildDynamoDBTableProps): dynamodb.Table {
+export function buildDynamoDBTableWithStream(scope: cdk.Construct, props: BuildDynamoDBTableWithStreamProps): dynamodb.ITable {
   // Conditional DynamoDB Table creation
   if (!props.existingTableObj) {
     // Set the default props for DynamoDB table

--- a/source/patterns/@aws-solutions-constructs/core/test/dynamo-table.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/dynamo-table.test.ts
@@ -322,10 +322,10 @@ test('test buildDynamoDBTableWithStream with existingTableObj', () => {
     stream: dynamodb.StreamViewType.NEW_IMAGE
   };
 
-  const existingTableObj = new dynamodb.Table(stack, 'DynamoTable', tableProps);
+  const existingTableInterface = new dynamodb.Table(stack, 'DynamoTable', tableProps);
 
   defaults.buildDynamoDBTableWithStream(stack, {
-    existingTableObj
+    existingTableInterface
   });
 
   expectCDK(stack).to(haveResource('AWS::DynamoDB::Table', {


### PR DESCRIPTION
*Issue #, if available:* [119](https://github.com/awslabs/aws-solutions-constructs/issues/119)

*Description of changes:*

Allow users to pass `dynamodb.ITable` for in construct props `existingTableObj` for dynamodb stream patterns

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.