### PR TITLE
fix (MediaStore policy fix to deny anonymous user-agents access aws-cloudfront-mediastore) 

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/lib/index.ts
@@ -95,9 +95,11 @@ export class CloudFrontToMediaStore extends Construct {
               ],
               Resource: `arn:${Aws.PARTITION}:mediastore:${Aws.REGION}:${Aws.ACCOUNT_ID}:container/${Aws.STACK_NAME}/*`,
               Condition: {
+                StringEquals: {
+                    'aws:UserAgent': this.cloudFrontOriginAccessIdentity.originAccessIdentityName
+                },
                 Bool: {
-                  'aws:UserAgent': this.cloudFrontOriginAccessIdentity.originAccessIdentityName,
-                  'aws:SecureTransport': 'true'
+                    'aws:SecureTransport': 'true'
                 }
               }
             }]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/lib/index.ts
@@ -96,10 +96,10 @@ export class CloudFrontToMediaStore extends Construct {
               Resource: `arn:${Aws.PARTITION}:mediastore:${Aws.REGION}:${Aws.ACCOUNT_ID}:container/${Aws.STACK_NAME}/*`,
               Condition: {
                 StringEquals: {
-                    'aws:UserAgent': this.cloudFrontOriginAccessIdentity.originAccessIdentityName
+                  'aws:UserAgent': this.cloudFrontOriginAccessIdentity.originAccessIdentityName
                 },
                 Bool: {
-                    'aws:SecureTransport': 'true'
+                  'aws:SecureTransport': 'true'
                 }
               }
             }]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/__snapshots__/cloudfront-mediastore.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/__snapshots__/cloudfront-mediastore.test.js.snap
@@ -285,11 +285,11 @@ Object {
               Object {
                 "Ref": "AWS::StackName",
               },
-              "/*\\",\\"Condition\\":{\\"Bool\\":{\\"aws:UserAgent\\":\\"",
+              "/*\\",\\"Condition\\":{\\"StringEquals\\":{\\"aws:UserAgent\\":\\"",
               Object {
                 "Ref": "testcloudfrontmediastoreCloudFrontOriginAccessIdentity966405A0",
               },
-              "\\",\\"aws:SecureTransport\\":\\"true\\"}}}]}",
+              "\\"},\\"Bool\\":{\\"aws:SecureTransport\\":\\"true\\"}}}]}",
             ],
           ],
         },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.default.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.default.expected.json
@@ -71,11 +71,11 @@
               {
                 "Ref": "AWS::StackName"
               },
-              "/*\",\"Condition\":{\"Bool\":{\"aws:UserAgent\":\"",
+              "/*\",\"Condition\":{\"StringEquals\":{\"aws:UserAgent\":\"",
               {
                 "Ref": "testcloudfrontmediastoreCloudFrontOriginAccessIdentity966405A0"
               },
-              "\",\"aws:SecureTransport\":\"true\"}}}]}"
+              "\"},\"Bool\":{\"aws:SecureTransport\":\"true\"}}}]}"
             ]
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.withoutHttpSecurityHeaders.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.withoutHttpSecurityHeaders.expected.json
@@ -71,11 +71,11 @@
               {
                 "Ref": "AWS::StackName"
               },
-              "/*\",\"Condition\":{\"Bool\":{\"aws:UserAgent\":\"",
+              "/*\",\"Condition\":{\"StringEquals\":{\"aws:UserAgent\":\"",
               {
                 "Ref": "testcloudfrontmediastoreCloudFrontOriginAccessIdentity966405A0"
               },
-              "\",\"aws:SecureTransport\":\"true\"}}}]}"
+              "\"},\"Bool\":{\"aws:SecureTransport\":\"true\"}}}]}"
             ]
           ]
         }


### PR DESCRIPTION
*Issue #, if available:*
#252 

*Description of changes:*
Modified the AWS MediaStore policy condition to only allow the AWS CloudFront user agent. Look at the bug description for more details. 
https://github.com/awslabs/aws-solutions-constructs/issues/252

Tested changes to make sure they have the intended effect of only allowing access to GET request files from the Amazon CloudFront endpoint. GET requests directly to MediaStore endpoint now just return a generic 403 access denied response. 

`
Condition: {
  StringEquals: {
    'aws:UserAgent': this.cloudFrontOriginAccessIdentity.originAccessIdentityName
  },
  Bool: {
    'aws:SecureTransport': 'true'
}
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

BREAKING CHANGE: The construct docs say Mediastore requests are only accepted from CloudFront. The policy as written did not enforce this. If your app relied on the undocumented behavior and made Mediastore requests directly this change will break your app as the policy is now implemented as documented - only calls through CloudFront are accepted.