### PR TITLE
fix(bucket encryption) added bucket encryption for s3 in test helpers

### DIFF
--- a/source/patterns/@aws-solutions-constructs/core/test/test-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/test-helper.ts
@@ -13,7 +13,7 @@
 
 // Imports
 import { Bucket, BucketProps } from "@aws-cdk/aws-s3";
-import { Construct, RemovalPolicy } from "@aws-cdk/core";
+import { Construct, RemovalPolicy, BucketEncryption } from "@aws-cdk/core";
 import { overrideProps, addCfnSuppressRules } from "../lib/utils";
 import * as path from 'path';
 
@@ -22,6 +22,7 @@ export function CreateScrapBucket(scope: Construct, props?: BucketProps | any) {
   const defaultProps = {
     versioned: true,
     removalPolicy: RemovalPolicy.DESTROY,
+    encryption: BucketEncryption.S3_MANAGED
   };
 
   let synthesizedProps: BucketProps;


### PR DESCRIPTION
*Issue #305 , if available:*

*Description of changes:*
Added bucket encryption for s3 in test helpers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.