### PR TITLE
fix (allow IBucket for aws-cloudfront-s3 pattern) (#139)

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/README.md
@@ -49,7 +49,7 @@ _Parameters_
 
 | **Name**     | **Type**        | **Description** |
 |:-------------|:----------------|-----------------|
-|existingBucketObj?|[`s3.Bucket`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.Bucket.html)|Existing instance of S3 Bucket object. If this is provided, then also providing bucketProps is an error. |
+|existingBucketInterface?|[`s3.IBucket`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.IBucket.html)|Existing instance of S3 Bucket object or interface. If this is provided, then also providing bucketProps will cause an error. |
 |bucketProps?|[`s3.BucketProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.BucketProps.html)|User provided props to override the default props for the S3 Bucket.|
 |cloudFrontDistributionProps?|[`cloudfront.DistributionProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.DistributionProps.html)|Optional user provided props to override the default props for CloudFront Distribution|
 |insertHttpSecurityHeaders?|`boolean`|Optional user provided props to turn on/off the automatic injection of best practice HTTP security headers in all responses from CloudFront|
@@ -61,7 +61,8 @@ _Parameters_
 |cloudFrontWebDistribution|[`cloudfront.CloudFrontWebDistribution`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.CloudFrontWebDistribution.html)|Returns an instance of cloudfront.CloudFrontWebDistribution created by the construct|
 |edgeLambdaFunctionVersion|[`lambda.Version`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Version.html)|Returns an instance of the edge Lambda function version created by the pattern.|
 |cloudFrontLoggingBucket|[`s3.Bucket`](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-s3-readme.html)|Returns an instance of the logging bucket for CloudFront WebDistribution.|
-|s3Bucket?|[`s3.Bucket`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.Bucket.html)|Returns an instance of s3.Bucket created by the construct.|
+|s3BucketInterface|[`s3.IBucket`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.IBucket.html)|Returns an instance of s3.IBucket created by the construct|
+|s3Bucket?|[`s3.Bucket`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.Bucket.html)|Returns an instance of s3.Bucket created by the construct. IMPORTANT: If existingBucketInterface was provided in Pattern Construct Props, this property will be `undefined`|
 |s3LoggingBucket?|[`s3.Bucket`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.Bucket.html)|Returns an instance of s3.Bucket created by the construct as the logging bucket for the primary bucket.|
 
 ## Default settings

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/lib/index.ts
@@ -26,7 +26,7 @@ export interface CloudFrontToS3Props {
    *
    * @default - None
    */
-  readonly existingBucketObj?: s3.Bucket,
+  readonly existingBucketInterface?: s3.IBucket,
   /**
    * User provided props to override the default props for the S3 Bucket.
    *
@@ -52,6 +52,7 @@ export class CloudFrontToS3 extends Construct {
     public readonly cloudFrontWebDistribution: cloudfront.Distribution;
     public readonly edgeLambdaFunctionVersion?: lambda.Version;
     public readonly cloudFrontLoggingBucket?: s3.Bucket;
+    public readonly s3BucketInterface: s3.IBucket;
     public readonly s3Bucket?: s3.Bucket;
     public readonly s3LoggingBucket?: s3.Bucket;
 
@@ -67,23 +68,17 @@ export class CloudFrontToS3 extends Construct {
       super(scope, id);
       defaults.CheckProps(props);
 
-      let bucket: s3.Bucket;
-
-      if (props.existingBucketObj && props.bucketProps) {
-        throw new Error('Cannot specify both bucket properties and an existing bucket');
-      }
-
-      if (!props.existingBucketObj) {
+      if (!props.existingBucketInterface) {
         [this.s3Bucket, this.s3LoggingBucket] = defaults.buildS3Bucket(this, {
           bucketProps: props.bucketProps
         });
-        bucket = this.s3Bucket;
+        this.s3BucketInterface = this.s3Bucket;
       } else {
-        bucket = props.existingBucketObj;
+        this.s3BucketInterface = props.existingBucketInterface;
       }
 
       [this.cloudFrontWebDistribution, this.edgeLambdaFunctionVersion, this.cloudFrontLoggingBucket] =
-          defaults.CloudFrontDistributionForS3(this, bucket,
+          defaults.CloudFrontDistributionForS3(this, this.s3BucketInterface,
             props.cloudFrontDistributionProps, props.insertHttpSecurityHeaders);
     }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.existing-bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.existing-bucket.ts
@@ -29,7 +29,7 @@ let mybucket: s3.Bucket;
 mybucket = defaults.CreateScrapBucket(stack, { removalPolicy: RemovalPolicy.DESTROY });
 
 const _construct = new CloudFrontToS3(stack, 'test-cloudfront-s3', {
-  existingBucketObj: mybucket,
+  existingBucketInterface: mybucket,
 });
 
 // Add Cache Policy

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -94,7 +94,7 @@ test('check existing bucket', () => {
   });
 
   const props: CloudFrontToS3Props = {
-    existingBucketObj: existingBucket
+    existingBucketInterface: existingBucket
   };
 
   new CloudFrontToS3(stack, 'test-cloudfront-s3', props);
@@ -214,7 +214,7 @@ test("Test bad call with existingBucket and bucketProps", () => {
   const app = () => {
     // Helper declaration
     new CloudFrontToS3(stack, "bad-s3-args", {
-      existingBucketObj: testBucket,
+      existingBucketInterface: testBucket,
       bucketProps: {
         removalPolicy: RemovalPolicy.DESTROY
       },

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-defaults.ts
@@ -58,7 +58,7 @@ export function DefaultCloudFrontWebDistributionForApiGatewayProps(apiEndPoint: 
   }
 }
 
-export function DefaultCloudFrontWebDistributionForS3Props(sourceBucket: s3.Bucket, loggingBucket: s3.Bucket,
+export function DefaultCloudFrontWebDistributionForS3Props(sourceBucket: s3.IBucket, loggingBucket: s3.Bucket,
   setHttpSecurityHeaders: boolean,
   edgeLambda?: lambda.Version): cloudfront.DistributionProps {
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
@@ -140,7 +140,7 @@ export function CloudFrontDistributionForApiGateway(scope: cdk.Construct,
 }
 
 export function CloudFrontDistributionForS3(scope: cdk.Construct,
-  sourceBucket: s3.Bucket,
+  sourceBucket: s3.IBucket,
   cloudFrontDistributionProps?: cloudfront.DistributionProps | any,
   httpSecurityHeaders?: boolean): [cloudfront.Distribution,
                                             lambda.Version?, s3.Bucket?] {

--- a/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
@@ -27,6 +27,7 @@ import * as kms from "@aws-cdk/aws-kms";
 export interface VerifiedProps {
   readonly dynamoTableProps?: dynamodb.TableProps,
   readonly existingTableObj?: dynamodb.Table,
+  readonly existingTableInterface?: dynamodb.ITable,
 
   readonly existingStreamObj?: kinesis.Stream;
   readonly kinesisStreamProps?: kinesis.StreamProps,
@@ -43,6 +44,7 @@ export interface VerifiedProps {
   readonly mediaStoreContainerProps?: mediastore.CfnContainerProps;
 
   readonly existingBucketObj?: s3.Bucket,
+  readonly existingBucketInterface?: s3.IBucket,
   readonly bucketProps?: s3.BucketProps,
 
   readonly topicProps?: sns.TopicProps,
@@ -75,6 +77,11 @@ export function CheckProps(propsObject: VerifiedProps | any) {
     errorFound = true;
   }
 
+  if (propsObject.dynamoTableProps && propsObject.existingTableInterface) {
+    errorMessages += 'Error - Either provide existingTableInterface or dynamoTableProps, but not both.\n';
+    errorFound = true;
+  }
+
   if (propsObject.existingStreamObj  && propsObject.kinesisStreamProps) {
     errorMessages += 'Error - Either provide existingStreamObj or kinesisStreamProps, but not both.\n';
     errorFound = true;
@@ -102,6 +109,11 @@ export function CheckProps(propsObject: VerifiedProps | any) {
 
   if (propsObject.existingBucketObj && propsObject.bucketProps) {
     errorMessages += 'Error - Either provide bucketProps or existingBucketObj, but not both.\n';
+    errorFound = true;
+  }
+
+  if (propsObject.existingBucketInterface && propsObject.bucketProps) {
+    errorMessages += 'Error - Either provide bucketProps or existingBucketInterface, but not both.\n';
     errorFound = true;
   }
 


### PR DESCRIPTION
*Issue #, if available:* [139](https://github.com/awslabs/aws-solutions-constructs/issues/139)

*Description of changes:*

Allow users to pass `s3.IBucket` for in construct props `existingBucketInterface` for aws-cloudfront-s3 pattern

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.