### PR TITLE
feat (Set eligible constructs to Stable)

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/README.md
@@ -3,11 +3,7 @@
 
 ---
 
-![Stability: Experimental](https://img.shields.io/badge/stability-Experimental-important.svg?style=for-the-badge)
-
-> All classes are under active development and subject to non-backward compatible changes or removal in any
-> future version. These are not subject to the [Semantic Versioning](https://semver.org/) model.
-> This means that while you may use them, you may need to update your source code when upgrading to a newer version of this package.
+![Stability: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ---
 <!--END STABILITY BANNER-->


### PR DESCRIPTION
*Issue #, if available:*
[Issue322](https://github.com/awslabs/aws-solutions-constructs/issues/322) 

*Description of changes:*
<!-- short description of the feature you are proposing: -->
[INTERNAL] AWS has criteria for number of deployments and time period without a breaking change to make a construct stable. The following constructs are now eligible and can be moved:

apigateway-lambda
apigateway-sqs
kinesisfirehose-s3
lambda-dynamodb
lambda-s3
lambda-sqs
s3-lambda
sns-lambda
sqs-lambda

We'll be documenting the criteria soon, but in short they are:

**Construct Eligibility**
- 30 days without a breaking change
- 50 deployments of the construct
- Each key service interface is considered stable (eg apigateway and lambda for the first construct above)

**Key Service Eligibility**
- A total of 200 deployments of constructs that include the service (eg - 125 cloudfront-apigateway and 100 apigateway-lambda)
- At least 2 released constructs using that key service
- CDK L2 construct for service is GA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.