### PR TITLE
feat (Disable DataTraceEnabled by default in API Gateway constructs

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/__snapshots__/apigateway-dynamodb.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/__snapshots__/apigateway-dynamodb.test.js.snap
@@ -199,7 +199,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.apigateway-dynamodb-CRUD.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.apigateway-dynamodb-CRUD.expected.json
@@ -103,7 +103,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.apigateway-dynamodb-existing-table.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.apigateway-dynamodb-existing-table.expected.json
@@ -100,7 +100,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.no-arguments.expected.json
@@ -100,7 +100,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/__snapshots__/test.apigateway-iot.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/__snapshots__/test.apigateway-iot.test.js.snap
@@ -195,7 +195,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1484,7 +1484,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -2712,7 +2712,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -4061,7 +4061,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.defaultParams.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.defaultParams.expected.json
@@ -164,7 +164,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.expected.json
@@ -166,7 +166,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.override_auth_api_keys.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.override_auth_api_keys.expected.json
@@ -164,7 +164,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/__snapshots__/apigateway-kinesis.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/__snapshots__/apigateway-kinesis.test.js.snap
@@ -219,7 +219,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -779,7 +779,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1279,7 +1279,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/apigateway-kinesis.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/apigateway-kinesis.test.ts
@@ -74,7 +74,7 @@ test('Test deployment w/ overwritten properties', () => {
   expect(stack).toHaveResourceLike('AWS::ApiGateway::Stage', {
     MethodSettings: [
       {
-        DataTraceEnabled: true,
+        DataTraceEnabled: false,
         HttpMethod: '*',
         LoggingLevel: 'INFO',
         ResourcePath: '/*'

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/integ.apigateway-kinesis-overwrite.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/integ.apigateway-kinesis-overwrite.expected.json
@@ -79,7 +79,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/integ.no-arguments.expected.json
@@ -79,7 +79,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/__snapshots__/test.apigateway-lambda.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/__snapshots__/test.apigateway-lambda.test.js.snap
@@ -383,7 +383,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1029,7 +1029,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1712,7 +1712,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -2309,7 +2309,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/integ.deployFunction.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/integ.deployFunction.expected.json
@@ -245,7 +245,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/integ.existingFunction.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/integ.existingFunction.expected.json
@@ -245,7 +245,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/__snapshots__/apigateway-sagemakerendpoint.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/__snapshots__/apigateway-sagemakerendpoint.test.js.snap
@@ -216,7 +216,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -583,7 +583,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/apigateway-sagemakerendpoint.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/apigateway-sagemakerendpoint.test.ts
@@ -93,7 +93,7 @@ test('Test deployment w/ overwritten properties', () => {
   expect(stack).toHaveResourceLike('AWS::ApiGateway::Stage', {
     MethodSettings: [
       {
-        DataTraceEnabled: true,
+        DataTraceEnabled: false,
         HttpMethod: '*',
         LoggingLevel: 'INFO',
         ResourcePath: '/*'

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/integ.apigateway-sagemakerendpoint-overwrite.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/integ.apigateway-sagemakerendpoint-overwrite.expected.json
@@ -128,7 +128,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/integ.no-overwrite.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/integ.no-overwrite.expected.json
@@ -75,7 +75,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/__snapshots__/apigateway-sqs.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/__snapshots__/apigateway-sqs.test.js.snap
@@ -175,7 +175,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -875,7 +875,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1388,7 +1388,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1815,7 +1815,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -2328,7 +2328,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apigateway-sqs-crud.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apigateway-sqs-crud.expected.json
@@ -239,7 +239,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.no-arguments.expected.json
@@ -237,7 +237,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/__snapshots__/test.cloudfront-apigateway-lambda.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/__snapshots__/test.cloudfront-apigateway-lambda.test.js.snap
@@ -816,7 +816,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.no-arguments.expected.json
@@ -245,7 +245,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.override-behavior.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.override-behavior.expected.json
@@ -294,7 +294,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/__snapshots__/test.cloudfront-apigateway.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/__snapshots__/test.cloudfront-apigateway.test.js.snap
@@ -479,7 +479,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.no-arguments.expected.json
@@ -245,7 +245,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/__snapshots__/test.cognito-apigateway-lambda.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/__snapshots__/test.cognito-apigateway-lambda.test.js.snap
@@ -561,7 +561,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/integ.no-arguments.expected.json
@@ -244,7 +244,7 @@
         },
         "MethodSettings": [
           {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*"

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
@@ -32,7 +32,7 @@ function DefaultRestApiProps(_endpointType: api.EndpointType[], _logGroup: LogGr
       accessLogDestination: new api.LogGroupLogDestination(_logGroup),
       accessLogFormat: api.AccessLogFormat.jsonWithStandardFields(),
       loggingLevel: api.MethodLoggingLevel.INFO,
-      dataTraceEnabled: true,
+      dataTraceEnabled: false,
       tracingEnabled: true
     },
     defaultMethodOptions: {

--- a/source/patterns/@aws-solutions-constructs/core/test/__snapshots__/apigateway-helper.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/core/test/__snapshots__/apigateway-helper.test.js.snap
@@ -174,7 +174,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -557,7 +557,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -851,7 +851,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1146,7 +1146,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
@@ -1779,7 +1779,7 @@ Object {
         },
         "MethodSettings": Array [
           Object {
-            "DataTraceEnabled": true,
+            "DataTraceEnabled": false,
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",


### PR DESCRIPTION
*Issue #, if available:*
[218](https://github.com/awslabs/aws-solutions-constructs/issues/218)

*Description of changes:*
Set DataTraceEnabled to false by default in all API Gateway constructs. This is best practice according to AWS Security

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.