### PR TITLE
Remove `| any` from `apiGatewayProps`

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/lib/index.ts
@@ -40,7 +40,7 @@ export interface ApiGatewayToLambdaProps {
    *
    * @default - Default props are used.
    */
-  readonly apiGatewayProps?: api.LambdaRestApiProps | any,
+  readonly apiGatewayProps?: Partial<api.LambdaRestApiProps>,
   /**
    * User provided props to override the default props for the CloudWatchLogs LogGroup.
    *


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Adding ` | any` to the type for `apiGatewayProps` in the aws-apigateway-lambda construct was removing intellisense. Not sure why it was in there. This _shouldn't_ be a breaking change for anyone who has validly-defined props, unless I'm missing something...