### PR TITLE
fix(wrapped constructs): shorten wrapped ID names in deprecated constructs

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
@@ -119,7 +119,7 @@ export class DynamoDBStreamToLambdaToElasticSearchAndKibana extends Construct {
     const convertedProps: DynamoDBStreamToLambdaToElasticSearchAndKibanaProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new DynamoDBStreamsToLambdaToElasticSearchAndKibana instead of DynamoDBStreamToLambdaToElasticSearchAndKibana)
     const wrappedConstruct: DynamoDBStreamToLambdaToElasticSearchAndKibana = new DynamoDBStreamsToLambdaToElasticSearchAndKibana(

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
@@ -117,6 +117,11 @@ export class DynamoDBStreamToLambdaToElasticSearchAndKibana extends Construct {
   constructor(scope: Construct, id: string, props: DynamoDBStreamToLambdaToElasticSearchAndKibanaProps) {
     super(scope, id);
     const convertedProps: DynamoDBStreamToLambdaToElasticSearchAndKibanaProps = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new DynamoDBStreamsToLambdaToElasticSearchAndKibana instead of DynamoDBStreamToLambdaToElasticSearchAndKibana)
     const wrappedConstruct: DynamoDBStreamToLambdaToElasticSearchAndKibana = new DynamoDBStreamsToLambdaToElasticSearchAndKibana(
       this, `${id}W`, convertedProps);
 

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/lib/index.ts
@@ -118,7 +118,7 @@ export class DynamoDBStreamToLambdaToElasticSearchAndKibana extends Construct {
     super(scope, id);
     const convertedProps: DynamoDBStreamToLambdaToElasticSearchAndKibanaProps = { ...props };
     const wrappedConstruct: DynamoDBStreamToLambdaToElasticSearchAndKibana = new DynamoDBStreamsToLambdaToElasticSearchAndKibana(
-      this, `${id}-wrapped`, convertedProps);
+      this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;
     this.dynamoTable = wrappedConstruct.dynamoTable;

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/test/__snapshots__/dynamodb-stream-lambda-elasticsearch-kibana.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/test/__snapshots__/dynamodb-stream-lambda-elasticsearch-kibana.test.js.snap
@@ -17,7 +17,7 @@ Object {
     },
   },
   "Resources": Object {
-    "teststackteststackwrappedDynamoDBStreamsToLambdaDynamoTable285FB6C5": Object {
+    "teststackteststackWDynamoDBStreamsToLambdaDynamoTableC58704B3": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "AttributeDefinitions": Array [
@@ -46,10 +46,10 @@ Object {
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
     },
-    "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionDF5A3CF8": Object {
+    "teststackteststackWDynamoDBStreamsToLambdaLambdaFunction02D303BD": Object {
       "DependsOn": Array [
-        "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicy74D14AAA",
-        "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDFC00776",
+        "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicyDDC691BF",
+        "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRole9196C7E3",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -113,7 +113,7 @@ Object {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DOMAIN_ENDPOINT": Object {
               "Fn::GetAtt": Array [
-                "teststackteststackwrappedLambdaToElasticSearchElasticsearchDomain7582D2E3",
+                "teststackteststackWLambdaToElasticSearchElasticsearchDomainA58EE4BC",
                 "DomainEndpoint",
               ],
             },
@@ -122,7 +122,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDFC00776",
+            "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRole9196C7E3",
             "Arn",
           ],
         },
@@ -133,7 +133,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionDynamoDBEventSourceteststackteststackwrappedDynamoDBStreamsToLambdaDynamoTableE5F505A30EC154BA": Object {
+    "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionDynamoDBEventSourceteststackteststackWDynamoDBStreamsToLambdaDynamoTable73DF79BC81B75056": Object {
       "Properties": Object {
         "BatchSize": 100,
         "BisectBatchOnFunctionError": true,
@@ -141,7 +141,7 @@ Object {
           "OnFailure": Object {
             "Destination": Object {
               "Fn::GetAtt": Array [
-                "teststackteststackwrappedDynamoDBStreamsToLambdaSqsDlqQueue5B5A4F47",
+                "teststackteststackWDynamoDBStreamsToLambdaSqsDlqQueue10818CA0",
                 "Arn",
               ],
             },
@@ -149,12 +149,12 @@ Object {
         },
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
-            "teststackteststackwrappedDynamoDBStreamsToLambdaDynamoTable285FB6C5",
+            "teststackteststackWDynamoDBStreamsToLambdaDynamoTableC58704B3",
             "StreamArn",
           ],
         },
         "FunctionName": Object {
-          "Ref": "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionDF5A3CF8",
+          "Ref": "teststackteststackWDynamoDBStreamsToLambdaLambdaFunction02D303BD",
         },
         "MaximumRecordAgeInSeconds": 86400,
         "MaximumRetryAttempts": 500,
@@ -162,7 +162,7 @@ Object {
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDFC00776": Object {
+    "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRole9196C7E3": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -217,7 +217,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicy74D14AAA": Object {
+    "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicyDDC691BF": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -253,7 +253,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "teststackteststackwrappedDynamoDBStreamsToLambdaDynamoTable285FB6C5",
+                  "teststackteststackWDynamoDBStreamsToLambdaDynamoTableC58704B3",
                   "StreamArn",
                 ],
               },
@@ -267,7 +267,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "teststackteststackwrappedDynamoDBStreamsToLambdaSqsDlqQueue5B5A4F47",
+                  "teststackteststackWDynamoDBStreamsToLambdaSqsDlqQueue10818CA0",
                   "Arn",
                 ],
               },
@@ -275,16 +275,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicy74D14AAA",
+        "PolicyName": "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicyDDC691BF",
         "Roles": Array [
           Object {
-            "Ref": "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDFC00776",
+            "Ref": "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRole9196C7E3",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "teststackteststackwrappedDynamoDBStreamsToLambdaSqsDlqQueue5B5A4F47": Object {
+    "teststackteststackWDynamoDBStreamsToLambdaSqsDlqQueue10818CA0": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": "alias/aws/sqs",
@@ -292,7 +292,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "teststackteststackwrappedDynamoDBStreamsToLambdaSqsDlqQueuePolicyE03A7292": Object {
+    "teststackteststackWDynamoDBStreamsToLambdaSqsDlqQueuePolicyDEE1A56C": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -327,7 +327,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "teststackteststackwrappedDynamoDBStreamsToLambdaSqsDlqQueue5B5A4F47",
+                  "teststackteststackWDynamoDBStreamsToLambdaSqsDlqQueue10818CA0",
                   "Arn",
                 ],
               },
@@ -346,7 +346,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "teststackteststackwrappedDynamoDBStreamsToLambdaSqsDlqQueue5B5A4F47",
+                  "teststackteststackWDynamoDBStreamsToLambdaSqsDlqQueue10818CA0",
                   "Arn",
                 ],
               },
@@ -357,13 +357,13 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "teststackteststackwrappedDynamoDBStreamsToLambdaSqsDlqQueue5B5A4F47",
+            "Ref": "teststackteststackWDynamoDBStreamsToLambdaSqsDlqQueue10818CA0",
           },
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "teststackteststackwrappedLambdaToElasticSearchAutomatedSnapshotFailureTooHighAlarm7CC2CA20": Object {
+    "teststackteststackWLambdaToElasticSearchAutomatedSnapshotFailureTooHighAlarmDB9BEA35": Object {
       "Properties": Object {
         "AlarmDescription": "An automated snapshot failed. This failure is often the result of a red cluster health status.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -376,7 +376,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchCPUUtilizationTooHighAlarm98B1C537": Object {
+    "teststackteststackWLambdaToElasticSearchCPUUtilizationTooHighAlarmB8332071": Object {
       "Properties": Object {
         "AlarmDescription": "100% CPU utilization is not uncommon, but sustained high usage is problematic. Consider using larger instance types or adding instances.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -389,7 +389,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchCognitoAuthorizedRole15BFD8EB": Object {
+    "teststackteststackWLambdaToElasticSearchCognitoAuthorizedRole9F564D93": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -401,7 +401,7 @@ Object {
                 },
                 "StringEquals": Object {
                   "cognito-identity.amazonaws.com:aud": Object {
-                    "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoIdentityPoolF92B1D06",
+                    "Ref": "teststackteststackWLambdaToElasticSearchCognitoIdentityPool3BA17797",
                   },
                 },
               },
@@ -450,17 +450,17 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "teststackteststackwrappedLambdaToElasticSearchCognitoIdentityPoolF92B1D06": Object {
+    "teststackteststackWLambdaToElasticSearchCognitoIdentityPool3BA17797": Object {
       "Properties": Object {
         "AllowUnauthenticatedIdentities": false,
         "CognitoIdentityProviders": Array [
           Object {
             "ClientId": Object {
-              "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolClient14E0ADEE",
+              "Ref": "teststackteststackWLambdaToElasticSearchCognitoUserPoolClient4EC5CDBA",
             },
             "ProviderName": Object {
               "Fn::GetAtt": Array [
-                "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97",
+                "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8",
                 "ProviderName",
               ],
             },
@@ -470,7 +470,7 @@ Object {
       },
       "Type": "AWS::Cognito::IdentityPool",
     },
-    "teststackteststackwrappedLambdaToElasticSearchCognitoKibanaConfigureRoleD014A932": Object {
+    "teststackteststackWLambdaToElasticSearchCognitoKibanaConfigureRole583382EC": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -487,7 +487,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "teststackteststackwrappedLambdaToElasticSearchCognitoKibanaConfigureRolePolicy5276FFBA": Object {
+    "teststackteststackWLambdaToElasticSearchCognitoKibanaConfigureRolePolicy78D4B93D": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -510,7 +510,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97",
+                    "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8",
                     "Arn",
                   ],
                 },
@@ -528,7 +528,7 @@ Object {
                       },
                       ":identitypool/",
                       Object {
-                        "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoIdentityPoolF92B1D06",
+                        "Ref": "teststackteststackWLambdaToElasticSearchCognitoIdentityPool3BA17797",
                       },
                     ],
                   ],
@@ -561,7 +561,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "teststackteststackwrappedLambdaToElasticSearchCognitoKibanaConfigureRoleD014A932",
+                  "teststackteststackWLambdaToElasticSearchCognitoKibanaConfigureRole583382EC",
                   "Arn",
                 ],
               },
@@ -569,16 +569,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "teststackteststackwrappedLambdaToElasticSearchCognitoKibanaConfigureRolePolicy5276FFBA",
+        "PolicyName": "teststackteststackWLambdaToElasticSearchCognitoKibanaConfigureRolePolicy78D4B93D",
         "Roles": Array [
           Object {
-            "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoKibanaConfigureRoleD014A932",
+            "Ref": "teststackteststackWLambdaToElasticSearchCognitoKibanaConfigureRole583382EC",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97": Object {
+    "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "AccountRecoverySetting": Object {
@@ -612,7 +612,7 @@ Object {
       "Type": "AWS::Cognito::UserPool",
       "UpdateReplacePolicy": "Retain",
     },
-    "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolClient14E0ADEE": Object {
+    "teststackteststackWLambdaToElasticSearchCognitoUserPoolClient4EC5CDBA": Object {
       "Properties": Object {
         "AllowedOAuthFlows": Array [
           "implicit",
@@ -633,12 +633,12 @@ Object {
           "COGNITO",
         ],
         "UserPoolId": Object {
-          "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97",
+          "Ref": "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8",
         },
       },
       "Type": "AWS::Cognito::UserPoolClient",
     },
-    "teststackteststackwrappedLambdaToElasticSearchElasticsearchDomain7582D2E3": Object {
+    "teststackteststackWLambdaToElasticSearchElasticsearchDomainA58EE4BC": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -663,13 +663,13 @@ Object {
                 "AWS": Array [
                   Object {
                     "Fn::GetAtt": Array [
-                      "teststackteststackwrappedLambdaToElasticSearchCognitoAuthorizedRole15BFD8EB",
+                      "teststackteststackWLambdaToElasticSearchCognitoAuthorizedRole9F564D93",
                       "Arn",
                     ],
                   },
                   Object {
                     "Fn::GetAtt": Array [
-                      "teststackteststackwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDFC00776",
+                      "teststackteststackWDynamoDBStreamsToLambdaLambdaFunctionServiceRole9196C7E3",
                       "Arn",
                     ],
                   },
@@ -698,16 +698,16 @@ Object {
         "CognitoOptions": Object {
           "Enabled": true,
           "IdentityPoolId": Object {
-            "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoIdentityPoolF92B1D06",
+            "Ref": "teststackteststackWLambdaToElasticSearchCognitoIdentityPool3BA17797",
           },
           "RoleArn": Object {
             "Fn::GetAtt": Array [
-              "teststackteststackwrappedLambdaToElasticSearchCognitoKibanaConfigureRoleD014A932",
+              "teststackteststackWLambdaToElasticSearchCognitoKibanaConfigureRole583382EC",
               "Arn",
             ],
           },
           "UserPoolId": Object {
-            "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97",
+            "Ref": "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8",
           },
         },
         "DomainName": "test-domain",
@@ -737,7 +737,7 @@ Object {
       },
       "Type": "AWS::Elasticsearch::Domain",
     },
-    "teststackteststackwrappedLambdaToElasticSearchFreeStorageSpaceTooLowAlarm03262807": Object {
+    "teststackteststackWLambdaToElasticSearchFreeStorageSpaceTooLowAlarmA97B2388": Object {
       "Properties": Object {
         "AlarmDescription": "A node in your cluster is down to 20 GiB of free storage space.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
@@ -750,15 +750,15 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchIdentityPoolRoleMapping529E4FD4": Object {
+    "teststackteststackWLambdaToElasticSearchIdentityPoolRoleMappingA90C3B64": Object {
       "Properties": Object {
         "IdentityPoolId": Object {
-          "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoIdentityPoolF92B1D06",
+          "Ref": "teststackteststackWLambdaToElasticSearchCognitoIdentityPool3BA17797",
         },
         "Roles": Object {
           "authenticated": Object {
             "Fn::GetAtt": Array [
-              "teststackteststackwrappedLambdaToElasticSearchCognitoAuthorizedRole15BFD8EB",
+              "teststackteststackWLambdaToElasticSearchCognitoAuthorizedRole9F564D93",
               "Arn",
             ],
           },
@@ -766,7 +766,7 @@ Object {
       },
       "Type": "AWS::Cognito::IdentityPoolRoleAttachment",
     },
-    "teststackteststackwrappedLambdaToElasticSearchIndexWritesBlockedTooHighAlarm806FBE2F": Object {
+    "teststackteststackWLambdaToElasticSearchIndexWritesBlockedTooHighAlarmAB181272": Object {
       "Properties": Object {
         "AlarmDescription": "Your cluster is blocking write requests.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -779,7 +779,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchJVMMemoryPressureTooHighAlarm357EE07D": Object {
+    "teststackteststackWLambdaToElasticSearchJVMMemoryPressureTooHighAlarmB5BFB3E3": Object {
       "Properties": Object {
         "AlarmDescription": "Average JVM memory pressure over last 15 minutes too high. Consider scaling vertically.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -792,7 +792,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchMasterCPUUtilizationTooHighAlarmF390E9A4": Object {
+    "teststackteststackWLambdaToElasticSearchMasterCPUUtilizationTooHighAlarmED6A34F6": Object {
       "Properties": Object {
         "AlarmDescription": "Average CPU utilization over last 45 minutes too high. Consider using larger instance types for your dedicated master nodes.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -805,7 +805,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchMasterJVMMemoryPressureTooHighAlarm9B82F810": Object {
+    "teststackteststackWLambdaToElasticSearchMasterJVMMemoryPressureTooHighAlarmC496CE72": Object {
       "Properties": Object {
         "AlarmDescription": "Average JVM memory pressure over last 15 minutes too high. Consider scaling vertically.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -818,7 +818,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchStatusRedAlarm5BF76B79": Object {
+    "teststackteststackWLambdaToElasticSearchStatusRedAlarm6C99C305": Object {
       "Properties": Object {
         "AlarmDescription": "At least one primary shard and its replicas are not allocated to a node. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -831,7 +831,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchStatusYellowAlarm2F036EF1": Object {
+    "teststackteststackWLambdaToElasticSearchStatusYellowAlarm8AA413EB": Object {
       "Properties": Object {
         "AlarmDescription": "At least one replica shard is not allocated to a node.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -844,14 +844,14 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "teststackteststackwrappedLambdaToElasticSearchUserPoolDomain5511272B": Object {
+    "teststackteststackWLambdaToElasticSearchUserPoolDomainCB8B0E89": Object {
       "DependsOn": Array [
-        "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97",
+        "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8",
       ],
       "Properties": Object {
         "Domain": "test-domain",
         "UserPoolId": Object {
-          "Ref": "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97",
+          "Ref": "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8",
         },
       },
       "Type": "AWS::Cognito::UserPoolDomain",

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/test/dynamodb-stream-lambda-elasticsearch-kibana.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/test/dynamodb-stream-lambda-elasticsearch-kibana.test.ts
@@ -45,7 +45,7 @@ test('check domain names', () => {
   expect(stack).toHaveResource('AWS::Cognito::UserPoolDomain', {
     Domain: "test-domain",
     UserPoolId: {
-      Ref: "teststackteststackwrappedLambdaToElasticSearchCognitoUserPoolBA16EA97"
+      Ref: "teststackteststackWLambdaToElasticSearchCognitoUserPool788087A8"
     }
   });
 

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/test/integ.no-arguments.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRole8E01C5A6": {
+    "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRole8D6AEC0A": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -55,7 +55,7 @@
         ]
       }
     },
-    "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicyC8A1DCB4": {
+    "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicy5AE52FA4": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -82,7 +82,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedDynamoDBStreamsToLambdaDynamoTableF4FAE7DB",
+                  "testtestWDynamoDBStreamsToLambdaDynamoTable9804CAC7",
                   "StreamArn"
                 ]
               }
@@ -96,7 +96,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedDynamoDBStreamsToLambdaSqsDlqQueueD06676DD",
+                  "testtestWDynamoDBStreamsToLambdaSqsDlqQueueC634D3F4",
                   "Arn"
                 ]
               }
@@ -104,10 +104,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicyC8A1DCB4",
+        "PolicyName": "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicy5AE52FA4",
         "Roles": [
           {
-            "Ref": "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRole8E01C5A6"
+            "Ref": "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRole8D6AEC0A"
           }
         ]
       },
@@ -122,7 +122,7 @@
         }
       }
     },
-    "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionCD258013": {
+    "testtestWDynamoDBStreamsToLambdaLambdaFunction452E3147": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -165,7 +165,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRole8E01C5A6",
+            "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRole8D6AEC0A",
             "Arn"
           ]
         },
@@ -174,7 +174,7 @@
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "DOMAIN_ENDPOINT": {
               "Fn::GetAtt": [
-                "testtestwrappedLambdaToElasticSearchElasticsearchDomain4F3B9456",
+                "testtestWLambdaToElasticSearchElasticsearchDomain66526D54",
                 "DomainEndpoint"
               ]
             }
@@ -187,8 +187,8 @@
         }
       },
       "DependsOn": [
-        "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicyC8A1DCB4",
-        "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRole8E01C5A6"
+        "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRoleDefaultPolicy5AE52FA4",
+        "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRole8D6AEC0A"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -209,11 +209,11 @@
         }
       }
     },
-    "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionDynamoDBEventSourcenoargumentstesttestwrappedDynamoDBStreamsToLambdaDynamoTable7AFC1B74327F66DB": {
+    "testtestWDynamoDBStreamsToLambdaLambdaFunctionDynamoDBEventSourcenoargumentstesttestWDynamoDBStreamsToLambdaDynamoTable2E65396DBA100DE2": {
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "FunctionName": {
-          "Ref": "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionCD258013"
+          "Ref": "testtestWDynamoDBStreamsToLambdaLambdaFunction452E3147"
         },
         "BatchSize": 100,
         "BisectBatchOnFunctionError": true,
@@ -221,7 +221,7 @@
           "OnFailure": {
             "Destination": {
               "Fn::GetAtt": [
-                "testtestwrappedDynamoDBStreamsToLambdaSqsDlqQueueD06676DD",
+                "testtestWDynamoDBStreamsToLambdaSqsDlqQueueC634D3F4",
                 "Arn"
               ]
             }
@@ -229,7 +229,7 @@
         },
         "EventSourceArn": {
           "Fn::GetAtt": [
-            "testtestwrappedDynamoDBStreamsToLambdaDynamoTableF4FAE7DB",
+            "testtestWDynamoDBStreamsToLambdaDynamoTable9804CAC7",
             "StreamArn"
           ]
         },
@@ -238,7 +238,7 @@
         "StartingPosition": "TRIM_HORIZON"
       }
     },
-    "testtestwrappedDynamoDBStreamsToLambdaDynamoTableF4FAE7DB": {
+    "testtestWDynamoDBStreamsToLambdaDynamoTable9804CAC7": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
         "KeySchema": [
@@ -267,7 +267,7 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testtestwrappedDynamoDBStreamsToLambdaSqsDlqQueueD06676DD": {
+    "testtestWDynamoDBStreamsToLambdaSqsDlqQueueC634D3F4": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": "alias/aws/sqs"
@@ -275,7 +275,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "testtestwrappedDynamoDBStreamsToLambdaSqsDlqQueuePolicy8E9DDE8A": {
+    "testtestWDynamoDBStreamsToLambdaSqsDlqQueuePolicy523C1EAF": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -311,7 +311,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedDynamoDBStreamsToLambdaSqsDlqQueueD06676DD",
+                  "testtestWDynamoDBStreamsToLambdaSqsDlqQueueC634D3F4",
                   "Arn"
                 ]
               },
@@ -330,7 +330,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedDynamoDBStreamsToLambdaSqsDlqQueueD06676DD",
+                  "testtestWDynamoDBStreamsToLambdaSqsDlqQueueC634D3F4",
                   "Arn"
                 ]
               },
@@ -341,12 +341,12 @@
         },
         "Queues": [
           {
-            "Ref": "testtestwrappedDynamoDBStreamsToLambdaSqsDlqQueueD06676DD"
+            "Ref": "testtestWDynamoDBStreamsToLambdaSqsDlqQueueC634D3F4"
           }
         ]
       }
     },
-    "testtestwrappedLambdaToElasticSearchCognitoUserPool6750FF20": {
+    "testtestWLambdaToElasticSearchCognitoUserPool5E9014B9": {
       "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "AccountRecoverySetting": {
@@ -380,11 +380,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testtestwrappedLambdaToElasticSearchCognitoUserPoolClientF2A9DE1F": {
+    "testtestWLambdaToElasticSearchCognitoUserPoolClientC2F90D5C": {
       "Type": "AWS::Cognito::UserPoolClient",
       "Properties": {
         "UserPoolId": {
-          "Ref": "testtestwrappedLambdaToElasticSearchCognitoUserPool6750FF20"
+          "Ref": "testtestWLambdaToElasticSearchCognitoUserPool5E9014B9"
         },
         "AllowedOAuthFlows": [
           "implicit",
@@ -406,18 +406,18 @@
         ]
       }
     },
-    "testtestwrappedLambdaToElasticSearchCognitoIdentityPoolBBBA5E0F": {
+    "testtestWLambdaToElasticSearchCognitoIdentityPoolEEAE6502": {
       "Type": "AWS::Cognito::IdentityPool",
       "Properties": {
         "AllowUnauthenticatedIdentities": false,
         "CognitoIdentityProviders": [
           {
             "ClientId": {
-              "Ref": "testtestwrappedLambdaToElasticSearchCognitoUserPoolClientF2A9DE1F"
+              "Ref": "testtestWLambdaToElasticSearchCognitoUserPoolClientC2F90D5C"
             },
             "ProviderName": {
               "Fn::GetAtt": [
-                "testtestwrappedLambdaToElasticSearchCognitoUserPool6750FF20",
+                "testtestWLambdaToElasticSearchCognitoUserPool5E9014B9",
                 "ProviderName"
               ]
             },
@@ -426,19 +426,19 @@
         ]
       }
     },
-    "testtestwrappedLambdaToElasticSearchUserPoolDomain0808E3E8": {
+    "testtestWLambdaToElasticSearchUserPoolDomain10FEF9F8": {
       "Type": "AWS::Cognito::UserPoolDomain",
       "Properties": {
         "Domain": "testdomainconstructs",
         "UserPoolId": {
-          "Ref": "testtestwrappedLambdaToElasticSearchCognitoUserPool6750FF20"
+          "Ref": "testtestWLambdaToElasticSearchCognitoUserPool5E9014B9"
         }
       },
       "DependsOn": [
-        "testtestwrappedLambdaToElasticSearchCognitoUserPool6750FF20"
+        "testtestWLambdaToElasticSearchCognitoUserPool5E9014B9"
       ]
     },
-    "testtestwrappedLambdaToElasticSearchCognitoAuthorizedRole19FEDD1D": {
+    "testtestWLambdaToElasticSearchCognitoAuthorizedRole17175485": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -448,7 +448,7 @@
               "Condition": {
                 "StringEquals": {
                   "cognito-identity.amazonaws.com:aud": {
-                    "Ref": "testtestwrappedLambdaToElasticSearchCognitoIdentityPoolBBBA5E0F"
+                    "Ref": "testtestWLambdaToElasticSearchCognitoIdentityPoolEEAE6502"
                   }
                 },
                 "ForAnyValue:StringLike": {
@@ -499,23 +499,23 @@
         ]
       }
     },
-    "testtestwrappedLambdaToElasticSearchIdentityPoolRoleMapping5F7EC18B": {
+    "testtestWLambdaToElasticSearchIdentityPoolRoleMapping397EAC3B": {
       "Type": "AWS::Cognito::IdentityPoolRoleAttachment",
       "Properties": {
         "IdentityPoolId": {
-          "Ref": "testtestwrappedLambdaToElasticSearchCognitoIdentityPoolBBBA5E0F"
+          "Ref": "testtestWLambdaToElasticSearchCognitoIdentityPoolEEAE6502"
         },
         "Roles": {
           "authenticated": {
             "Fn::GetAtt": [
-              "testtestwrappedLambdaToElasticSearchCognitoAuthorizedRole19FEDD1D",
+              "testtestWLambdaToElasticSearchCognitoAuthorizedRole17175485",
               "Arn"
             ]
           }
         }
       }
     },
-    "testtestwrappedLambdaToElasticSearchCognitoKibanaConfigureRole93B20B59": {
+    "testtestWLambdaToElasticSearchCognitoKibanaConfigureRole86FD44DD": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -532,7 +532,7 @@
         }
       }
     },
-    "testtestwrappedLambdaToElasticSearchCognitoKibanaConfigureRolePolicy932C86F3": {
+    "testtestWLambdaToElasticSearchCognitoKibanaConfigureRolePolicy6E3BFFA7": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -556,7 +556,7 @@
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "testtestwrappedLambdaToElasticSearchCognitoUserPool6750FF20",
+                    "testtestWLambdaToElasticSearchCognitoUserPool5E9014B9",
                     "Arn"
                   ]
                 },
@@ -574,7 +574,7 @@
                       },
                       ":identitypool/",
                       {
-                        "Ref": "testtestwrappedLambdaToElasticSearchCognitoIdentityPoolBBBA5E0F"
+                        "Ref": "testtestWLambdaToElasticSearchCognitoIdentityPoolEEAE6502"
                       }
                     ]
                   ]
@@ -607,7 +607,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedLambdaToElasticSearchCognitoKibanaConfigureRole93B20B59",
+                  "testtestWLambdaToElasticSearchCognitoKibanaConfigureRole86FD44DD",
                   "Arn"
                 ]
               }
@@ -615,15 +615,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testtestwrappedLambdaToElasticSearchCognitoKibanaConfigureRolePolicy932C86F3",
+        "PolicyName": "testtestWLambdaToElasticSearchCognitoKibanaConfigureRolePolicy6E3BFFA7",
         "Roles": [
           {
-            "Ref": "testtestwrappedLambdaToElasticSearchCognitoKibanaConfigureRole93B20B59"
+            "Ref": "testtestWLambdaToElasticSearchCognitoKibanaConfigureRole86FD44DD"
           }
         ]
       }
     },
-    "testtestwrappedLambdaToElasticSearchElasticsearchDomain4F3B9456": {
+    "testtestWLambdaToElasticSearchElasticsearchDomain66526D54": {
       "Type": "AWS::Elasticsearch::Domain",
       "Properties": {
         "AccessPolicies": {
@@ -635,13 +635,13 @@
                 "AWS": [
                   {
                     "Fn::GetAtt": [
-                      "testtestwrappedLambdaToElasticSearchCognitoAuthorizedRole19FEDD1D",
+                      "testtestWLambdaToElasticSearchCognitoAuthorizedRole17175485",
                       "Arn"
                     ]
                   },
                   {
                     "Fn::GetAtt": [
-                      "testtestwrappedDynamoDBStreamsToLambdaLambdaFunctionServiceRole8E01C5A6",
+                      "testtestWDynamoDBStreamsToLambdaLambdaFunctionServiceRole8D6AEC0A",
                       "Arn"
                     ]
                   }
@@ -670,16 +670,16 @@
         "CognitoOptions": {
           "Enabled": true,
           "IdentityPoolId": {
-            "Ref": "testtestwrappedLambdaToElasticSearchCognitoIdentityPoolBBBA5E0F"
+            "Ref": "testtestWLambdaToElasticSearchCognitoIdentityPoolEEAE6502"
           },
           "RoleArn": {
             "Fn::GetAtt": [
-              "testtestwrappedLambdaToElasticSearchCognitoKibanaConfigureRole93B20B59",
+              "testtestWLambdaToElasticSearchCognitoKibanaConfigureRole86FD44DD",
               "Arn"
             ]
           },
           "UserPoolId": {
-            "Ref": "testtestwrappedLambdaToElasticSearchCognitoUserPool6750FF20"
+            "Ref": "testtestWLambdaToElasticSearchCognitoUserPool5E9014B9"
           }
         },
         "DomainName": "testdomainconstructs",
@@ -722,7 +722,7 @@
         }
       }
     },
-    "testtestwrappedLambdaToElasticSearchStatusRedAlarm608817FB": {
+    "testtestWLambdaToElasticSearchStatusRedAlarmE6B095FF": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -735,7 +735,7 @@
         "Threshold": 1
       }
     },
-    "testtestwrappedLambdaToElasticSearchStatusYellowAlarmF45341A3": {
+    "testtestWLambdaToElasticSearchStatusYellowAlarm0C999F8F": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -748,7 +748,7 @@
         "Threshold": 1
       }
     },
-    "testtestwrappedLambdaToElasticSearchFreeStorageSpaceTooLowAlarm00EA1A3E": {
+    "testtestWLambdaToElasticSearchFreeStorageSpaceTooLowAlarm109A8033": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "LessThanOrEqualToThreshold",
@@ -761,7 +761,7 @@
         "Threshold": 20000
       }
     },
-    "testtestwrappedLambdaToElasticSearchIndexWritesBlockedTooHighAlarm35863904": {
+    "testtestWLambdaToElasticSearchIndexWritesBlockedTooHighAlarmBD2D206C": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -774,7 +774,7 @@
         "Threshold": 1
       }
     },
-    "testtestwrappedLambdaToElasticSearchAutomatedSnapshotFailureTooHighAlarmB131BD29": {
+    "testtestWLambdaToElasticSearchAutomatedSnapshotFailureTooHighAlarmD905CDF5": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -787,7 +787,7 @@
         "Threshold": 1
       }
     },
-    "testtestwrappedLambdaToElasticSearchCPUUtilizationTooHighAlarm70BA0B9B": {
+    "testtestWLambdaToElasticSearchCPUUtilizationTooHighAlarm729A1FDD": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -800,7 +800,7 @@
         "Threshold": 80
       }
     },
-    "testtestwrappedLambdaToElasticSearchJVMMemoryPressureTooHighAlarmB609AA8D": {
+    "testtestWLambdaToElasticSearchJVMMemoryPressureTooHighAlarm4D78F647": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -813,7 +813,7 @@
         "Threshold": 80
       }
     },
-    "testtestwrappedLambdaToElasticSearchMasterCPUUtilizationTooHighAlarmCC31FDFC": {
+    "testtestWLambdaToElasticSearchMasterCPUUtilizationTooHighAlarmC9825580": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -826,7 +826,7 @@
         "Threshold": 50
       }
     },
-    "testtestwrappedLambdaToElasticSearchMasterJVMMemoryPressureTooHighAlarm0930E4B4": {
+    "testtestWLambdaToElasticSearchMasterJVMMemoryPressureTooHighAlarm18284E37": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
@@ -83,7 +83,7 @@ export class DynamoDBStreamToLambda extends Construct {
   constructor(scope: Construct, id: string, props: DynamoDBStreamToLambdaProps) {
     super(scope, id);
     const convertedProps: DynamoDBStreamToLambdaProps = { ...props };
-    const wrappedConstruct: DynamoDBStreamToLambda = new DynamoDBStreamsToLambda(this, `${id}-wrapped`, convertedProps);
+    const wrappedConstruct: DynamoDBStreamToLambda = new DynamoDBStreamsToLambda(this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;
     this.dynamoTableInterface = wrappedConstruct.dynamoTableInterface;

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
@@ -87,8 +87,8 @@ export class DynamoDBStreamToLambda extends Construct {
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
     // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
-    // will be required.  (eg - new EventbridgeToLambda instead of DynamoDBStreamToLambda)
-    const wrappedConstruct: DynamoDBStreamsToLambda = new DynamoDBStreamsToLambda(this, `${id}W`, convertedProps);
+    // will be required.  (eg - new DynamoDBStreamsToLambda instead of DynamoDBStreamToLambda)
+    const wrappedConstruct: DynamoDBStreamToLambda = new DynamoDBStreamsToLambda(this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;
     this.dynamoTableInterface = wrappedConstruct.dynamoTableInterface;

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
@@ -83,7 +83,12 @@ export class DynamoDBStreamToLambda extends Construct {
   constructor(scope: Construct, id: string, props: DynamoDBStreamToLambdaProps) {
     super(scope, id);
     const convertedProps: DynamoDBStreamToLambdaProps = { ...props };
-    const wrappedConstruct: DynamoDBStreamToLambda = new DynamoDBStreamsToLambda(this, `${id}W`, convertedProps);
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new EventbridgeToLambda instead of DynamoDBStreamToLambda)
+    const wrappedConstruct: DynamoDBStreamsToLambda = new DynamoDBStreamsToLambda(this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;
     this.dynamoTableInterface = wrappedConstruct.dynamoTableInterface;

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/lib/index.ts
@@ -85,7 +85,7 @@ export class DynamoDBStreamToLambda extends Construct {
     const convertedProps: DynamoDBStreamToLambdaProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new EventbridgeToLambda instead of DynamoDBStreamToLambda)
     const wrappedConstruct: DynamoDBStreamsToLambda = new DynamoDBStreamsToLambda(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/__snapshots__/dynamodb-stream-lambda.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/__snapshots__/dynamodb-stream-lambda.test.js.snap
@@ -17,7 +17,7 @@ Object {
     },
   },
   "Resources": Object {
-    "testlambdadynamodbstacktestlambdadynamodbstackwrappedDynamoTable93A88343": Object {
+    "testlambdadynamodbstacktestlambdadynamodbstackWDynamoTableA36F83E4": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "AttributeDefinitions": Array [
@@ -46,10 +46,10 @@ Object {
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
     },
-    "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunction3A45417B": Object {
+    "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionB74B248B": Object {
       "DependsOn": Array [
-        "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionServiceRoleDefaultPolicyAE179EDE",
-        "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionServiceRole0A19125C",
+        "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionServiceRoleDefaultPolicyF4C9216A",
+        "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionServiceRoleD33A4DB6",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -116,7 +116,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionServiceRole0A19125C",
+            "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionServiceRoleD33A4DB6",
             "Arn",
           ],
         },
@@ -127,7 +127,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionDynamoDBEventSourcetestlambdadynamodbstacktestlambdadynamodbstackwrappedDynamoTable0CA0B4D9170871E7": Object {
+    "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionDynamoDBEventSourcetestlambdadynamodbstacktestlambdadynamodbstackWDynamoTable613AF80451DF30E5": Object {
       "Properties": Object {
         "BatchSize": 100,
         "BisectBatchOnFunctionError": true,
@@ -135,7 +135,7 @@ Object {
           "OnFailure": Object {
             "Destination": Object {
               "Fn::GetAtt": Array [
-                "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7",
+                "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500",
                 "Arn",
               ],
             },
@@ -143,12 +143,12 @@ Object {
         },
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
-            "testlambdadynamodbstacktestlambdadynamodbstackwrappedDynamoTable93A88343",
+            "testlambdadynamodbstacktestlambdadynamodbstackWDynamoTableA36F83E4",
             "StreamArn",
           ],
         },
         "FunctionName": Object {
-          "Ref": "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunction3A45417B",
+          "Ref": "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionB74B248B",
         },
         "MaximumRecordAgeInSeconds": 86400,
         "MaximumRetryAttempts": 500,
@@ -156,7 +156,7 @@ Object {
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionServiceRole0A19125C": Object {
+    "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionServiceRoleD33A4DB6": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -211,7 +211,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionServiceRoleDefaultPolicyAE179EDE": Object {
+    "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionServiceRoleDefaultPolicyF4C9216A": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -247,7 +247,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testlambdadynamodbstacktestlambdadynamodbstackwrappedDynamoTable93A88343",
+                  "testlambdadynamodbstacktestlambdadynamodbstackWDynamoTableA36F83E4",
                   "StreamArn",
                 ],
               },
@@ -261,7 +261,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7",
+                  "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500",
                   "Arn",
                 ],
               },
@@ -269,16 +269,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionServiceRoleDefaultPolicyAE179EDE",
+        "PolicyName": "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionServiceRoleDefaultPolicyF4C9216A",
         "Roles": Array [
           Object {
-            "Ref": "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunctionServiceRole0A19125C",
+            "Ref": "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionServiceRoleD33A4DB6",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7": Object {
+    "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": "alias/aws/sqs",
@@ -286,7 +286,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueuePolicyDBA29802": Object {
+    "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueuePolicy5666EFE7": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -321,7 +321,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7",
+                  "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500",
                   "Arn",
                 ],
               },
@@ -340,7 +340,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7",
+                  "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500",
                   "Arn",
                 ],
               },
@@ -351,7 +351,7 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7",
+            "Ref": "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/dynamodb-stream-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/dynamodb-stream-lambda.test.ts
@@ -43,12 +43,12 @@ test('check lambda EventSourceMapping', () => {
   expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
     EventSourceArn: {
       "Fn::GetAtt": [
-        "testlambdadynamodbstacktestlambdadynamodbstackwrappedDynamoTable93A88343",
+        "testlambdadynamodbstacktestlambdadynamodbstackWDynamoTableA36F83E4",
         "StreamArn"
       ]
     },
     FunctionName: {
-      Ref: "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunction3A45417B"
+      Ref: "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionB74B248B"
     },
     BatchSize: 100,
     StartingPosition: "TRIM_HORIZON",
@@ -77,12 +77,12 @@ test('check DynamoEventSourceProps override', () => {
   expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
     EventSourceArn: {
       "Fn::GetAtt": [
-        "testlambdadynamodbstacktestlambdadynamodbstackwrappedDynamoTable93A88343",
+        "testlambdadynamodbstacktestlambdadynamodbstackWDynamoTableA36F83E4",
         "StreamArn"
       ]
     },
     FunctionName: {
-      Ref: "testlambdadynamodbstacktestlambdadynamodbstackwrappedLambdaFunction3A45417B"
+      Ref: "testlambdadynamodbstacktestlambdadynamodbstackWLambdaFunctionB74B248B"
     },
     BatchSize: 55,
     StartingPosition: "LATEST"
@@ -118,7 +118,7 @@ test('check lambda permission to read dynamodb stream', () => {
           Effect: "Allow",
           Resource: {
             "Fn::GetAtt": [
-              "testlambdadynamodbstacktestlambdadynamodbstackwrappedDynamoTable93A88343",
+              "testlambdadynamodbstacktestlambdadynamodbstackWDynamoTableA36F83E4",
               "StreamArn"
             ]
           }
@@ -132,7 +132,7 @@ test('check lambda permission to read dynamodb stream', () => {
           Effect: "Allow",
           Resource: {
             "Fn::GetAtt": [
-              "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7",
+              "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500",
               "Arn"
             ]
           }
@@ -286,7 +286,7 @@ test('check dynamodb table stream override with ITable', () => {
           Effect: "Allow",
           Resource: {
             "Fn::GetAtt": [
-              "testlambdadynamodbstacktestlambdadynamodbstackwrappedSqsDlqQueue391BFBC7",
+              "testlambdadynamodbstacktestlambdadynamodbstackWSqsDlqQueueEABCC500",
               "Arn"
             ]
           }

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.existing-table.expected.json
@@ -29,7 +29,7 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -84,7 +84,7 @@
         ]
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDefaultPolicy29F7C03C": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleDefaultPolicy5313D05B": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -125,7 +125,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                  "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                   "Arn"
                 ]
               }
@@ -133,10 +133,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDefaultPolicy29F7C03C",
+        "PolicyName": "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleDefaultPolicy5313D05B",
         "Roles": [
           {
-            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8"
+            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516"
           }
         ]
       },
@@ -151,7 +151,7 @@
         }
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunction791A020D": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunction8F8F40D1": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -194,7 +194,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8",
+            "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516",
             "Arn"
           ]
         },
@@ -210,8 +210,8 @@
         }
       },
       "DependsOn": [
-        "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDefaultPolicy29F7C03C",
-        "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8"
+        "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleDefaultPolicy5313D05B",
+        "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -232,11 +232,11 @@
         }
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionDynamoDBEventSourceexistingtablemytable8CDC34525AEA074F": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionDynamoDBEventSourceexistingtablemytable8CDC3452C2755EF6": {
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "FunctionName": {
-          "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunction791A020D"
+          "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunction8F8F40D1"
         },
         "BatchSize": 100,
         "BisectBatchOnFunctionError": true,
@@ -244,7 +244,7 @@
           "OnFailure": {
             "Destination": {
               "Fn::GetAtt": [
-                "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                 "Arn"
               ]
             }
@@ -261,7 +261,7 @@
         "StartingPosition": "TRIM_HORIZON"
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": "alias/aws/sqs"
@@ -269,7 +269,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueuePolicy4A3A8225": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueuePolicy6200BA59": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -305,7 +305,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                  "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                   "Arn"
                 ]
               },
@@ -324,7 +324,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                  "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                   "Arn"
                 ]
               },
@@ -335,7 +335,7 @@
         },
         "Queues": [
           {
-            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653"
+            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A"
           }
         ]
       }

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/test/integ.no-arguments.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -55,7 +55,7 @@
         ]
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDefaultPolicy29F7C03C": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleDefaultPolicy5313D05B": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -82,7 +82,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedDynamoTable79768550",
+                  "testdynamodbstreamlambdatestdynamodbstreamlambdaWDynamoTable31B87C4E",
                   "StreamArn"
                 ]
               }
@@ -96,7 +96,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                  "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                   "Arn"
                 ]
               }
@@ -104,10 +104,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDefaultPolicy29F7C03C",
+        "PolicyName": "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleDefaultPolicy5313D05B",
         "Roles": [
           {
-            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8"
+            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516"
           }
         ]
       },
@@ -122,7 +122,7 @@
         }
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunction791A020D": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunction8F8F40D1": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -165,7 +165,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8",
+            "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516",
             "Arn"
           ]
         },
@@ -181,8 +181,8 @@
         }
       },
       "DependsOn": [
-        "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDefaultPolicy29F7C03C",
-        "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionServiceRoleDDCFD0C8"
+        "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleDefaultPolicy5313D05B",
+        "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionServiceRoleB070F516"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -203,11 +203,11 @@
         }
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunctionDynamoDBEventSourcenoargumentstestdynamodbstreamlambdatestdynamodbstreamlambdawrappedDynamoTableCADBA6654B02FB6D": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunctionDynamoDBEventSourcenoargumentstestdynamodbstreamlambdatestdynamodbstreamlambdaWDynamoTableCCCB3D4A68E403D3": {
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "FunctionName": {
-          "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedLambdaFunction791A020D"
+          "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdaWLambdaFunction8F8F40D1"
         },
         "BatchSize": 100,
         "BisectBatchOnFunctionError": true,
@@ -215,7 +215,7 @@
           "OnFailure": {
             "Destination": {
               "Fn::GetAtt": [
-                "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                 "Arn"
               ]
             }
@@ -223,7 +223,7 @@
         },
         "EventSourceArn": {
           "Fn::GetAtt": [
-            "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedDynamoTable79768550",
+            "testdynamodbstreamlambdatestdynamodbstreamlambdaWDynamoTable31B87C4E",
             "StreamArn"
           ]
         },
@@ -232,7 +232,7 @@
         "StartingPosition": "TRIM_HORIZON"
       }
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedDynamoTable79768550": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWDynamoTable31B87C4E": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
         "KeySchema": [
@@ -261,7 +261,7 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": "alias/aws/sqs"
@@ -269,7 +269,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueuePolicy4A3A8225": {
+    "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueuePolicy6200BA59": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -305,7 +305,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                  "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                   "Arn"
                 ]
               },
@@ -324,7 +324,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653",
+                  "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A",
                   "Arn"
                 ]
               },
@@ -335,7 +335,7 @@
         },
         "Queues": [
           {
-            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdawrappedSqsDlqQueue1DFD3653"
+            "Ref": "testdynamodbstreamlambdatestdynamodbstreamlambdaWSqsDlqQueueC4CD9C0A"
           }
         ]
       }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
@@ -88,7 +88,7 @@ export class EventsRuleToKinesisFirehoseToS3 extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToKinesisFirehoseToS3Props) {
     super(scope, id);
     const convertedProps: EventsRuleToKinesisFirehoseToS3Props = { ...props };
-    const wrappedConstruct: EventsRuleToKinesisFirehoseToS3 = new EventbridgeToKinesisFirehoseToS3(this, `${id}-wrapped`, convertedProps);
+    const wrappedConstruct: EventsRuleToKinesisFirehoseToS3 = new EventbridgeToKinesisFirehoseToS3(this, `${id}W`, convertedProps);
     this.eventsRule = wrappedConstruct.eventsRule;
     this.eventsRole = wrappedConstruct.eventsRole;
     this.kinesisFirehose = wrappedConstruct.kinesisFirehose;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
@@ -90,7 +90,7 @@ export class EventsRuleToKinesisFirehoseToS3 extends Construct {
     const convertedProps: EventsRuleToKinesisFirehoseToS3Props = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new EventbridgeToKinesisFirehoseToS3 instead of EventsRuleToKinesisFirehoseToS3)
     const wrappedConstruct: EventsRuleToKinesisFirehoseToS3 = new EventbridgeToKinesisFirehoseToS3(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/lib/index.ts
@@ -88,6 +88,11 @@ export class EventsRuleToKinesisFirehoseToS3 extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToKinesisFirehoseToS3Props) {
     super(scope, id);
     const convertedProps: EventsRuleToKinesisFirehoseToS3Props = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new EventbridgeToKinesisFirehoseToS3 instead of EventsRuleToKinesisFirehoseToS3)
     const wrappedConstruct: EventsRuleToKinesisFirehoseToS3 = new EventbridgeToKinesisFirehoseToS3(this, `${id}W`, convertedProps);
     this.eventsRule = wrappedConstruct.eventsRule;
     this.eventsRole = wrappedConstruct.eventsRole;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/__snapshots__/events-rule-kinesisfirehose-s3.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/__snapshots__/events-rule-kinesisfirehose-s3.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Test snapshot match with default parameters 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedEventsRule701EAD4B": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWEventsRule231C9A1C": Object {
       "Properties": Object {
         "Description": "event rule props",
         "ScheduleExpression": "rate(5 minutes)",
@@ -12,14 +12,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehose975E4A25",
+                "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehoseE1E70A8A",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedEventsRuleInvokeKinesisFirehoseRoleBDFA598C",
+                "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWEventsRuleInvokeKinesisFirehoseRole31E4422A",
                 "Arn",
               ],
             },
@@ -28,7 +28,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedEventsRuleInvokeKinesisFirehosePolicyA352A040": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWEventsRuleInvokeKinesisFirehosePolicy0A5464DF": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -40,7 +40,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehose975E4A25",
+                  "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehoseE1E70A8A",
                   "Arn",
                 ],
               },
@@ -48,16 +48,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "sfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedEventsRuleInvokeKinesisFirehosePolicyA352A040",
+        "PolicyName": "kinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWEventsRuleInvokeKinesisFirehosePolicy0A5464DF",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedEventsRuleInvokeKinesisFirehoseRoleBDFA598C",
+            "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWEventsRuleInvokeKinesisFirehoseRole31E4422A",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedEventsRuleInvokeKinesisFirehoseRoleBDFA598C": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWEventsRuleInvokeKinesisFirehoseRole31E4422A": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -75,7 +75,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehose975E4A25": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehoseE1E70A8A": Object {
       "Properties": Object {
         "DeliveryStreamEncryptionConfigurationInput": Object {
           "KeyType": "AWS_OWNED_CMK",
@@ -83,7 +83,7 @@ Object {
         "ExtendedS3DestinationConfiguration": Object {
           "BucketARN": Object {
             "Fn::GetAtt": Array [
-              "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketAB5E6153",
+              "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3Bucket84D286D2",
               "Arn",
             ],
           },
@@ -94,10 +94,10 @@ Object {
           "CloudWatchLoggingOptions": Object {
             "Enabled": true,
             "LogGroupName": Object {
-              "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3firehoseloggroupA40A0981",
+              "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3firehoseloggroupEFEFBB43",
             },
             "LogStreamName": Object {
-              "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream18CEFFB7",
+              "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3firehoseloggroupfirehoselogstream7EEC31E1",
             },
           },
           "CompressionFormat": "GZIP",
@@ -127,7 +127,7 @@ Object {
           },
           "RoleARN": Object {
             "Fn::GetAtt": Array [
-              "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehoseRole5731BDE4",
+              "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehoseRole7BCEFD7F",
               "Arn",
             ],
           },
@@ -135,7 +135,7 @@ Object {
       },
       "Type": "AWS::KinesisFirehose::DeliveryStream",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehosePolicy44E1B846": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehosePolicy59C959E0": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -152,7 +152,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketAB5E6153",
+                    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3Bucket84D286D2",
                     "Arn",
                   ],
                 },
@@ -162,7 +162,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketAB5E6153",
+                          "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3Bucket84D286D2",
                           "Arn",
                         ],
                       },
@@ -193,11 +193,11 @@ Object {
                     },
                     ":log-group:",
                     Object {
-                      "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3firehoseloggroupA40A0981",
+                      "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3firehoseloggroupEFEFBB43",
                     },
                     ":log-stream:",
                     Object {
-                      "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream18CEFFB7",
+                      "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3firehoseloggroupfirehoselogstream7EEC31E1",
                     },
                   ],
                 ],
@@ -206,16 +206,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "rehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehosePolicy44E1B846",
+        "PolicyName": "esisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehosePolicy59C959E0",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehoseRole5731BDE4",
+            "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehoseRole7BCEFD7F",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3KinesisFirehoseRole5731BDE4": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3KinesisFirehoseRole7BCEFD7F": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -232,7 +232,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketAB5E6153": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3Bucket84D286D2": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketEncryption": Object {
@@ -259,7 +259,7 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket4A633461",
+            "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3LoggingBucket598555FD",
           },
         },
         "PublicAccessBlockConfiguration": Object {
@@ -275,10 +275,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketPolicy7F2323E5": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3BucketPolicyA1D61C49": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketAB5E6153",
+          "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3Bucket84D286D2",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -300,7 +300,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketAB5E6153",
+                          "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3Bucket84D286D2",
                           "Arn",
                         ],
                       },
@@ -310,7 +310,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3BucketAB5E6153",
+                    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3Bucket84D286D2",
                     "Arn",
                   ],
                 },
@@ -323,7 +323,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket4A633461": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3LoggingBucket598555FD": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -359,10 +359,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3LoggingBucketPolicy4BFA94A9": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3LoggingBucketPolicyBBDC87C8": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket4A633461",
+          "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3LoggingBucket598555FD",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -384,7 +384,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket4A633461",
+                          "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3LoggingBucket598555FD",
                           "Arn",
                         ],
                       },
@@ -394,7 +394,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket4A633461",
+                    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3S3LoggingBucket598555FD",
                     "Arn",
                   ],
                 },
@@ -407,7 +407,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3firehoseloggroupA40A0981": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3firehoseloggroupEFEFBB43": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -426,11 +426,11 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream18CEFFB7": Object {
+    "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3firehoseloggroupfirehoselogstream7EEC31E1": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "LogGroupName": Object {
-          "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparameterswrappedKinesisFirehoseToS3firehoseloggroupA40A0981",
+          "Ref": "testeventsrulekinesisfirehoses3defaultparameterstesteventsrulekinesisfirehoses3defaultparametersWKinesisFirehoseToS3firehoseloggroupEFEFBB43",
         },
       },
       "Type": "AWS::Logs::LogStream",
@@ -443,16 +443,16 @@ Object {
 exports[`check eventbus property, snapshot & eventbus exists 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedCustomEventBusA38E34FB": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWCustomEventBusDC0B1528": Object {
       "Properties": Object {
-        "Name": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedCustomEventBusC8B80FA8",
+        "Name": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWCustomEventBus733832E5",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedEventsRule73C81E12": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWEventsRule6405B59E": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedCustomEventBusA38E34FB",
+          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWCustomEventBusDC0B1528",
         },
         "EventPattern": Object {
           "source": Array [
@@ -464,14 +464,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehose73F7BDDF",
+                "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehose359E5CB2",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedEventsRuleInvokeKinesisFirehoseRole459438BC",
+                "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWEventsRuleInvokeKinesisFirehoseRole4A78641F",
                 "Arn",
               ],
             },
@@ -480,7 +480,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedEventsRuleInvokeKinesisFirehosePolicyA2B37AD5": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWEventsRuleInvokeKinesisFirehosePolicyED42C0A7": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -492,7 +492,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehose73F7BDDF",
+                  "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehose359E5CB2",
                   "Arn",
                 ],
               },
@@ -500,16 +500,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "nesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedEventsRuleInvokeKinesisFirehosePolicyA2B37AD5",
+        "PolicyName": "rulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWEventsRuleInvokeKinesisFirehosePolicyED42C0A7",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedEventsRuleInvokeKinesisFirehoseRole459438BC",
+            "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWEventsRuleInvokeKinesisFirehoseRole4A78641F",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedEventsRuleInvokeKinesisFirehoseRole459438BC": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWEventsRuleInvokeKinesisFirehoseRole4A78641F": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -527,7 +527,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehose73F7BDDF": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehose359E5CB2": Object {
       "Properties": Object {
         "DeliveryStreamEncryptionConfigurationInput": Object {
           "KeyType": "AWS_OWNED_CMK",
@@ -535,7 +535,7 @@ Object {
         "ExtendedS3DestinationConfiguration": Object {
           "BucketARN": Object {
             "Fn::GetAtt": Array [
-              "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3Bucket31AB8440",
+              "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3Bucket23F44FFE",
               "Arn",
             ],
           },
@@ -546,10 +546,10 @@ Object {
           "CloudWatchLoggingOptions": Object {
             "Enabled": true,
             "LogGroupName": Object {
-              "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3firehoseloggroup16F2CCA8",
+              "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3firehoseloggroup714598F2",
             },
             "LogStreamName": Object {
-              "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamE1259129",
+              "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3firehoseloggroupfirehoselogstream42B0168A",
             },
           },
           "CompressionFormat": "GZIP",
@@ -579,7 +579,7 @@ Object {
           },
           "RoleARN": Object {
             "Fn::GetAtt": Array [
-              "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehoseRole09FB29ED",
+              "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehoseRole03B14AF1",
               "Arn",
             ],
           },
@@ -587,7 +587,7 @@ Object {
       },
       "Type": "AWS::KinesisFirehose::DeliveryStream",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehosePolicyAEAF4F55": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehosePolicy01068871": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -604,7 +604,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3Bucket31AB8440",
+                    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3Bucket23F44FFE",
                     "Arn",
                   ],
                 },
@@ -614,7 +614,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3Bucket31AB8440",
+                          "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3Bucket23F44FFE",
                           "Arn",
                         ],
                       },
@@ -645,11 +645,11 @@ Object {
                     },
                     ":log-group:",
                     Object {
-                      "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3firehoseloggroup16F2CCA8",
+                      "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3firehoseloggroup714598F2",
                     },
                     ":log-stream:",
                     Object {
-                      "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamE1259129",
+                      "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3firehoseloggroupfirehoselogstream42B0168A",
                     },
                   ],
                 ],
@@ -658,16 +658,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "isfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehosePolicyAEAF4F55",
+        "PolicyName": "ekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehosePolicy01068871",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehoseRole09FB29ED",
+            "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehoseRole03B14AF1",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3KinesisFirehoseRole09FB29ED": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3KinesisFirehoseRole03B14AF1": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -684,7 +684,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3Bucket31AB8440": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3Bucket23F44FFE": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketEncryption": Object {
@@ -711,7 +711,7 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket537E041B",
+            "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3LoggingBucketA996F4EA",
           },
         },
         "PublicAccessBlockConfiguration": Object {
@@ -727,10 +727,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3BucketPolicyCE4D59C9": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3BucketPolicy42227E47": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3Bucket31AB8440",
+          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3Bucket23F44FFE",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -752,7 +752,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3Bucket31AB8440",
+                          "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3Bucket23F44FFE",
                           "Arn",
                         ],
                       },
@@ -762,7 +762,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3Bucket31AB8440",
+                    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3Bucket23F44FFE",
                     "Arn",
                   ],
                 },
@@ -775,7 +775,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket537E041B": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3LoggingBucketA996F4EA": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -811,10 +811,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3LoggingBucketPolicy7B87A085": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3LoggingBucketPolicyAE23D8B9": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket537E041B",
+          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3LoggingBucketA996F4EA",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -836,7 +836,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket537E041B",
+                          "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3LoggingBucketA996F4EA",
                           "Arn",
                         ],
                       },
@@ -846,7 +846,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3S3LoggingBucket537E041B",
+                    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3S3LoggingBucketA996F4EA",
                     "Arn",
                   ],
                 },
@@ -859,7 +859,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3firehoseloggroup16F2CCA8": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3firehoseloggroup714598F2": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -878,11 +878,11 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamE1259129": Object {
+    "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3firehoseloggroupfirehoselogstream42B0168A": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "LogGroupName": Object {
-          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparameterswrappedKinesisFirehoseToS3firehoseloggroup16F2CCA8",
+          "Ref": "testeventsrulekinesisfirehosedefaultparameterstesteventsrulekinesisfirehosedefaultparametersWKinesisFirehoseToS3firehoseloggroup714598F2",
         },
       },
       "Type": "AWS::Logs::LogStream",
@@ -895,16 +895,16 @@ Object {
 exports[`check multiple constructs in a single stack 1`] = `
 Object {
   "Resources": Object {
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedCustomEventBus05E5B70C": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WCustomEventBus5B5E4452": Object {
       "Properties": Object {
-        "Name": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedCustomEventBus79EA412E",
+        "Name": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WCustomEventBus4EEAAC29",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedEventsRuleFBD4B61F": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WEventsRuleE79A7687": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedCustomEventBus05E5B70C",
+          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WCustomEventBus5B5E4452",
         },
         "EventPattern": Object {
           "source": Array [
@@ -916,14 +916,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehose7C071B84",
+                "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehoseA95F57ED",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedEventsRuleInvokeKinesisFirehoseRole8B96F55E",
+                "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WEventsRuleInvokeKinesisFirehoseRole2D9787E0",
                 "Arn",
               ],
             },
@@ -932,7 +932,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedEventsRuleInvokeKinesisFirehosePolicyB1BC496D": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WEventsRuleInvokeKinesisFirehosePolicy70C58056": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -944,7 +944,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehose7C071B84",
+                  "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehoseA95F57ED",
                   "Arn",
                 ],
               },
@@ -952,16 +952,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedEventsRuleInvokeKinesisFirehosePolicyB1BC496D",
+        "PolicyName": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WEventsRuleInvokeKinesisFirehosePolicy70C58056",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedEventsRuleInvokeKinesisFirehoseRole8B96F55E",
+            "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WEventsRuleInvokeKinesisFirehoseRole2D9787E0",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedEventsRuleInvokeKinesisFirehoseRole8B96F55E": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WEventsRuleInvokeKinesisFirehoseRole2D9787E0": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -979,7 +979,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehose7C071B84": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehoseA95F57ED": Object {
       "Properties": Object {
         "DeliveryStreamEncryptionConfigurationInput": Object {
           "KeyType": "AWS_OWNED_CMK",
@@ -987,7 +987,7 @@ Object {
         "ExtendedS3DestinationConfiguration": Object {
           "BucketARN": Object {
             "Fn::GetAtt": Array [
-              "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3Bucket45031F9A",
+              "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3Bucket53A32F6A",
               "Arn",
             ],
           },
@@ -998,10 +998,10 @@ Object {
           "CloudWatchLoggingOptions": Object {
             "Enabled": true,
             "LogGroupName": Object {
-              "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3firehoseloggroupFFE7CB51",
+              "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3firehoseloggroupB080DEC3",
             },
             "LogStreamName": Object {
-              "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamDB33CB9C",
+              "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3firehoseloggroupfirehoselogstream42131EDC",
             },
           },
           "CompressionFormat": "GZIP",
@@ -1031,7 +1031,7 @@ Object {
           },
           "RoleARN": Object {
             "Fn::GetAtt": Array [
-              "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehoseRoleBFF6284D",
+              "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehoseRole48DDB6F3",
               "Arn",
             ],
           },
@@ -1039,7 +1039,7 @@ Object {
       },
       "Type": "AWS::KinesisFirehose::DeliveryStream",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehosePolicy39C46C2D": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehosePolicy0520BA1E": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1056,7 +1056,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3Bucket45031F9A",
+                    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3Bucket53A32F6A",
                     "Arn",
                   ],
                 },
@@ -1066,7 +1066,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3Bucket45031F9A",
+                          "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3Bucket53A32F6A",
                           "Arn",
                         ],
                       },
@@ -1097,11 +1097,11 @@ Object {
                     },
                     ":log-group:",
                     Object {
-                      "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3firehoseloggroupFFE7CB51",
+                      "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3firehoseloggroupB080DEC3",
                     },
                     ":log-stream:",
                     Object {
-                      "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamDB33CB9C",
+                      "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3firehoseloggroupfirehoselogstream42131EDC",
                     },
                   ],
                 ],
@@ -1110,16 +1110,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehosePolicy39C46C2D",
+        "PolicyName": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehosePolicy0520BA1E",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehoseRoleBFF6284D",
+            "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehoseRole48DDB6F3",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3KinesisFirehoseRoleBFF6284D": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3KinesisFirehoseRole48DDB6F3": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1136,7 +1136,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3Bucket45031F9A": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3Bucket53A32F6A": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketEncryption": Object {
@@ -1163,7 +1163,7 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3LoggingBucketF94908EE",
+            "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3LoggingBucket95C77672",
           },
         },
         "PublicAccessBlockConfiguration": Object {
@@ -1179,10 +1179,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3BucketPolicyDF067464": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3BucketPolicy9DCFF8E9": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3Bucket45031F9A",
+          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3Bucket53A32F6A",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1204,7 +1204,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3Bucket45031F9A",
+                          "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3Bucket53A32F6A",
                           "Arn",
                         ],
                       },
@@ -1214,7 +1214,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3Bucket45031F9A",
+                    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3Bucket53A32F6A",
                     "Arn",
                   ],
                 },
@@ -1227,7 +1227,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3LoggingBucketF94908EE": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3LoggingBucket95C77672": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -1263,10 +1263,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3LoggingBucketPolicy3A1EA0F1": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3LoggingBucketPolicy36080103": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3LoggingBucketF94908EE",
+          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3LoggingBucket95C77672",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1288,7 +1288,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3LoggingBucketF94908EE",
+                          "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3LoggingBucket95C77672",
                           "Arn",
                         ],
                       },
@@ -1298,7 +1298,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3S3LoggingBucketF94908EE",
+                    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3S3LoggingBucket95C77672",
                     "Arn",
                   ],
                 },
@@ -1311,7 +1311,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3firehoseloggroupFFE7CB51": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3firehoseloggroupB080DEC3": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -1330,26 +1330,26 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamDB33CB9C": Object {
+    "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3firehoseloggroupfirehoselogstream42131EDC": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "LogGroupName": Object {
-          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1wrappedKinesisFirehoseToS3firehoseloggroupFFE7CB51",
+          "Ref": "testneweventsrulekinesisfirehose1testneweventsrulekinesisfirehose1WKinesisFirehoseToS3firehoseloggroupB080DEC3",
         },
       },
       "Type": "AWS::Logs::LogStream",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedCustomEventBus07CCC64F": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WCustomEventBusC5F2EC35": Object {
       "Properties": Object {
-        "Name": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedCustomEventBus855E1D7A",
+        "Name": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WCustomEventBus874FF828",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedEventsRule9B97B75A": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WEventsRuleD8710394": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedCustomEventBus07CCC64F",
+          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WCustomEventBusC5F2EC35",
         },
         "EventPattern": Object {
           "source": Array [
@@ -1361,14 +1361,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehoseE2AFA304",
+                "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehoseA7686855",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedEventsRuleInvokeKinesisFirehoseRole319E8861",
+                "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WEventsRuleInvokeKinesisFirehoseRoleEB85507E",
                 "Arn",
               ],
             },
@@ -1377,7 +1377,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedEventsRuleInvokeKinesisFirehosePolicyEF8DFDF1": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WEventsRuleInvokeKinesisFirehosePolicyB19D8441": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1389,7 +1389,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehoseE2AFA304",
+                  "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehoseA7686855",
                   "Arn",
                 ],
               },
@@ -1397,16 +1397,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedEventsRuleInvokeKinesisFirehosePolicyEF8DFDF1",
+        "PolicyName": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WEventsRuleInvokeKinesisFirehosePolicyB19D8441",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedEventsRuleInvokeKinesisFirehoseRole319E8861",
+            "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WEventsRuleInvokeKinesisFirehoseRoleEB85507E",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedEventsRuleInvokeKinesisFirehoseRole319E8861": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WEventsRuleInvokeKinesisFirehoseRoleEB85507E": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1424,7 +1424,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehoseE2AFA304": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehoseA7686855": Object {
       "Properties": Object {
         "DeliveryStreamEncryptionConfigurationInput": Object {
           "KeyType": "AWS_OWNED_CMK",
@@ -1432,7 +1432,7 @@ Object {
         "ExtendedS3DestinationConfiguration": Object {
           "BucketARN": Object {
             "Fn::GetAtt": Array [
-              "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3Bucket5B431DE8",
+              "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3Bucket01018DDF",
               "Arn",
             ],
           },
@@ -1443,10 +1443,10 @@ Object {
           "CloudWatchLoggingOptions": Object {
             "Enabled": true,
             "LogGroupName": Object {
-              "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3firehoseloggroup389CF763",
+              "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3firehoseloggroupA88358AB",
             },
             "LogStreamName": Object {
-              "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamCB52E2C0",
+              "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3firehoseloggroupfirehoselogstreamA84741AB",
             },
           },
           "CompressionFormat": "GZIP",
@@ -1476,7 +1476,7 @@ Object {
           },
           "RoleARN": Object {
             "Fn::GetAtt": Array [
-              "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehoseRoleBB2827FF",
+              "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehoseRoleEA8A162C",
               "Arn",
             ],
           },
@@ -1484,7 +1484,7 @@ Object {
       },
       "Type": "AWS::KinesisFirehose::DeliveryStream",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehosePolicy3E91A1BC": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehosePolicy8BF521E7": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1501,7 +1501,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3Bucket5B431DE8",
+                    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3Bucket01018DDF",
                     "Arn",
                   ],
                 },
@@ -1511,7 +1511,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3Bucket5B431DE8",
+                          "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3Bucket01018DDF",
                           "Arn",
                         ],
                       },
@@ -1542,11 +1542,11 @@ Object {
                     },
                     ":log-group:",
                     Object {
-                      "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3firehoseloggroup389CF763",
+                      "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3firehoseloggroupA88358AB",
                     },
                     ":log-stream:",
                     Object {
-                      "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamCB52E2C0",
+                      "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3firehoseloggroupfirehoselogstreamA84741AB",
                     },
                   ],
                 ],
@@ -1555,16 +1555,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehosePolicy3E91A1BC",
+        "PolicyName": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehosePolicy8BF521E7",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehoseRoleBB2827FF",
+            "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehoseRoleEA8A162C",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3KinesisFirehoseRoleBB2827FF": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3KinesisFirehoseRoleEA8A162C": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1581,7 +1581,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3Bucket5B431DE8": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3Bucket01018DDF": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketEncryption": Object {
@@ -1608,7 +1608,7 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3LoggingBucket512134B0",
+            "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3LoggingBucket1125F06F",
           },
         },
         "PublicAccessBlockConfiguration": Object {
@@ -1624,10 +1624,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3BucketPolicy383FFA3C": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3BucketPolicy68147434": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3Bucket5B431DE8",
+          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3Bucket01018DDF",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1649,7 +1649,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3Bucket5B431DE8",
+                          "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3Bucket01018DDF",
                           "Arn",
                         ],
                       },
@@ -1659,7 +1659,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3Bucket5B431DE8",
+                    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3Bucket01018DDF",
                     "Arn",
                   ],
                 },
@@ -1672,7 +1672,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3LoggingBucket512134B0": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3LoggingBucket1125F06F": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -1708,10 +1708,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3LoggingBucketPolicyCD9F4F5A": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3LoggingBucketPolicyA4163089": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3LoggingBucket512134B0",
+          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3LoggingBucket1125F06F",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1733,7 +1733,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3LoggingBucket512134B0",
+                          "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3LoggingBucket1125F06F",
                           "Arn",
                         ],
                       },
@@ -1743,7 +1743,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3S3LoggingBucket512134B0",
+                    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3S3LoggingBucket1125F06F",
                     "Arn",
                   ],
                 },
@@ -1756,7 +1756,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3firehoseloggroup389CF763": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3firehoseloggroupA88358AB": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -1775,11 +1775,11 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamCB52E2C0": Object {
+    "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3firehoseloggroupfirehoselogstreamA84741AB": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "LogGroupName": Object {
-          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2wrappedKinesisFirehoseToS3firehoseloggroup389CF763",
+          "Ref": "testneweventsrulekinesisfirehose2testneweventsrulekinesisfirehose2WKinesisFirehoseToS3firehoseloggroupA88358AB",
         },
       },
       "Type": "AWS::Logs::LogStream",
@@ -1798,7 +1798,7 @@ Object {
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedEventsRule564D171F": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWEventsRule199C6397": Object {
       "Properties": Object {
         "EventBusName": Object {
           "Ref": "testexistingeventbusC6E4A2D0",
@@ -1813,14 +1813,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehose23BADD4C",
+                "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehose5BD3CDC8",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedEventsRuleInvokeKinesisFirehoseRole5DF44DBF",
+                "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWEventsRuleInvokeKinesisFirehoseRole6538EF44",
                 "Arn",
               ],
             },
@@ -1829,7 +1829,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedEventsRuleInvokeKinesisFirehosePolicy9375C2D9": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWEventsRuleInvokeKinesisFirehosePolicy72F0E72E": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1841,7 +1841,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehose23BADD4C",
+                  "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehose5BD3CDC8",
                   "Arn",
                 ],
               },
@@ -1849,16 +1849,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedEventsRuleInvokeKinesisFirehosePolicy9375C2D9",
+        "PolicyName": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWEventsRuleInvokeKinesisFirehosePolicy72F0E72E",
         "Roles": Array [
           Object {
-            "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedEventsRuleInvokeKinesisFirehoseRole5DF44DBF",
+            "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWEventsRuleInvokeKinesisFirehoseRole6538EF44",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedEventsRuleInvokeKinesisFirehoseRole5DF44DBF": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWEventsRuleInvokeKinesisFirehoseRole6538EF44": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1876,7 +1876,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehose23BADD4C": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehose5BD3CDC8": Object {
       "Properties": Object {
         "DeliveryStreamEncryptionConfigurationInput": Object {
           "KeyType": "AWS_OWNED_CMK",
@@ -1884,7 +1884,7 @@ Object {
         "ExtendedS3DestinationConfiguration": Object {
           "BucketARN": Object {
             "Fn::GetAtt": Array [
-              "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3Bucket63AE09AD",
+              "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3Bucket7FC695A6",
               "Arn",
             ],
           },
@@ -1895,10 +1895,10 @@ Object {
           "CloudWatchLoggingOptions": Object {
             "Enabled": true,
             "LogGroupName": Object {
-              "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3firehoseloggroup9C3418A5",
+              "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3firehoseloggroup14BECCD5",
             },
             "LogStreamName": Object {
-              "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamD5E403D1",
+              "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3firehoseloggroupfirehoselogstreamC6D12661",
             },
           },
           "CompressionFormat": "GZIP",
@@ -1928,7 +1928,7 @@ Object {
           },
           "RoleARN": Object {
             "Fn::GetAtt": Array [
-              "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehoseRoleE50E908B",
+              "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehoseRole64EF3B2D",
               "Arn",
             ],
           },
@@ -1936,7 +1936,7 @@ Object {
       },
       "Type": "AWS::KinesisFirehose::DeliveryStream",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehosePolicy6E70AD3F": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehosePolicyE81FE550": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1953,7 +1953,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3Bucket63AE09AD",
+                    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3Bucket7FC695A6",
                     "Arn",
                   ],
                 },
@@ -1963,7 +1963,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3Bucket63AE09AD",
+                          "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3Bucket7FC695A6",
                           "Arn",
                         ],
                       },
@@ -1994,11 +1994,11 @@ Object {
                     },
                     ":log-group:",
                     Object {
-                      "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3firehoseloggroup9C3418A5",
+                      "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3firehoseloggroup14BECCD5",
                     },
                     ":log-stream:",
                     Object {
-                      "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamD5E403D1",
+                      "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3firehoseloggroupfirehoselogstreamC6D12661",
                     },
                   ],
                 ],
@@ -2007,16 +2007,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "estexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehosePolicy6E70AD3F",
+        "PolicyName": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehosePolicyE81FE550",
         "Roles": Array [
           Object {
-            "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehoseRoleE50E908B",
+            "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehoseRole64EF3B2D",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3KinesisFirehoseRoleE50E908B": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3KinesisFirehoseRole64EF3B2D": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -2033,7 +2033,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3Bucket63AE09AD": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3Bucket7FC695A6": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketEncryption": Object {
@@ -2060,7 +2060,7 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3LoggingBucketED2856BB",
+            "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3LoggingBucket7D1A0A6C",
           },
         },
         "PublicAccessBlockConfiguration": Object {
@@ -2076,10 +2076,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3BucketPolicyB9AF7AF2": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3BucketPolicyB93D78A6": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3Bucket63AE09AD",
+          "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3Bucket7FC695A6",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -2101,7 +2101,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3Bucket63AE09AD",
+                          "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3Bucket7FC695A6",
                           "Arn",
                         ],
                       },
@@ -2111,7 +2111,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3Bucket63AE09AD",
+                    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3Bucket7FC695A6",
                     "Arn",
                   ],
                 },
@@ -2124,7 +2124,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3LoggingBucketED2856BB": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3LoggingBucket7D1A0A6C": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -2160,10 +2160,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3LoggingBucketPolicy3A9341FD": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3LoggingBucketPolicy6DD495DA": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3LoggingBucketED2856BB",
+          "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3LoggingBucket7D1A0A6C",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -2185,7 +2185,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3LoggingBucketED2856BB",
+                          "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3LoggingBucket7D1A0A6C",
                           "Arn",
                         ],
                       },
@@ -2195,7 +2195,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3S3LoggingBucketED2856BB",
+                    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3S3LoggingBucket7D1A0A6C",
                     "Arn",
                   ],
                 },
@@ -2208,7 +2208,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3firehoseloggroup9C3418A5": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3firehoseloggroup14BECCD5": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -2227,11 +2227,11 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamD5E403D1": Object {
+    "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3firehoseloggroupfirehoselogstreamC6D12661": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "LogGroupName": Object {
-          "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehosewrappedKinesisFirehoseToS3firehoseloggroup9C3418A5",
+          "Ref": "testexistingeventsrulekinesisfirehosetestexistingeventsrulekinesisfirehoseWKinesisFirehoseToS3firehoseloggroup14BECCD5",
         },
       },
       "Type": "AWS::Logs::LogStream",

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/integ.events-rule-kinesisfirehose-s3-existing-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/integ.events-rule-kinesisfirehose-s3-existing-eventbus.expected.json
@@ -7,7 +7,7 @@
         "Name": "eventsrulekinesisfirehoses3existingeventbustestexistingeventbus60C95343"
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -43,11 +43,11 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketPolicy05DABD06": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketPolicyF9460CFD": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06"
         },
         "PolicyDocument": {
           "Statement": [
@@ -69,7 +69,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06",
                           "Arn"
                         ]
                       },
@@ -79,7 +79,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06",
                     "Arn"
                   ]
                 }
@@ -91,7 +91,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -118,7 +118,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -134,11 +134,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketPolicyE0F0697B": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketPolicy908B8F80": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248"
         },
         "PolicyDocument": {
           "Statement": [
@@ -160,7 +160,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                           "Arn"
                         ]
                       },
@@ -170,7 +170,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                     "Arn"
                   ]
                 }
@@ -182,7 +182,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1": {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain",
@@ -201,17 +201,17 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream8B8FD71B": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream6FA9D51F": {
       "Type": "AWS::Logs::LogStream",
       "Properties": {
         "LogGroupName": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1"
         }
       },
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRoleF67ACB54": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole7326FCDB": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -228,7 +228,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehosePolicyA86454BE": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehosePolicyFD980509": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -246,7 +246,7 @@
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                     "Arn"
                   ]
                 },
@@ -256,7 +256,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                           "Arn"
                         ]
                       },
@@ -287,11 +287,11 @@
                     },
                     ":log-group:",
                     {
-                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F"
+                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1"
                     },
                     ":log-stream:",
                     {
-                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream8B8FD71B"
+                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream6FA9D51F"
                     }
                   ]
                 ]
@@ -300,15 +300,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehosePolicyA86454BE",
+        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehosePolicyFD980509",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRoleF67ACB54"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole7326FCDB"
           }
         ]
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose2D280EBC": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose9AE5A31E": {
       "Type": "AWS::KinesisFirehose::DeliveryStream",
       "Properties": {
         "DeliveryStreamEncryptionConfigurationInput": {
@@ -317,7 +317,7 @@
         "ExtendedS3DestinationConfiguration": {
           "BucketARN": {
             "Fn::GetAtt": [
-              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
               "Arn"
             ]
           },
@@ -328,10 +328,10 @@
           "CloudWatchLoggingOptions": {
             "Enabled": true,
             "LogGroupName": {
-              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F"
+              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1"
             },
             "LogStreamName": {
-              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream8B8FD71B"
+              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream6FA9D51F"
             }
           },
           "CompressionFormat": "GZIP",
@@ -361,14 +361,14 @@
           },
           "RoleARN": {
             "Fn::GetAtt": [
-              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRoleF67ACB54",
+              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole7326FCDB",
               "Arn"
             ]
           }
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRoleCBD0B3E7": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRole09EB34EE": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -386,7 +386,7 @@
         "Description": "Events Rule To Kinesis Firehose Role"
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehosePolicy7273993A": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehosePolicyF2F1B017": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -399,7 +399,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose2D280EBC",
+                  "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose9AE5A31E",
                   "Arn"
                 ]
               }
@@ -407,15 +407,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehosePolicy7273993A",
+        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehosePolicyF2F1B017",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRoleCBD0B3E7"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRole09EB34EE"
           }
         ]
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRule6DC79A2F": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRule71C353D5": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
@@ -431,14 +431,14 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose2D280EBC",
+                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose9AE5A31E",
                 "Arn"
               ]
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRoleCBD0B3E7",
+                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRole09EB34EE",
                 "Arn"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/integ.events-rule-kinesisfirehose-s3-new-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/integ.events-rule-kinesisfirehose-s3-new-eventbus.expected.json
@@ -1,7 +1,7 @@
 {
   "Description": "Integration Test for aws-eventsrule-kinesisfirehose-s3",
   "Resources": {
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -37,11 +37,11 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketPolicy05DABD06": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketPolicyF9460CFD": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06"
         },
         "PolicyDocument": {
           "Statement": [
@@ -63,7 +63,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06",
                           "Arn"
                         ]
                       },
@@ -73,7 +73,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06",
                     "Arn"
                   ]
                 }
@@ -85,7 +85,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -112,7 +112,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucket53EAAB2B"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketF39FAD06"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -128,11 +128,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketPolicyE0F0697B": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketPolicy908B8F80": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248"
         },
         "PolicyDocument": {
           "Statement": [
@@ -154,7 +154,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                           "Arn"
                         ]
                       },
@@ -164,7 +164,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                     "Arn"
                   ]
                 }
@@ -176,7 +176,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1": {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain",
@@ -195,17 +195,17 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream8B8FD71B": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream6FA9D51F": {
       "Type": "AWS::Logs::LogStream",
       "Properties": {
         "LogGroupName": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1"
         }
       },
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRoleF67ACB54": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole7326FCDB": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -222,7 +222,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehosePolicyA86454BE": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehosePolicyFD980509": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -240,7 +240,7 @@
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                     "Arn"
                   ]
                 },
@@ -250,7 +250,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
                           "Arn"
                         ]
                       },
@@ -281,11 +281,11 @@
                     },
                     ":log-group:",
                     {
-                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F"
+                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1"
                     },
                     ":log-stream:",
                     {
-                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream8B8FD71B"
+                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream6FA9D51F"
                     }
                   ]
                 ]
@@ -294,15 +294,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehosePolicyA86454BE",
+        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehosePolicyFD980509",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRoleF67ACB54"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole7326FCDB"
           }
         ]
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose2D280EBC": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose9AE5A31E": {
       "Type": "AWS::KinesisFirehose::DeliveryStream",
       "Properties": {
         "DeliveryStreamEncryptionConfigurationInput": {
@@ -311,7 +311,7 @@
         "ExtendedS3DestinationConfiguration": {
           "BucketARN": {
             "Fn::GetAtt": [
-              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3Bucket4EC20CF9",
+              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketF9EB0248",
               "Arn"
             ]
           },
@@ -322,10 +322,10 @@
           "CloudWatchLoggingOptions": {
             "Enabled": true,
             "LogGroupName": {
-              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6E1EA62F"
+              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup7B174BA1"
             },
             "LogStreamName": {
-              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstream8B8FD71B"
+              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream6FA9D51F"
             }
           },
           "CompressionFormat": "GZIP",
@@ -355,14 +355,14 @@
           },
           "RoleARN": {
             "Fn::GetAtt": [
-              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRoleF67ACB54",
+              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole7326FCDB",
               "Arn"
             ]
           }
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRoleCBD0B3E7": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRole09EB34EE": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -380,7 +380,7 @@
         "Description": "Events Rule To Kinesis Firehose Role"
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehosePolicy7273993A": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehosePolicyF2F1B017": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -393,7 +393,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose2D280EBC",
+                  "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose9AE5A31E",
                   "Arn"
                 ]
               }
@@ -401,25 +401,25 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehosePolicy7273993A",
+        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehosePolicyF2F1B017",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRoleCBD0B3E7"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRole09EB34EE"
           }
         ]
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedCustomEventBus14A84EDD": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WCustomEventBusC937349B": {
       "Type": "AWS::Events::EventBus",
       "Properties": {
-        "Name": "eventsrulekinesisfirehoses3neweventbustesteventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedCustomEventBusEAF7E687"
+        "Name": "eventsrulekinesisfirehoses3neweventbustesteventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WCustomEventBus13FD48C9"
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRule6DC79A2F": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRule71C353D5": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedCustomEventBus14A84EDD"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WCustomEventBusC937349B"
         },
         "EventPattern": {
           "source": [
@@ -431,14 +431,14 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose2D280EBC",
+                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose9AE5A31E",
                 "Arn"
               ]
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRoleCBD0B3E7",
+                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRole09EB34EE",
                 "Arn"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/integ.events-rule-kinesisfirehose-s3-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/test/integ.events-rule-kinesisfirehose-s3-no-arguments.expected.json
@@ -1,7 +1,7 @@
 {
   "Description": "Integration Test for aws-events-rule-kinesisfirehose-s3",
   "Resources": {
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketC8D377B4": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketC5C17A3C": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -37,11 +37,11 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketPolicyC5D94659": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketPolicyB9D88D03": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketC8D377B4"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketC5C17A3C"
         },
         "PolicyDocument": {
           "Statement": [
@@ -63,7 +63,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketC8D377B4",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketC5C17A3C",
                           "Arn"
                         ]
                       },
@@ -73,7 +73,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketC8D377B4",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketC5C17A3C",
                     "Arn"
                   ]
                 }
@@ -85,7 +85,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketCD527E9F": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3Bucket099FD6EC": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -112,7 +112,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3LoggingBucketC8D377B4"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3LoggingBucketC5C17A3C"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -128,11 +128,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketPolicyE692149F": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3BucketPolicyB5F556D0": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketCD527E9F"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3Bucket099FD6EC"
         },
         "PolicyDocument": {
           "Statement": [
@@ -154,7 +154,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketCD527E9F",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3Bucket099FD6EC",
                           "Arn"
                         ]
                       },
@@ -164,7 +164,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketCD527E9F",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3Bucket099FD6EC",
                     "Arn"
                   ]
                 }
@@ -176,7 +176,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6B531CEB": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup9EE85371": {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain",
@@ -195,17 +195,17 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamC13E36D9": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream0ECFD952": {
       "Type": "AWS::Logs::LogStream",
       "Properties": {
         "LogGroupName": {
-          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6B531CEB"
+          "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup9EE85371"
         }
       },
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRole064D0492": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole39C4193F": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -222,7 +222,7 @@
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehosePolicyD9FDA11C": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehosePolicy6BDAC476": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -240,7 +240,7 @@
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketCD527E9F",
+                    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3Bucket099FD6EC",
                     "Arn"
                   ]
                 },
@@ -250,7 +250,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketCD527E9F",
+                          "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3Bucket099FD6EC",
                           "Arn"
                         ]
                       },
@@ -281,11 +281,11 @@
                     },
                     ":log-group:",
                     {
-                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6B531CEB"
+                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup9EE85371"
                     },
                     ":log-stream:",
                     {
-                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamC13E36D9"
+                      "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream0ECFD952"
                     }
                   ]
                 ]
@@ -294,15 +294,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehosePolicyD9FDA11C",
+        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehosePolicy6BDAC476",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRole064D0492"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole39C4193F"
           }
         ]
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose7127034D": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose30C8ED9D": {
       "Type": "AWS::KinesisFirehose::DeliveryStream",
       "Properties": {
         "DeliveryStreamEncryptionConfigurationInput": {
@@ -311,7 +311,7 @@
         "ExtendedS3DestinationConfiguration": {
           "BucketARN": {
             "Fn::GetAtt": [
-              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3S3BucketCD527E9F",
+              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3S3Bucket099FD6EC",
               "Arn"
             ]
           },
@@ -322,10 +322,10 @@
           "CloudWatchLoggingOptions": {
             "Enabled": true,
             "LogGroupName": {
-              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroup6B531CEB"
+              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroup9EE85371"
             },
             "LogStreamName": {
-              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3firehoseloggroupfirehoselogstreamC13E36D9"
+              "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3firehoseloggroupfirehoselogstream0ECFD952"
             }
           },
           "CompressionFormat": "GZIP",
@@ -355,14 +355,14 @@
           },
           "RoleARN": {
             "Fn::GetAtt": [
-              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehoseRole064D0492",
+              "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehoseRole39C4193F",
               "Arn"
             ]
           }
         }
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRole781B6418": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRoleAF132B5A": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -380,7 +380,7 @@
         "Description": "Events Rule To Kinesis Firehose Role"
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehosePolicyA729EDC6": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehosePolicyC8498865": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -393,7 +393,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose7127034D",
+                  "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose30C8ED9D",
                   "Arn"
                 ]
               }
@@ -401,15 +401,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehosePolicyA729EDC6",
+        "PolicyName": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehosePolicyC8498865",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRole781B6418"
+            "Ref": "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRoleAF132B5A"
           }
         ]
       }
     },
-    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRule26228C8C": {
+    "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRule5A650994": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -418,14 +418,14 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedKinesisFirehoseToS3KinesisFirehose7127034D",
+                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WKinesisFirehoseToS3KinesisFirehose30C8ED9D",
                 "Arn"
               ]
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3wrappedEventsRuleInvokeKinesisFirehoseRole781B6418",
+                "testeventsrulekinesisfirehoses3testeventsrulekinesisfirehoses3WEventsRuleInvokeKinesisFirehoseRoleAF132B5A",
                 "Arn"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/lib/index.ts
@@ -78,6 +78,11 @@ export class EventsRuleToKinesisStreams extends Construct {
     constructor(scope: Construct, id: string, props: EventsRuleToKinesisStreamsProps) {
       super(scope, id);
       const convertedProps: EventsRuleToKinesisStreamsProps = { ...props };
+
+      // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+      // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+      // it in place of the older named version. They are functionally identical, aside from the types no other changes
+      // will be required.  (eg - new EventbridgeToKinesisStreams instead of EventsRuleToKinesisStreams)
       const wrappedConstruct: EventsRuleToKinesisStreams = new EventbridgeToKinesisStreams(this, `${id}W`, convertedProps);
 
       this.kinesisStream = wrappedConstruct.kinesisStream;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/lib/index.ts
@@ -80,7 +80,7 @@ export class EventsRuleToKinesisStreams extends Construct {
       const convertedProps: EventsRuleToKinesisStreamsProps = { ...props };
 
       // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-      // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+      // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
       // it in place of the older named version. They are functionally identical, aside from the types no other changes
       // will be required.  (eg - new EventbridgeToKinesisStreams instead of EventsRuleToKinesisStreams)
       const wrappedConstruct: EventsRuleToKinesisStreams = new EventbridgeToKinesisStreams(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/lib/index.ts
@@ -78,7 +78,7 @@ export class EventsRuleToKinesisStreams extends Construct {
     constructor(scope: Construct, id: string, props: EventsRuleToKinesisStreamsProps) {
       super(scope, id);
       const convertedProps: EventsRuleToKinesisStreamsProps = { ...props };
-      const wrappedConstruct: EventsRuleToKinesisStreams = new EventbridgeToKinesisStreams(this, `${id}-wrapped`, convertedProps);
+      const wrappedConstruct: EventsRuleToKinesisStreams = new EventbridgeToKinesisStreams(this, `${id}W`, convertedProps);
 
       this.kinesisStream = wrappedConstruct.kinesisStream;
       this.eventsRule = wrappedConstruct.eventsRule;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/__snapshots__/events-rule-kinesisstreams.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/__snapshots__/events-rule-kinesisstreams.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Test existing resources 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedEventsRule6F517F6D": Object {
+    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWEventsRuleE1CDDC86": Object {
       "Properties": Object {
         "Description": "event rule props",
         "ScheduleExpression": "rate(5 minutes)",
@@ -19,7 +19,7 @@ Object {
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedeventsRole6A38551C",
+                "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWeventsRoleA4611D14",
                 "Arn",
               ],
             },
@@ -28,7 +28,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedKinesisStreamGetRecordsIteratorAgeAlarmCC70229C": Object {
+    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWKinesisStreamGetRecordsIteratorAgeAlarm75C03BAF": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Record Processing Falling Behind, there is risk for data loss due to record expiration.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -41,7 +41,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedKinesisStreamReadProvisionedThroughputExceededAlarmFEFEEFB6": Object {
+    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWKinesisStreamReadProvisionedThroughputExceededAlarmA3CD49C6": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Application is Reading at a Slower Rate Than Expected.",
         "ComparisonOperator": "GreaterThanThreshold",
@@ -54,7 +54,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedeventsRole6A38551C": Object {
+    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWeventsRoleA4611D14": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -72,7 +72,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedeventsRoleDefaultPolicy40C6DC8E": Object {
+    "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWeventsRoleDefaultPolicy54FB5780": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -93,10 +93,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedeventsRoleDefaultPolicy40C6DC8E",
+        "PolicyName": "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWeventsRoleDefaultPolicy54FB5780",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourcewrappedeventsRole6A38551C",
+            "Ref": "testeventsrulekinesisstreamexistingresourcetesteventsrulekinesisstreamexistingresourceWeventsRoleA4611D14",
           },
         ],
       },
@@ -117,7 +117,7 @@ Object {
 exports[`Test snapshot match with default parameters 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedEventsRuleE7386116": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWEventsRule3B0BBD02": Object {
       "Properties": Object {
         "Description": "event rule props",
         "ScheduleExpression": "rate(5 minutes)",
@@ -126,14 +126,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStream89BFC3D2",
+                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamEB30AB36",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleA6F5A164",
+                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRole02A0AEFA",
                 "Arn",
               ],
             },
@@ -142,7 +142,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStream89BFC3D2": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamEB30AB36": Object {
       "Properties": Object {
         "RetentionPeriodHours": 24,
         "ShardCount": 1,
@@ -153,7 +153,7 @@ Object {
       },
       "Type": "AWS::Kinesis::Stream",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStreamGetRecordsIteratorAgeAlarm49F13725": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamGetRecordsIteratorAgeAlarm6B710C39": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Record Processing Falling Behind, there is risk for data loss due to record expiration.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -166,7 +166,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStreamReadProvisionedThroughputExceededAlarm47CADB74": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamReadProvisionedThroughputExceededAlarm530C042A": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Application is Reading at a Slower Rate Than Expected.",
         "ComparisonOperator": "GreaterThanThreshold",
@@ -179,7 +179,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleA6F5A164": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRole02A0AEFA": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -197,7 +197,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleDefaultPolicyDD5DE3BB": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRoleDefaultPolicyAAE313AA": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -210,7 +210,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStream89BFC3D2",
+                  "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamEB30AB36",
                   "Arn",
                 ],
               },
@@ -218,10 +218,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleDefaultPolicyDD5DE3BB",
+        "PolicyName": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRoleDefaultPolicyAAE313AA",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleA6F5A164",
+            "Ref": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRole02A0AEFA",
           },
         ],
       },
@@ -234,17 +234,17 @@ Object {
 exports[`check eventbus property, snapshot & eventbus exists 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedCustomEventBus087D7397": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWCustomEventBusE379FB3A": Object {
       "Properties": Object {
-        "Name": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedCustomEventBus9C437671",
+        "Name": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWCustomEventBusC4EC5A85",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedEventsRuleE7386116": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWEventsRule3B0BBD02": Object {
       "Properties": Object {
         "Description": "event rule props",
         "EventBusName": Object {
-          "Ref": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedCustomEventBus087D7397",
+          "Ref": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWCustomEventBusE379FB3A",
         },
         "EventPattern": Object {
           "source": Array [
@@ -256,14 +256,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStream89BFC3D2",
+                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamEB30AB36",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleA6F5A164",
+                "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRole02A0AEFA",
                 "Arn",
               ],
             },
@@ -272,7 +272,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStream89BFC3D2": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamEB30AB36": Object {
       "Properties": Object {
         "RetentionPeriodHours": 24,
         "ShardCount": 1,
@@ -283,7 +283,7 @@ Object {
       },
       "Type": "AWS::Kinesis::Stream",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStreamGetRecordsIteratorAgeAlarm49F13725": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamGetRecordsIteratorAgeAlarm6B710C39": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Record Processing Falling Behind, there is risk for data loss due to record expiration.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -296,7 +296,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStreamReadProvisionedThroughputExceededAlarm47CADB74": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamReadProvisionedThroughputExceededAlarm530C042A": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Application is Reading at a Slower Rate Than Expected.",
         "ComparisonOperator": "GreaterThanThreshold",
@@ -309,7 +309,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleA6F5A164": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRole02A0AEFA": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -327,7 +327,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleDefaultPolicyDD5DE3BB": Object {
+    "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRoleDefaultPolicyAAE313AA": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -340,7 +340,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedKinesisStream89BFC3D2",
+                  "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWKinesisStreamEB30AB36",
                   "Arn",
                 ],
               },
@@ -348,10 +348,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleDefaultPolicyDD5DE3BB",
+        "PolicyName": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRoleDefaultPolicyAAE313AA",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparameterswrappedeventsRoleA6F5A164",
+            "Ref": "testeventsrulekinesisstreamsdefaultparameterstesteventsrulekinesisstreamsdefaultparametersWeventsRole02A0AEFA",
           },
         ],
       },
@@ -364,16 +364,16 @@ Object {
 exports[`check multiple constructs in a single stack 1`] = `
 Object {
   "Resources": Object {
-    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedCustomEventBus621052D2": Object {
+    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WCustomEventBusCB793FD2": Object {
       "Properties": Object {
-        "Name": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedCustomEventBus37D43AA4",
+        "Name": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WCustomEventBus370A4667",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedEventsRule77B7C6F9": Object {
+    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WEventsRule68EE3DEC": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedCustomEventBus621052D2",
+          "Ref": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WCustomEventBusCB793FD2",
         },
         "EventPattern": Object {
           "source": Array [
@@ -385,14 +385,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedKinesisStreamDE3E5A94",
+                "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WKinesisStream405ABD89",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedeventsRole7A2DE877",
+                "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WeventsRoleF8A00A46",
                 "Arn",
               ],
             },
@@ -401,7 +401,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedKinesisStreamDE3E5A94": Object {
+    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WKinesisStream405ABD89": Object {
       "Properties": Object {
         "RetentionPeriodHours": 24,
         "ShardCount": 1,
@@ -412,7 +412,7 @@ Object {
       },
       "Type": "AWS::Kinesis::Stream",
     },
-    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedKinesisStreamGetRecordsIteratorAgeAlarm49174F65": Object {
+    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WKinesisStreamGetRecordsIteratorAgeAlarm10EF9BCB": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Record Processing Falling Behind, there is risk for data loss due to record expiration.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -425,7 +425,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedKinesisStreamReadProvisionedThroughputExceededAlarm383A38FA": Object {
+    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WKinesisStreamReadProvisionedThroughputExceededAlarm130E52F3": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Application is Reading at a Slower Rate Than Expected.",
         "ComparisonOperator": "GreaterThanThreshold",
@@ -438,25 +438,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedeventsRole7A2DE877": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Description": "Events Rule Role",
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedeventsRoleDefaultPolicyD0CF32D7": Object {
+    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WeventsRoleDefaultPolicy887766E9": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -469,7 +451,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedKinesisStreamDE3E5A94",
+                  "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WKinesisStream405ABD89",
                   "Arn",
                 ],
               },
@@ -477,90 +459,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedeventsRoleDefaultPolicyD0CF32D7",
+        "PolicyName": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WeventsRoleDefaultPolicy887766E9",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1wrappedeventsRole7A2DE877",
+            "Ref": "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WeventsRoleF8A00A46",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedCustomEventBusC5B06C6E": Object {
-      "Properties": Object {
-        "Name": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedCustomEventBus21CC267C",
-      },
-      "Type": "AWS::Events::EventBus",
-    },
-    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedEventsRule39C7A89E": Object {
-      "Properties": Object {
-        "EventBusName": Object {
-          "Ref": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedCustomEventBusC5B06C6E",
-        },
-        "EventPattern": Object {
-          "source": Array [
-            "solutionsconstructs",
-          ],
-        },
-        "State": "ENABLED",
-        "Targets": Array [
-          Object {
-            "Arn": Object {
-              "Fn::GetAtt": Array [
-                "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedKinesisStreamDA2C3864",
-                "Arn",
-              ],
-            },
-            "Id": "Target0",
-            "RoleArn": Object {
-              "Fn::GetAtt": Array [
-                "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedeventsRole96D19F61",
-                "Arn",
-              ],
-            },
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
-    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedKinesisStreamDA2C3864": Object {
-      "Properties": Object {
-        "RetentionPeriodHours": 24,
-        "ShardCount": 1,
-        "StreamEncryption": Object {
-          "EncryptionType": "KMS",
-          "KeyId": "alias/aws/kinesis",
-        },
-      },
-      "Type": "AWS::Kinesis::Stream",
-    },
-    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedKinesisStreamGetRecordsIteratorAgeAlarmB69C2758": Object {
-      "Properties": Object {
-        "AlarmDescription": "Consumer Record Processing Falling Behind, there is risk for data loss due to record expiration.",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "MetricName": "GetRecords.IteratorAgeMilliseconds",
-        "Namespace": "AWS/Kinesis",
-        "Period": 300,
-        "Statistic": "Maximum",
-        "Threshold": 2592000,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedKinesisStreamReadProvisionedThroughputExceededAlarm8C8AB6DF": Object {
-      "Properties": Object {
-        "AlarmDescription": "Consumer Application is Reading at a Slower Rate Than Expected.",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "MetricName": "ReadProvisionedThroughputExceeded",
-        "Namespace": "AWS/Kinesis",
-        "Period": 300,
-        "Statistic": "Average",
-        "Threshold": 0,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedeventsRole96D19F61": Object {
+    "testneweventsrulekinesisstreams1testneweventsrulekinesisstreams1WeventsRoleF8A00A46": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -578,7 +486,99 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedeventsRoleDefaultPolicy54D57280": Object {
+    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WCustomEventBus104AF840": Object {
+      "Properties": Object {
+        "Name": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WCustomEventBus153160C3",
+      },
+      "Type": "AWS::Events::EventBus",
+    },
+    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WEventsRule80162E43": Object {
+      "Properties": Object {
+        "EventBusName": Object {
+          "Ref": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WCustomEventBus104AF840",
+        },
+        "EventPattern": Object {
+          "source": Array [
+            "solutionsconstructs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WKinesisStream652ED8BF",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "RoleArn": Object {
+              "Fn::GetAtt": Array [
+                "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WeventsRole052FF25B",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WKinesisStream652ED8BF": Object {
+      "Properties": Object {
+        "RetentionPeriodHours": 24,
+        "ShardCount": 1,
+        "StreamEncryption": Object {
+          "EncryptionType": "KMS",
+          "KeyId": "alias/aws/kinesis",
+        },
+      },
+      "Type": "AWS::Kinesis::Stream",
+    },
+    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WKinesisStreamGetRecordsIteratorAgeAlarmC6800575": Object {
+      "Properties": Object {
+        "AlarmDescription": "Consumer Record Processing Falling Behind, there is risk for data loss due to record expiration.",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "GetRecords.IteratorAgeMilliseconds",
+        "Namespace": "AWS/Kinesis",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 2592000,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WKinesisStreamReadProvisionedThroughputExceededAlarm27C47D57": Object {
+      "Properties": Object {
+        "AlarmDescription": "Consumer Application is Reading at a Slower Rate Than Expected.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadProvisionedThroughputExceeded",
+        "Namespace": "AWS/Kinesis",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WeventsRole052FF25B": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": "Events Rule Role",
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WeventsRoleDefaultPolicy9776E535": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -591,7 +591,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedKinesisStreamDA2C3864",
+                  "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WKinesisStream652ED8BF",
                   "Arn",
                 ],
               },
@@ -599,10 +599,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedeventsRoleDefaultPolicy54D57280",
+        "PolicyName": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WeventsRoleDefaultPolicy9776E535",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2wrappedeventsRole96D19F61",
+            "Ref": "testneweventsrulekinesisstreams2testneweventsrulekinesisstreams2WeventsRole052FF25B",
           },
         ],
       },
@@ -621,7 +621,7 @@ Object {
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedEventsRuleC111EF82": Object {
+    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWEventsRule93E97062": Object {
       "Properties": Object {
         "EventBusName": Object {
           "Ref": "testexistingeventbusC6E4A2D0",
@@ -636,14 +636,14 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedKinesisStreamBE691F23",
+                "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWKinesisStream75CA0531",
                 "Arn",
               ],
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedeventsRole2FDE3897",
+                "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWeventsRole5CA69F99",
                 "Arn",
               ],
             },
@@ -652,7 +652,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedKinesisStreamBE691F23": Object {
+    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWKinesisStream75CA0531": Object {
       "Properties": Object {
         "RetentionPeriodHours": 24,
         "ShardCount": 1,
@@ -663,7 +663,7 @@ Object {
       },
       "Type": "AWS::Kinesis::Stream",
     },
-    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedKinesisStreamGetRecordsIteratorAgeAlarmD6B50B08": Object {
+    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWKinesisStreamGetRecordsIteratorAgeAlarm12C7C44D": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Record Processing Falling Behind, there is risk for data loss due to record expiration.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -676,7 +676,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedKinesisStreamReadProvisionedThroughputExceededAlarmA695BB87": Object {
+    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWKinesisStreamReadProvisionedThroughputExceededAlarm52D4EB2F": Object {
       "Properties": Object {
         "AlarmDescription": "Consumer Application is Reading at a Slower Rate Than Expected.",
         "ComparisonOperator": "GreaterThanThreshold",
@@ -689,7 +689,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedeventsRole2FDE3897": Object {
+    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWeventsRole5CA69F99": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -707,7 +707,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedeventsRoleDefaultPolicy2AA1053A": Object {
+    "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWeventsRoleDefaultPolicyE5FEBF35": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -720,7 +720,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedKinesisStreamBE691F23",
+                  "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWKinesisStream75CA0531",
                   "Arn",
                 ],
               },
@@ -728,10 +728,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedeventsRoleDefaultPolicy2AA1053A",
+        "PolicyName": "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWeventsRoleDefaultPolicyE5FEBF35",
         "Roles": Array [
           Object {
-            "Ref": "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamswrappedeventsRole2FDE3897",
+            "Ref": "testexistingeventsrulekinesisstreamstestexistingeventsrulekinesisstreamsWeventsRole5CA69F99",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-existing-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-existing-eventbus.expected.json
@@ -18,7 +18,7 @@
         "Name": "eventsrulekinesisstreamsexistingeventbusexistingeventbus213FA4D6"
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRole38D10826": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRole95F9546E": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -36,7 +36,7 @@
         "Description": "Events Rule Role"
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRoleDefaultPolicy59074775": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRoleDefaultPolicy1EDA1128": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -58,15 +58,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRoleDefaultPolicy59074775",
+        "PolicyName": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRoleDefaultPolicy1EDA1128",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRole38D10826"
+            "Ref": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRole95F9546E"
           }
         ]
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedEventsRuleFD150210": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWEventsRule2FF4D2A3": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
@@ -89,7 +89,7 @@
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRole38D10826",
+                "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRole95F9546E",
                 "Arn"
               ]
             }
@@ -97,7 +97,7 @@
         ]
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedKinesisStreamGetRecordsIteratorAgeAlarm2292FE85": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWKinesisStreamGetRecordsIteratorAgeAlarm43FEE706": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -110,7 +110,7 @@
         "Threshold": 2592000
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedKinesisStreamReadProvisionedThroughputExceededAlarm2C18A4CF": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWKinesisStreamReadProvisionedThroughputExceededAlarmC7B9BAE4": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanThreshold",

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-existing.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-existing.expected.json
@@ -12,7 +12,7 @@
         }
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRole15D05460": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRole8EE694B6": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -30,7 +30,7 @@
         "Description": "Events Rule Role"
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRoleDefaultPolicyF94BA3BF": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRoleDefaultPolicyFE301D92": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -52,15 +52,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRoleDefaultPolicyF94BA3BF",
+        "PolicyName": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRoleDefaultPolicyFE301D92",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRole15D05460"
+            "Ref": "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRole8EE694B6"
           }
         ]
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedEventsRule5BECD28B": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWEventsRuleF8624345": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -76,7 +76,7 @@
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedeventsRole15D05460",
+                "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWeventsRole8EE694B6",
                 "Arn"
               ]
             }
@@ -84,7 +84,7 @@
         ]
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedKinesisStreamGetRecordsIteratorAgeAlarmDD39CA16": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWKinesisStreamGetRecordsIteratorAgeAlarm197B0C62": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -97,7 +97,7 @@
         "Threshold": 2592000
       }
     },
-    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingwrappedKinesisStreamReadProvisionedThroughputExceededAlarmF2408E46": {
+    "testeventsrulekinesisstreamexistingtesteventsrulekinesisstreamexistingWKinesisStreamReadProvisionedThroughputExceededAlarmB84DCE25": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanThreshold",

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-new-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-new-eventbus.expected.json
@@ -1,7 +1,7 @@
 {
   "Description": "Integration Test for aws-eventsrule-kinesisstreams",
   "Resources": {
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStream019D9FCF": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStream67B308F2": {
       "Type": "AWS::Kinesis::Stream",
       "Properties": {
         "ShardCount": 1,
@@ -12,7 +12,7 @@
         }
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleEE166637": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRole0A44F5C7": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -30,7 +30,7 @@
         "Description": "Events Rule Role"
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleDefaultPolicyD1DFFED9": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRoleDefaultPolicy4F587315": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -44,7 +44,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStream019D9FCF",
+                  "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStream67B308F2",
                   "Arn"
                 ]
               }
@@ -52,25 +52,25 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleDefaultPolicyD1DFFED9",
+        "PolicyName": "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRoleDefaultPolicy4F587315",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleEE166637"
+            "Ref": "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRole0A44F5C7"
           }
         ]
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedCustomEventBus8EBC01DE": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWCustomEventBusAF7D2D89": {
       "Type": "AWS::Events::EventBus",
       "Properties": {
-        "Name": "eventsrulekinesisstreamsneweventbustesteventsrulekinesisstreamtesteventsrulekinesisstreamwrappedCustomEventBusCC2C9ADE"
+        "Name": "eventsrulekinesisstreamsneweventbustesteventsrulekinesisstreamtesteventsrulekinesisstreamWCustomEventBusB7D74ACD"
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedEventsRule7EF25945": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWEventsRuleC03ABB43": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
-          "Ref": "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedCustomEventBus8EBC01DE"
+          "Ref": "testeventsrulekinesisstreamtesteventsrulekinesisstreamWCustomEventBusAF7D2D89"
         },
         "EventPattern": {
           "source": [
@@ -82,14 +82,14 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStream019D9FCF",
+                "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStream67B308F2",
                 "Arn"
               ]
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleEE166637",
+                "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRole0A44F5C7",
                 "Arn"
               ]
             }
@@ -97,7 +97,7 @@
         ]
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStreamGetRecordsIteratorAgeAlarm5D9EA10B": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStreamGetRecordsIteratorAgeAlarm0F9A252D": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -110,7 +110,7 @@
         "Threshold": 2592000
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStreamReadProvisionedThroughputExceededAlarm62FD5A3B": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStreamReadProvisionedThroughputExceededAlarm5F32E34D": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanThreshold",

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/test/integ.events-rule-kinesisstreams-no-arguments.expected.json
@@ -1,7 +1,7 @@
 {
   "Description": "Integration Test for aws-events-rule-kinesisstreams",
   "Resources": {
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStream0DF0B979": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStreamB773BFD9": {
       "Type": "AWS::Kinesis::Stream",
       "Properties": {
         "ShardCount": 1,
@@ -12,7 +12,7 @@
         }
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleB9FCFED0": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRole1FCDD9A3": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -30,7 +30,7 @@
         "Description": "Events Rule Role"
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleDefaultPolicyE3C3B504": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRoleDefaultPolicy2CC69EFD": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -44,7 +44,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStream0DF0B979",
+                  "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStreamB773BFD9",
                   "Arn"
                 ]
               }
@@ -52,15 +52,15 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleDefaultPolicyE3C3B504",
+        "PolicyName": "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRoleDefaultPolicy2CC69EFD",
         "Roles": [
           {
-            "Ref": "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleB9FCFED0"
+            "Ref": "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRole1FCDD9A3"
           }
         ]
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedEventsRuleF40A5FAB": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWEventsRule91158D3F": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -69,14 +69,14 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStream0DF0B979",
+                "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStreamB773BFD9",
                 "Arn"
               ]
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedeventsRoleB9FCFED0",
+                "testeventsrulekinesisstreamtesteventsrulekinesisstreamWeventsRole1FCDD9A3",
                 "Arn"
               ]
             }
@@ -84,7 +84,7 @@
         ]
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStreamGetRecordsIteratorAgeAlarmE19C961D": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStreamGetRecordsIteratorAgeAlarm52562184": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -97,7 +97,7 @@
         "Threshold": 2592000
       }
     },
-    "testeventsrulekinesisstreamtesteventsrulekinesisstreamwrappedKinesisStreamReadProvisionedThroughputExceededAlarm1B392D10": {
+    "testeventsrulekinesisstreamtesteventsrulekinesisstreamWKinesisStreamReadProvisionedThroughputExceededAlarmE9C8ACA5": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanThreshold",

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/lib/index.ts
@@ -68,6 +68,11 @@ export class EventsRuleToLambda extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToLambdaProps) {
     super(scope, id);
     const convertedProps: EventsRuleToLambdaProps = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new EventbridgeToLambda instead of EventsRuleToLambda)
     const wrappedConstruct: EventsRuleToLambda = new EventbridgeToLambda(this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/lib/index.ts
@@ -70,7 +70,7 @@ export class EventsRuleToLambda extends Construct {
     const convertedProps: EventsRuleToLambdaProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new EventbridgeToLambda instead of EventsRuleToLambda)
     const wrappedConstruct: EventsRuleToLambda = new EventbridgeToLambda(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/lib/index.ts
@@ -68,7 +68,7 @@ export class EventsRuleToLambda extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToLambdaProps) {
     super(scope, id);
     const convertedProps: EventsRuleToLambdaProps = { ...props };
-    const wrappedConstruct: EventsRuleToLambda = new EventbridgeToLambda(this, `${id}-wrapped`, convertedProps);
+    const wrappedConstruct: EventsRuleToLambda = new EventbridgeToLambda(this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;
     this.eventsRule = wrappedConstruct.eventsRule;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/__snapshots__/events-rule-lambda.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/__snapshots__/events-rule-lambda.test.js.snap
@@ -17,16 +17,16 @@ Object {
     },
   },
   "Resources": Object {
-    "testneweventsrulelambdatestneweventsrulelambdawrappedCustomEventBusD55CE272": Object {
+    "testneweventsrulelambdatestneweventsrulelambdaWCustomEventBusACACFB40": Object {
       "Properties": Object {
-        "Name": "testneweventsrulelambdatestneweventsrulelambdawrappedCustomEventBusD11E8040",
+        "Name": "testneweventsrulelambdatestneweventsrulelambdaWCustomEventBus4B53AC86",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulelambdatestneweventsrulelambdawrappedEventsRuleD35AE1A2": Object {
+    "testneweventsrulelambdatestneweventsrulelambdaWEventsRule61826461": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulelambdatestneweventsrulelambdawrappedCustomEventBusD55CE272",
+          "Ref": "testneweventsrulelambdatestneweventsrulelambdaWCustomEventBusACACFB40",
         },
         "EventPattern": Object {
           "source": Array [
@@ -38,7 +38,7 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunction30F213FF",
+                "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunction82A6BFDD",
                 "Arn",
               ],
             },
@@ -48,10 +48,10 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunction30F213FF": Object {
+    "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunction82A6BFDD": Object {
       "DependsOn": Array [
-        "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyD89025ED",
-        "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionServiceRoleEF4B79C5",
+        "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyA4A6E440",
+        "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionServiceRole1A592834",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -118,7 +118,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionServiceRoleEF4B79C5",
+            "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionServiceRole1A592834",
             "Arn",
           ],
         },
@@ -129,60 +129,26 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionAwsEventsLambdaInvokePermission1524B4AEB": Object {
+    "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionAwsEventsLambdaInvokePermission1963A2F59": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunction30F213FF",
+            "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunction82A6BFDD",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambdatestneweventsrulelambdawrappedEventsRuleD35AE1A2",
+            "testneweventsrulelambdatestneweventsrulelambdaWEventsRule61826461",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyD89025ED": Object {
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W12",
-              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "xray:PutTraceSegments",
-                "xray:PutTelemetryRecords",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyD89025ED",
-        "Roles": Array [
-          Object {
-            "Ref": "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionServiceRoleEF4B79C5",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "testneweventsrulelambdatestneweventsrulelambdawrappedLambdaFunctionServiceRoleEF4B79C5": Object {
+    "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionServiceRole1A592834": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -236,6 +202,40 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyA4A6E440": Object {
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W12",
+              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyA4A6E440",
+        "Roles": Array [
+          Object {
+            "Ref": "testneweventsrulelambdatestneweventsrulelambdaWLambdaFunctionServiceRole1A592834",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
   },
 }
@@ -258,16 +258,16 @@ Object {
     },
   },
   "Resources": Object {
-    "testneweventsrulelambda1testneweventsrulelambda1wrappedCustomEventBusB523DE9D": Object {
+    "testneweventsrulelambda1testneweventsrulelambda1WCustomEventBusD70475EA": Object {
       "Properties": Object {
-        "Name": "testneweventsrulelambda1testneweventsrulelambda1wrappedCustomEventBus2947A41E",
+        "Name": "testneweventsrulelambda1testneweventsrulelambda1WCustomEventBusCCFC7671",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulelambda1testneweventsrulelambda1wrappedEventsRuleA63512F2": Object {
+    "testneweventsrulelambda1testneweventsrulelambda1WEventsRuleCAF3D220": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulelambda1testneweventsrulelambda1wrappedCustomEventBusB523DE9D",
+          "Ref": "testneweventsrulelambda1testneweventsrulelambda1WCustomEventBusD70475EA",
         },
         "EventPattern": Object {
           "source": Array [
@@ -279,7 +279,7 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunction26FF474D",
+                "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunction508366E8",
                 "Arn",
               ],
             },
@@ -289,10 +289,10 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunction26FF474D": Object {
+    "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunction508366E8": Object {
       "DependsOn": Array [
-        "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionServiceRoleDefaultPolicyEEA76A29",
-        "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionServiceRole9BD7A5E3",
+        "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionServiceRoleDefaultPolicy2EDAC674",
+        "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionServiceRole44F29D0D",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -359,7 +359,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionServiceRole9BD7A5E3",
+            "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionServiceRole44F29D0D",
             "Arn",
           ],
         },
@@ -370,26 +370,26 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionAwsEventsLambdaInvokePermission101A42949": Object {
+    "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionAwsEventsLambdaInvokePermission1BD774C6A": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunction26FF474D",
+            "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunction508366E8",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambda1testneweventsrulelambda1wrappedEventsRuleA63512F2",
+            "testneweventsrulelambda1testneweventsrulelambda1WEventsRuleCAF3D220",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionServiceRole9BD7A5E3": Object {
+    "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionServiceRole44F29D0D": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -444,7 +444,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionServiceRoleDefaultPolicyEEA76A29": Object {
+    "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionServiceRoleDefaultPolicy2EDAC674": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -469,25 +469,25 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionServiceRoleDefaultPolicyEEA76A29",
+        "PolicyName": "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionServiceRoleDefaultPolicy2EDAC674",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulelambda1testneweventsrulelambda1wrappedLambdaFunctionServiceRole9BD7A5E3",
+            "Ref": "testneweventsrulelambda1testneweventsrulelambda1WLambdaFunctionServiceRole44F29D0D",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulelambda2testneweventsrulelambda2wrappedCustomEventBus14F7A12E": Object {
+    "testneweventsrulelambda2testneweventsrulelambda2WCustomEventBusECAFE55E": Object {
       "Properties": Object {
-        "Name": "testneweventsrulelambda2testneweventsrulelambda2wrappedCustomEventBus545E341A",
+        "Name": "testneweventsrulelambda2testneweventsrulelambda2WCustomEventBus8B7AB031",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulelambda2testneweventsrulelambda2wrappedEventsRule7D7931F0": Object {
+    "testneweventsrulelambda2testneweventsrulelambda2WEventsRule3AEF73E1": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulelambda2testneweventsrulelambda2wrappedCustomEventBus14F7A12E",
+          "Ref": "testneweventsrulelambda2testneweventsrulelambda2WCustomEventBusECAFE55E",
         },
         "EventPattern": Object {
           "source": Array [
@@ -499,7 +499,7 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunction174D60EC",
+                "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunction0603676F",
                 "Arn",
               ],
             },
@@ -509,10 +509,10 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunction174D60EC": Object {
+    "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunction0603676F": Object {
       "DependsOn": Array [
-        "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionServiceRoleDefaultPolicy15343B2A",
-        "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionServiceRole73329C49",
+        "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionServiceRoleDefaultPolicyC838EF33",
+        "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionServiceRoleE2024B15",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -579,7 +579,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionServiceRole73329C49",
+            "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionServiceRoleE2024B15",
             "Arn",
           ],
         },
@@ -590,26 +590,60 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionAwsEventsLambdaInvokePermission1A86C7F7D": Object {
+    "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionAwsEventsLambdaInvokePermission19D4CBF19": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunction174D60EC",
+            "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunction0603676F",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulelambda2testneweventsrulelambda2wrappedEventsRule7D7931F0",
+            "testneweventsrulelambda2testneweventsrulelambda2WEventsRule3AEF73E1",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionServiceRole73329C49": Object {
+    "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionServiceRoleDefaultPolicyC838EF33": Object {
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W12",
+              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionServiceRoleDefaultPolicyC838EF33",
+        "Roles": Array [
+          Object {
+            "Ref": "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionServiceRoleE2024B15",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "testneweventsrulelambda2testneweventsrulelambda2WLambdaFunctionServiceRoleE2024B15": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -663,40 +697,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionServiceRoleDefaultPolicy15343B2A": Object {
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W12",
-              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "xray:PutTraceSegments",
-                "xray:PutTelemetryRecords",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionServiceRoleDefaultPolicy15343B2A",
-        "Roles": Array [
-          Object {
-            "Ref": "testneweventsrulelambda2testneweventsrulelambda2wrappedLambdaFunctionServiceRole73329C49",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
   },
 }
@@ -719,7 +719,7 @@ Object {
     },
   },
   "Resources": Object {
-    "testeventsrulelambdatesteventsrulelambdawrappedEventsRuleC19DAE50": Object {
+    "testeventsrulelambdatesteventsrulelambdaWEventsRule1B328BFB": Object {
       "Properties": Object {
         "ScheduleExpression": "rate(5 minutes)",
         "State": "ENABLED",
@@ -727,7 +727,7 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98",
+                "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8",
                 "Arn",
               ],
             },
@@ -737,10 +737,10 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98": Object {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8": Object {
       "DependsOn": Array [
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyF7B2C1E2",
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10",
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyD705B722",
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -807,7 +807,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB",
             "Arn",
           ],
         },
@@ -818,26 +818,60 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionAwsEventsLambdaInvokePermission15AD1F48C": Object {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionAwsEventsLambdaInvokePermission135EE70F4": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {
           "Fn::GetAtt": Array [
-            "testeventsrulelambdatesteventsrulelambdawrappedEventsRuleC19DAE50",
+            "testeventsrulelambdatesteventsrulelambdaWEventsRule1B328BFB",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10": Object {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyD705B722": Object {
+      "Metadata": Object {
+        "cfn_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "W12",
+              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyD705B722",
+        "Roles": Array [
+          Object {
+            "Ref": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -891,40 +925,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyF7B2C1E2": Object {
-      "Metadata": Object {
-        "cfn_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "W12",
-              "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "xray:PutTraceSegments",
-                "xray:PutTelemetryRecords",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyF7B2C1E2",
-        "Roles": Array [
-          Object {
-            "Ref": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
   },
 }
@@ -953,7 +953,7 @@ Object {
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedEventsRule1751BCED": Object {
+    "testexistingeventsrulelambdatestexistingeventsrulelambdaWEventsRuleEC7E86AC": Object {
       "Properties": Object {
         "EventBusName": Object {
           "Ref": "testexistingeventbusC6E4A2D0",
@@ -968,7 +968,7 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunction49FE3A50",
+                "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunction761A16B3",
                 "Arn",
               ],
             },
@@ -978,10 +978,10 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunction49FE3A50": Object {
+    "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunction761A16B3": Object {
       "DependsOn": Array [
-        "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyE0D1CBFE",
-        "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionServiceRole46509482",
+        "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicy9D955941",
+        "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionServiceRoleBE7F5B75",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -1048,7 +1048,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionServiceRole46509482",
+            "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionServiceRoleBE7F5B75",
             "Arn",
           ],
         },
@@ -1059,26 +1059,26 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionAwsEventsLambdaInvokePermission15E0B8DA1": Object {
+    "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionAwsEventsLambdaInvokePermission19C6183E3": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunction49FE3A50",
+            "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunction761A16B3",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {
           "Fn::GetAtt": Array [
-            "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedEventsRule1751BCED",
+            "testexistingeventsrulelambdatestexistingeventsrulelambdaWEventsRuleEC7E86AC",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionServiceRole46509482": Object {
+    "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionServiceRoleBE7F5B75": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1133,7 +1133,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyE0D1CBFE": Object {
+    "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicy9D955941": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -1158,10 +1158,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyE0D1CBFE",
+        "PolicyName": "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicy9D955941",
         "Roles": Array [
           Object {
-            "Ref": "testexistingeventsrulelambdatestexistingeventsrulelambdawrappedLambdaFunctionServiceRole46509482",
+            "Ref": "testexistingeventsrulelambdatestexistingeventsrulelambdaWLambdaFunctionServiceRoleBE7F5B75",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/events-rule-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/events-rule-lambda.test.ts
@@ -65,7 +65,7 @@ test('check lambda function properties for deploy: true', () => {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10",
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB",
         "Arn"
       ]
     },
@@ -87,14 +87,14 @@ test('check lambda function permission for deploy: true', () => {
     Action: "lambda:InvokeFunction",
     FunctionName: {
       "Fn::GetAtt": [
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98",
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8",
         "Arn"
       ]
     },
     Principal: "events.amazonaws.com",
     SourceArn: {
       "Fn::GetAtt": [
-        "testeventsrulelambdatesteventsrulelambdawrappedEventsRuleC19DAE50",
+        "testeventsrulelambdatesteventsrulelambdaWEventsRule1B328BFB",
         "Arn"
       ]
     }
@@ -172,7 +172,7 @@ test('check events rule properties for deploy: true', () => {
       {
         Arn: {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8",
             "Arn"
           ]
         },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/integ.events-rule-no-argument.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/integ.events-rule-no-argument.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -55,7 +55,7 @@
         ]
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyF7B2C1E2": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyD705B722": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -71,10 +71,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyF7B2C1E2",
+        "PolicyName": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyD705B722",
         "Roles": [
           {
-            "Ref": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10"
+            "Ref": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB"
           }
         ]
       },
@@ -89,7 +89,7 @@
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -132,7 +132,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB",
             "Arn"
           ]
         },
@@ -148,8 +148,8 @@
         }
       },
       "DependsOn": [
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicyF7B2C1E2",
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRole9A954D10"
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyD705B722",
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleFF9B9BDB"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -170,26 +170,26 @@
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionAwsEventsLambdaInvokePermission15AD1F48C": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionAwsEventsLambdaInvokePermission135EE70F4": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8",
             "Arn"
           ]
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedEventsRuleC19DAE50",
+            "testeventsrulelambdatesteventsrulelambdaWEventsRule1B328BFB",
             "Arn"
           ]
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedEventsRuleC19DAE50": {
+    "testeventsrulelambdatesteventsrulelambdaWEventsRule1B328BFB": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -198,7 +198,7 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunction0635FA98",
+                "testeventsrulelambdatesteventsrulelambdaWLambdaFunction5EE557E8",
                 "Arn"
               ]
             },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/integ.eventsrule-existing-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/integ.eventsrule-existing-eventbus.expected.json
@@ -6,7 +6,7 @@
         "Name": "eventsruleexistingeventbusexistingeventbusD8C5305D"
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -61,7 +61,7 @@
         ]
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicy4F3DDE53": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyB1F1051B": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -77,10 +77,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicy4F3DDE53",
+        "PolicyName": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyB1F1051B",
         "Roles": [
           {
-            "Ref": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11"
+            "Ref": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77"
           }
         ]
       },
@@ -95,7 +95,7 @@
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionFF005E9A": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunction0DF4D5F7": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -138,7 +138,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77",
             "Arn"
           ]
         },
@@ -154,8 +154,8 @@
         }
       },
       "DependsOn": [
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicy4F3DDE53",
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11"
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyB1F1051B",
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -176,26 +176,26 @@
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionAwsEventsLambdaInvokePermission115E53C70": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionAwsEventsLambdaInvokePermission18E194D7B": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionFF005E9A",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunction0DF4D5F7",
             "Arn"
           ]
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedEventsRule3AC0B436",
+            "testeventsrulelambdatesteventsrulelambdaWEventsRule08BAF3CA",
             "Arn"
           ]
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedEventsRule3AC0B436": {
+    "testeventsrulelambdatesteventsrulelambdaWEventsRule08BAF3CA": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
@@ -211,7 +211,7 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionFF005E9A",
+                "testeventsrulelambdatesteventsrulelambdaWLambdaFunction0DF4D5F7",
                 "Arn"
               ]
             },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/integ.eventsrule-new-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/test/integ.eventsrule-new-eventbus.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -55,7 +55,7 @@
         ]
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicy4F3DDE53": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyB1F1051B": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -71,10 +71,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicy4F3DDE53",
+        "PolicyName": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyB1F1051B",
         "Roles": [
           {
-            "Ref": "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11"
+            "Ref": "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77"
           }
         ]
       },
@@ -89,7 +89,7 @@
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionFF005E9A": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunction0DF4D5F7": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -132,7 +132,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77",
             "Arn"
           ]
         },
@@ -148,8 +148,8 @@
         }
       },
       "DependsOn": [
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleDefaultPolicy4F3DDE53",
-        "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionServiceRoleD9BE1A11"
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRoleDefaultPolicyB1F1051B",
+        "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionServiceRole9CD42F77"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -170,36 +170,36 @@
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionAwsEventsLambdaInvokePermission115E53C70": {
+    "testeventsrulelambdatesteventsrulelambdaWLambdaFunctionAwsEventsLambdaInvokePermission18E194D7B": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionFF005E9A",
+            "testeventsrulelambdatesteventsrulelambdaWLambdaFunction0DF4D5F7",
             "Arn"
           ]
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "testeventsrulelambdatesteventsrulelambdawrappedEventsRule3AC0B436",
+            "testeventsrulelambdatesteventsrulelambdaWEventsRule08BAF3CA",
             "Arn"
           ]
         }
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedCustomEventBusBFE424DC": {
+    "testeventsrulelambdatesteventsrulelambdaWCustomEventBusB98BC01F": {
       "Type": "AWS::Events::EventBus",
       "Properties": {
-        "Name": "eventsruleneweventbustesteventsrulelambdatesteventsrulelambdawrappedCustomEventBusB88B29EA"
+        "Name": "eventsruleneweventbustesteventsrulelambdatesteventsrulelambdaWCustomEventBusDD753DF4"
       }
     },
-    "testeventsrulelambdatesteventsrulelambdawrappedEventsRule3AC0B436": {
+    "testeventsrulelambdatesteventsrulelambdaWEventsRule08BAF3CA": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
-          "Ref": "testeventsrulelambdatesteventsrulelambdawrappedCustomEventBusBFE424DC"
+          "Ref": "testeventsrulelambdatesteventsrulelambdaWCustomEventBusB98BC01F"
         },
         "EventPattern": {
           "source": [
@@ -211,7 +211,7 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testeventsrulelambdatesteventsrulelambdawrappedLambdaFunctionFF005E9A",
+                "testeventsrulelambdatesteventsrulelambdaWLambdaFunction0DF4D5F7",
                 "Arn"
               ]
             },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/lib/index.ts
@@ -86,6 +86,11 @@ export class EventsRuleToSns extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToSnsProps) {
     super(scope, id);
     const convertedProps: EventsRuleToSnsProps = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new EventbridgeToSns instead of EventsRuleToSns)
     const wrappedConstruct: EventsRuleToSns = new EventbridgeToSns(this, `${id}`, convertedProps);
 
     this.snsTopic = wrappedConstruct.snsTopic;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/lib/index.ts
@@ -91,7 +91,7 @@ export class EventsRuleToSns extends Construct {
     // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new EventbridgeToSns instead of EventsRuleToSns)
-    const wrappedConstruct: EventsRuleToSns = new EventbridgeToSns(this, `${id}`, convertedProps);
+    const wrappedConstruct: EventsRuleToSns = new EventbridgeToSns(this, `${id}W`, convertedProps);
 
     this.snsTopic = wrappedConstruct.snsTopic;
     this.eventsRule = wrappedConstruct.eventsRule;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/lib/index.ts
@@ -88,7 +88,7 @@ export class EventsRuleToSns extends Construct {
     const convertedProps: EventsRuleToSnsProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new EventbridgeToSns instead of EventsRuleToSns)
     const wrappedConstruct: EventsRuleToSns = new EventbridgeToSns(this, `${id}`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/__snapshots__/events-rule-sns-topic.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/__snapshots__/events-rule-sns-topic.test.js.snap
@@ -3,13 +3,13 @@
 exports[`check eventbus property, snapshot & eventbus exists 1`] = `
 Object {
   "Resources": Object {
-    "testneweventbusCustomEventBusF21A668A": Object {
+    "testneweventbustestneweventbusWCustomEventBusF2664EFE": Object {
       "Properties": Object {
-        "Name": "testneweventbusCustomEventBus409B4FB3",
+        "Name": "testneweventbustestneweventbusWCustomEventBus51480605",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventbusEncryptionKey72D74021": Object {
+    "testneweventbustestneweventbusWEncryptionKeyCEA853ED": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -74,10 +74,10 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventbusEventsRuleE82FDFD2": Object {
+    "testneweventbustestneweventbusWEventsRuleB426C87E": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventbusCustomEventBusF21A668A",
+          "Ref": "testneweventbustestneweventbusWCustomEventBusF2664EFE",
         },
         "EventPattern": Object {
           "source": Array [
@@ -88,11 +88,11 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testneweventbusSnsTopic14EFE30B",
+              "Ref": "testneweventbustestneweventbusWSnsTopic2702F6D7",
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testneweventbusSnsTopic14EFE30B",
+                "testneweventbustestneweventbusWSnsTopic2702F6D7",
                 "TopicName",
               ],
             },
@@ -101,18 +101,18 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventbusSnsTopic14EFE30B": Object {
+    "testneweventbustestneweventbusWSnsTopic2702F6D7": Object {
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testneweventbusEncryptionKey72D74021",
+            "testneweventbustestneweventbusWEncryptionKeyCEA853ED",
             "Arn",
           ],
         },
       },
       "Type": "AWS::SNS::Topic",
     },
-    "testneweventbusSnsTopicPolicyEF27265B": Object {
+    "testneweventbustestneweventbusWSnsTopicPolicyB728B045": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -155,7 +155,7 @@ Object {
                 },
               },
               "Resource": Object {
-                "Ref": "testneweventbusSnsTopic14EFE30B",
+                "Ref": "testneweventbustestneweventbusWSnsTopic2702F6D7",
               },
               "Sid": "TopicOwnerOnlyAccess",
             },
@@ -181,7 +181,7 @@ Object {
                 "AWS": "*",
               },
               "Resource": Object {
-                "Ref": "testneweventbusSnsTopic14EFE30B",
+                "Ref": "testneweventbustestneweventbusWSnsTopic2702F6D7",
               },
               "Sid": "HttpsOnly",
             },
@@ -192,7 +192,7 @@ Object {
                 "Service": "events.amazonaws.com",
               },
               "Resource": Object {
-                "Ref": "testneweventbusSnsTopic14EFE30B",
+                "Ref": "testneweventbustestneweventbusWSnsTopic2702F6D7",
               },
               "Sid": "2",
             },
@@ -201,7 +201,7 @@ Object {
         },
         "Topics": Array [
           Object {
-            "Ref": "testneweventbusSnsTopic14EFE30B",
+            "Ref": "testneweventbustestneweventbusWSnsTopic2702F6D7",
           },
         ],
       },
@@ -214,13 +214,13 @@ Object {
 exports[`check multiple constructs in a single stack 1`] = `
 Object {
   "Resources": Object {
-    "testneweventsrulesns1CustomEventBusCBCAE01E": Object {
+    "testneweventsrulesns1testneweventsrulesns1WCustomEventBus92059687": Object {
       "Properties": Object {
-        "Name": "testneweventsrulesns1CustomEventBus0B8BCDC1",
+        "Name": "testneweventsrulesns1testneweventsrulesns1WCustomEventBus3405BE4B",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulesns1EncryptionKey18930514": Object {
+    "testneweventsrulesns1testneweventsrulesns1WEncryptionKey897A7F56": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -285,10 +285,10 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulesns1EventsRule4902A7E2": Object {
+    "testneweventsrulesns1testneweventsrulesns1WEventsRule8D7B1276": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulesns1CustomEventBusCBCAE01E",
+          "Ref": "testneweventsrulesns1testneweventsrulesns1WCustomEventBus92059687",
         },
         "EventPattern": Object {
           "source": Array [
@@ -299,11 +299,11 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testneweventsrulesns1SnsTopicB5A4AB2B",
+              "Ref": "testneweventsrulesns1testneweventsrulesns1WSnsTopic5FA11EB4",
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulesns1SnsTopicB5A4AB2B",
+                "testneweventsrulesns1testneweventsrulesns1WSnsTopic5FA11EB4",
                 "TopicName",
               ],
             },
@@ -312,18 +312,18 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulesns1SnsTopicB5A4AB2B": Object {
+    "testneweventsrulesns1testneweventsrulesns1WSnsTopic5FA11EB4": Object {
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulesns1EncryptionKey18930514",
+            "testneweventsrulesns1testneweventsrulesns1WEncryptionKey897A7F56",
             "Arn",
           ],
         },
       },
       "Type": "AWS::SNS::Topic",
     },
-    "testneweventsrulesns1SnsTopicPolicyCC362F92": Object {
+    "testneweventsrulesns1testneweventsrulesns1WSnsTopicPolicy63BBE31D": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -366,7 +366,7 @@ Object {
                 },
               },
               "Resource": Object {
-                "Ref": "testneweventsrulesns1SnsTopicB5A4AB2B",
+                "Ref": "testneweventsrulesns1testneweventsrulesns1WSnsTopic5FA11EB4",
               },
               "Sid": "TopicOwnerOnlyAccess",
             },
@@ -392,7 +392,7 @@ Object {
                 "AWS": "*",
               },
               "Resource": Object {
-                "Ref": "testneweventsrulesns1SnsTopicB5A4AB2B",
+                "Ref": "testneweventsrulesns1testneweventsrulesns1WSnsTopic5FA11EB4",
               },
               "Sid": "HttpsOnly",
             },
@@ -403,7 +403,7 @@ Object {
                 "Service": "events.amazonaws.com",
               },
               "Resource": Object {
-                "Ref": "testneweventsrulesns1SnsTopicB5A4AB2B",
+                "Ref": "testneweventsrulesns1testneweventsrulesns1WSnsTopic5FA11EB4",
               },
               "Sid": "2",
             },
@@ -412,19 +412,19 @@ Object {
         },
         "Topics": Array [
           Object {
-            "Ref": "testneweventsrulesns1SnsTopicB5A4AB2B",
+            "Ref": "testneweventsrulesns1testneweventsrulesns1WSnsTopic5FA11EB4",
           },
         ],
       },
       "Type": "AWS::SNS::TopicPolicy",
     },
-    "testneweventsrulesns2CustomEventBus74F26858": Object {
+    "testneweventsrulesns2testneweventsrulesns2WCustomEventBus627A5C94": Object {
       "Properties": Object {
-        "Name": "testneweventsrulesns2CustomEventBus611E703F",
+        "Name": "testneweventsrulesns2testneweventsrulesns2WCustomEventBus7D2C1571",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulesns2EncryptionKey0DCA5BAD": Object {
+    "testneweventsrulesns2testneweventsrulesns2WEncryptionKey8192A4D6": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -489,10 +489,10 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulesns2EventsRule7219E266": Object {
+    "testneweventsrulesns2testneweventsrulesns2WEventsRule3B7FEBA5": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulesns2CustomEventBus74F26858",
+          "Ref": "testneweventsrulesns2testneweventsrulesns2WCustomEventBus627A5C94",
         },
         "EventPattern": Object {
           "source": Array [
@@ -503,11 +503,11 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testneweventsrulesns2SnsTopic92885429",
+              "Ref": "testneweventsrulesns2testneweventsrulesns2WSnsTopic40FFC103",
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulesns2SnsTopic92885429",
+                "testneweventsrulesns2testneweventsrulesns2WSnsTopic40FFC103",
                 "TopicName",
               ],
             },
@@ -516,18 +516,18 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulesns2SnsTopic92885429": Object {
+    "testneweventsrulesns2testneweventsrulesns2WSnsTopic40FFC103": Object {
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulesns2EncryptionKey0DCA5BAD",
+            "testneweventsrulesns2testneweventsrulesns2WEncryptionKey8192A4D6",
             "Arn",
           ],
         },
       },
       "Type": "AWS::SNS::Topic",
     },
-    "testneweventsrulesns2SnsTopicPolicyBB1D364F": Object {
+    "testneweventsrulesns2testneweventsrulesns2WSnsTopicPolicyBD757099": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -570,7 +570,7 @@ Object {
                 },
               },
               "Resource": Object {
-                "Ref": "testneweventsrulesns2SnsTopic92885429",
+                "Ref": "testneweventsrulesns2testneweventsrulesns2WSnsTopic40FFC103",
               },
               "Sid": "TopicOwnerOnlyAccess",
             },
@@ -596,7 +596,7 @@ Object {
                 "AWS": "*",
               },
               "Resource": Object {
-                "Ref": "testneweventsrulesns2SnsTopic92885429",
+                "Ref": "testneweventsrulesns2testneweventsrulesns2WSnsTopic40FFC103",
               },
               "Sid": "HttpsOnly",
             },
@@ -607,7 +607,7 @@ Object {
                 "Service": "events.amazonaws.com",
               },
               "Resource": Object {
-                "Ref": "testneweventsrulesns2SnsTopic92885429",
+                "Ref": "testneweventsrulesns2testneweventsrulesns2WSnsTopic40FFC103",
               },
               "Sid": "2",
             },
@@ -616,7 +616,7 @@ Object {
         },
         "Topics": Array [
           Object {
-            "Ref": "testneweventsrulesns2SnsTopic92885429",
+            "Ref": "testneweventsrulesns2testneweventsrulesns2WSnsTopic40FFC103",
           },
         ],
       },
@@ -629,7 +629,7 @@ Object {
 exports[`snapshot test EventsRuleToSns default params 1`] = `
 Object {
   "Resources": Object {
-    "testEncryptionKey7058DF17": Object {
+    "testtestWEncryptionKeyC6B126B6": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -694,18 +694,18 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testEventsRuleC345F4C7": Object {
+    "testtestWEventsRuleDF9938A8": Object {
       "Properties": Object {
         "ScheduleExpression": "rate(5 minutes)",
         "State": "ENABLED",
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testSnsTopic431DB510",
+              "Ref": "testtestWSnsTopicBFF33C41",
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testSnsTopic431DB510",
+                "testtestWSnsTopicBFF33C41",
                 "TopicName",
               ],
             },
@@ -714,18 +714,18 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testSnsTopic431DB510": Object {
+    "testtestWSnsTopicBFF33C41": Object {
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testEncryptionKey7058DF17",
+            "testtestWEncryptionKeyC6B126B6",
             "Arn",
           ],
         },
       },
       "Type": "AWS::SNS::Topic",
     },
-    "testSnsTopicPolicyC811A1C0": Object {
+    "testtestWSnsTopicPolicy2A17B1B5": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -768,7 +768,7 @@ Object {
                 },
               },
               "Resource": Object {
-                "Ref": "testSnsTopic431DB510",
+                "Ref": "testtestWSnsTopicBFF33C41",
               },
               "Sid": "TopicOwnerOnlyAccess",
             },
@@ -794,7 +794,7 @@ Object {
                 "AWS": "*",
               },
               "Resource": Object {
-                "Ref": "testSnsTopic431DB510",
+                "Ref": "testtestWSnsTopicBFF33C41",
               },
               "Sid": "HttpsOnly",
             },
@@ -805,7 +805,7 @@ Object {
                 "Service": "events.amazonaws.com",
               },
               "Resource": Object {
-                "Ref": "testSnsTopic431DB510",
+                "Ref": "testtestWSnsTopicBFF33C41",
               },
               "Sid": "2",
             },
@@ -814,7 +814,7 @@ Object {
         },
         "Topics": Array [
           Object {
-            "Ref": "testSnsTopic431DB510",
+            "Ref": "testtestWSnsTopicBFF33C41",
           },
         ],
       },
@@ -833,7 +833,7 @@ Object {
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testexistingeventsrulesnsEncryptionKey8D9FDAF3": Object {
+    "testexistingeventsrulesnstestexistingeventsrulesnsWEncryptionKeyA657F0B7": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -898,7 +898,7 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testexistingeventsrulesnsEventsRule77C1F4E3": Object {
+    "testexistingeventsrulesnstestexistingeventsrulesnsWEventsRuleC69BF9D5": Object {
       "Properties": Object {
         "EventBusName": Object {
           "Ref": "testexistingeventbusC6E4A2D0",
@@ -912,11 +912,11 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testexistingeventsrulesnsSnsTopicAB6B05AA",
+              "Ref": "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicB26AB7C3",
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulesnsSnsTopicAB6B05AA",
+                "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicB26AB7C3",
                 "TopicName",
               ],
             },
@@ -925,18 +925,18 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testexistingeventsrulesnsSnsTopicAB6B05AA": Object {
+    "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicB26AB7C3": Object {
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testexistingeventsrulesnsEncryptionKey8D9FDAF3",
+            "testexistingeventsrulesnstestexistingeventsrulesnsWEncryptionKeyA657F0B7",
             "Arn",
           ],
         },
       },
       "Type": "AWS::SNS::Topic",
     },
-    "testexistingeventsrulesnsSnsTopicPolicy8267187E": Object {
+    "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicPolicyF0C4F75A": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -979,7 +979,7 @@ Object {
                 },
               },
               "Resource": Object {
-                "Ref": "testexistingeventsrulesnsSnsTopicAB6B05AA",
+                "Ref": "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicB26AB7C3",
               },
               "Sid": "TopicOwnerOnlyAccess",
             },
@@ -1005,7 +1005,7 @@ Object {
                 "AWS": "*",
               },
               "Resource": Object {
-                "Ref": "testexistingeventsrulesnsSnsTopicAB6B05AA",
+                "Ref": "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicB26AB7C3",
               },
               "Sid": "HttpsOnly",
             },
@@ -1016,7 +1016,7 @@ Object {
                 "Service": "events.amazonaws.com",
               },
               "Resource": Object {
-                "Ref": "testexistingeventsrulesnsSnsTopicAB6B05AA",
+                "Ref": "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicB26AB7C3",
               },
               "Sid": "2",
             },
@@ -1025,7 +1025,7 @@ Object {
         },
         "Topics": Array [
           Object {
-            "Ref": "testexistingeventsrulesnsSnsTopicAB6B05AA",
+            "Ref": "testexistingeventsrulesnstestexistingeventsrulesnsWSnsTopicB26AB7C3",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/events-rule-sns-topic.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/events-rule-sns-topic.test.ts
@@ -90,7 +90,7 @@ test('check if the event rule has permission/policy in place in sns for it to be
             }
           },
           Resource: {
-            Ref: "testSnsTopic431DB510"
+            Ref: "testtestWSnsTopicBFF33C41"
           },
           Sid: "TopicOwnerOnlyAccess"
         },
@@ -116,7 +116,7 @@ test('check if the event rule has permission/policy in place in sns for it to be
             AWS: "*"
           },
           Resource: {
-            Ref: "testSnsTopic431DB510"
+            Ref: "testtestWSnsTopicBFF33C41"
           },
           Sid: "HttpsOnly"
         },
@@ -127,7 +127,7 @@ test('check if the event rule has permission/policy in place in sns for it to be
             Service: "events.amazonaws.com"
           },
           Resource: {
-            Ref: "testSnsTopic431DB510"
+            Ref: "testtestWSnsTopicBFF33C41"
           },
           Sid: "2"
         }
@@ -136,7 +136,7 @@ test('check if the event rule has permission/policy in place in sns for it to be
     },
     Topics: [
       {
-        Ref: "testSnsTopic431DB510"
+        Ref: "testtestWSnsTopicBFF33C41"
       }
     ]
   }
@@ -153,11 +153,11 @@ test('check events rule properties', () => {
     Targets: [
       {
         Arn: {
-          Ref: "testSnsTopic431DB510"
+          Ref: "testtestWSnsTopicBFF33C41"
         },
         Id: {
           "Fn::GetAtt": [
-            "testSnsTopic431DB510",
+            "testtestWSnsTopicBFF33C41",
             "TopicName"
           ]
         }
@@ -181,7 +181,7 @@ test('check the sns topic properties', () => {
   expect(stack).toHaveResource('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
-        "testEncryptionKey7058DF17",
+        "testtestWEncryptionKeyC6B126B6",
         "Arn"
       ]
     }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.events-rule-no-arg.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.events-rule-no-arg.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "testEncryptionKey7058DF17": {
+    "testtestWEncryptionKeyC6B126B6": {
       "Type": "AWS::KMS::Key",
       "Properties": {
         "KeyPolicy": {
@@ -65,18 +65,18 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testSnsTopic431DB510": {
+    "testtestWSnsTopicBFF33C41": {
       "Type": "AWS::SNS::Topic",
       "Properties": {
         "KmsMasterKeyId": {
           "Fn::GetAtt": [
-            "testEncryptionKey7058DF17",
+            "testtestWEncryptionKeyC6B126B6",
             "Arn"
           ]
         }
       }
     },
-    "testSnsTopicPolicyC811A1C0": {
+    "testtestWSnsTopicPolicy2A17B1B5": {
       "Type": "AWS::SNS::TopicPolicy",
       "Properties": {
         "PolicyDocument": {
@@ -120,7 +120,7 @@
                 }
               },
               "Resource": {
-                "Ref": "testSnsTopic431DB510"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "TopicOwnerOnlyAccess"
             },
@@ -146,7 +146,7 @@
                 "AWS": "*"
               },
               "Resource": {
-                "Ref": "testSnsTopic431DB510"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "HttpsOnly"
             },
@@ -157,7 +157,7 @@
                 "Service": "events.amazonaws.com"
               },
               "Resource": {
-                "Ref": "testSnsTopic431DB510"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "2"
             }
@@ -166,12 +166,12 @@
         },
         "Topics": [
           {
-            "Ref": "testSnsTopic431DB510"
+            "Ref": "testtestWSnsTopicBFF33C41"
           }
         ]
       }
     },
-    "testEventsRuleC345F4C7": {
+    "testtestWEventsRuleDF9938A8": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -179,11 +179,11 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testSnsTopic431DB510"
+              "Ref": "testtestWSnsTopicBFF33C41"
             },
             "Id": {
               "Fn::GetAtt": [
-                "testSnsTopic431DB510",
+                "testtestWSnsTopicBFF33C41",
                 "TopicName"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.existing-bus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.existing-bus.expected.json
@@ -1,6 +1,12 @@
 {
   "Resources": {
-    "testconstructEncryptionKey23843722": {
+    "eventbus7CF8FDD5": {
+      "Type": "AWS::Events::EventBus",
+      "Properties": {
+        "Name": "existingbuseventbus9E470DE7"
+      }
+    },
+    "testtestWEncryptionKeyC6B126B6": {
       "Type": "AWS::KMS::Key",
       "Properties": {
         "KeyPolicy": {
@@ -65,18 +71,18 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testconstructSnsTopicAFB80A41": {
+    "testtestWSnsTopicBFF33C41": {
       "Type": "AWS::SNS::Topic",
       "Properties": {
         "KmsMasterKeyId": {
           "Fn::GetAtt": [
-            "testconstructEncryptionKey23843722",
+            "testtestWEncryptionKeyC6B126B6",
             "Arn"
           ]
         }
       }
     },
-    "testconstructSnsTopicPolicy4586B2D8": {
+    "testtestWSnsTopicPolicy2A17B1B5": {
       "Type": "AWS::SNS::TopicPolicy",
       "Properties": {
         "PolicyDocument": {
@@ -120,7 +126,7 @@
                 }
               },
               "Resource": {
-                "Ref": "testconstructSnsTopicAFB80A41"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "TopicOwnerOnlyAccess"
             },
@@ -146,7 +152,7 @@
                 "AWS": "*"
               },
               "Resource": {
-                "Ref": "testconstructSnsTopicAFB80A41"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "HttpsOnly"
             },
@@ -157,7 +163,7 @@
                 "Service": "events.amazonaws.com"
               },
               "Resource": {
-                "Ref": "testconstructSnsTopicAFB80A41"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "2"
             }
@@ -166,22 +172,16 @@
         },
         "Topics": [
           {
-            "Ref": "testconstructSnsTopicAFB80A41"
+            "Ref": "testtestWSnsTopicBFF33C41"
           }
         ]
       }
     },
-    "testconstructCustomEventBusABE87E7D": {
-      "Type": "AWS::Events::EventBus",
-      "Properties": {
-        "Name": "ernewbustestconstructCustomEventBus2040FED1"
-      }
-    },
-    "testconstructEventsRule1A3EDF9D": {
+    "testtestWEventsRuleDF9938A8": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
-          "Ref": "testconstructCustomEventBusABE87E7D"
+          "Ref": "eventbus7CF8FDD5"
         },
         "EventPattern": {
           "source": [
@@ -192,11 +192,11 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testconstructSnsTopicAFB80A41"
+              "Ref": "testtestWSnsTopicBFF33C41"
             },
             "Id": {
               "Fn::GetAtt": [
-                "testconstructSnsTopicAFB80A41",
+                "testtestWSnsTopicBFF33C41",
                 "TopicName"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.existing-bus.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.existing-bus.ts
@@ -12,21 +12,23 @@
  */
 
 import { EventsRuleToSns, EventsRuleToSnsProps } from '../lib';
+import * as events from '@aws-cdk/aws-events';
 import { App, Stack } from '@aws-cdk/core';
 import { generateIntegStackName } from '@aws-solutions-constructs/core';
 
 const app = new App();
 const stack = new Stack(app, generateIntegStackName(__filename));
-
+// Create existing custom EventBus
+const existingEventBus = new events.EventBus(stack, `event-bus`, {});
 const props: EventsRuleToSnsProps = {
   eventRuleProps: {
     eventPattern: {
       source: ['solutionsconstructs']
     }
   },
-  eventBusProps: {} // Pass props to create new custom EventBus
+  existingEventBusInterface: existingEventBus
 };
 
-new EventsRuleToSns(stack, 'test-construct', props);
+new EventsRuleToSns(stack, 'test', props);
 
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.new-bus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.new-bus.expected.json
@@ -1,12 +1,6 @@
 {
   "Resources": {
-    "existingeventbusA5B80487": {
-      "Type": "AWS::Events::EventBus",
-      "Properties": {
-        "Name": "erexistingbusexistingeventbus09054BD4"
-      }
-    },
-    "testconstructEncryptionKey23843722": {
+    "testtestWEncryptionKeyC6B126B6": {
       "Type": "AWS::KMS::Key",
       "Properties": {
         "KeyPolicy": {
@@ -71,18 +65,18 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testconstructSnsTopicAFB80A41": {
+    "testtestWSnsTopicBFF33C41": {
       "Type": "AWS::SNS::Topic",
       "Properties": {
         "KmsMasterKeyId": {
           "Fn::GetAtt": [
-            "testconstructEncryptionKey23843722",
+            "testtestWEncryptionKeyC6B126B6",
             "Arn"
           ]
         }
       }
     },
-    "testconstructSnsTopicPolicy4586B2D8": {
+    "testtestWSnsTopicPolicy2A17B1B5": {
       "Type": "AWS::SNS::TopicPolicy",
       "Properties": {
         "PolicyDocument": {
@@ -126,7 +120,7 @@
                 }
               },
               "Resource": {
-                "Ref": "testconstructSnsTopicAFB80A41"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "TopicOwnerOnlyAccess"
             },
@@ -152,7 +146,7 @@
                 "AWS": "*"
               },
               "Resource": {
-                "Ref": "testconstructSnsTopicAFB80A41"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "HttpsOnly"
             },
@@ -163,7 +157,7 @@
                 "Service": "events.amazonaws.com"
               },
               "Resource": {
-                "Ref": "testconstructSnsTopicAFB80A41"
+                "Ref": "testtestWSnsTopicBFF33C41"
               },
               "Sid": "2"
             }
@@ -172,16 +166,22 @@
         },
         "Topics": [
           {
-            "Ref": "testconstructSnsTopicAFB80A41"
+            "Ref": "testtestWSnsTopicBFF33C41"
           }
         ]
       }
     },
-    "testconstructEventsRule1A3EDF9D": {
+    "testtestWCustomEventBus372F1AD4": {
+      "Type": "AWS::Events::EventBus",
+      "Properties": {
+        "Name": "newbustesttestWCustomEventBusB6F6BBD3"
+      }
+    },
+    "testtestWEventsRuleDF9938A8": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
-          "Ref": "existingeventbusA5B80487"
+          "Ref": "testtestWCustomEventBus372F1AD4"
         },
         "EventPattern": {
           "source": [
@@ -192,11 +192,11 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testconstructSnsTopicAFB80A41"
+              "Ref": "testtestWSnsTopicBFF33C41"
             },
             "Id": {
               "Fn::GetAtt": [
-                "testconstructSnsTopicAFB80A41",
+                "testtestWSnsTopicBFF33C41",
                 "TopicName"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.new-bus.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sns/test/integ.new-bus.ts
@@ -12,23 +12,21 @@
  */
 
 import { EventsRuleToSns, EventsRuleToSnsProps } from '../lib';
-import * as events from '@aws-cdk/aws-events';
 import { App, Stack } from '@aws-cdk/core';
 import { generateIntegStackName } from '@aws-solutions-constructs/core';
 
 const app = new App();
 const stack = new Stack(app, generateIntegStackName(__filename));
-// Create existing custom EventBus
-const existingEventBus = new events.EventBus(stack, `existing-event-bus`, {});
+
 const props: EventsRuleToSnsProps = {
   eventRuleProps: {
     eventPattern: {
       source: ['solutionsconstructs']
     }
   },
-  existingEventBusInterface: existingEventBus
+  eventBusProps: {} // Pass props to create new custom EventBus
 };
 
-new EventsRuleToSns(stack, 'test-construct', props);
+new EventsRuleToSns(stack, 'test', props);
 
 app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/lib/index.ts
@@ -115,6 +115,11 @@ export class EventsRuleToSqs extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToSqsProps) {
     super(scope, id);
     const convertedProps: EventsRuleToSqsProps = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new EventbridgeToSqs instead of EventsRuleToSqs)
     const wrappedConstruct: EventsRuleToSqs = new EventbridgeToSqs(this, `${id}W`, convertedProps);
 
     this.sqsQueue = wrappedConstruct.sqsQueue;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/lib/index.ts
@@ -117,7 +117,7 @@ export class EventsRuleToSqs extends Construct {
     const convertedProps: EventsRuleToSqsProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new EventbridgeToSqs instead of EventsRuleToSqs)
     const wrappedConstruct: EventsRuleToSqs = new EventbridgeToSqs(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/lib/index.ts
@@ -115,7 +115,7 @@ export class EventsRuleToSqs extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToSqsProps) {
     super(scope, id);
     const convertedProps: EventsRuleToSqsProps = { ...props };
-    const wrappedConstruct: EventsRuleToSqs = new EventbridgeToSqs(this, `${id}-wrapped`, convertedProps);
+    const wrappedConstruct: EventsRuleToSqs = new EventbridgeToSqs(this, `${id}W`, convertedProps);
 
     this.sqsQueue = wrappedConstruct.sqsQueue;
     this.deadLetterQueue = wrappedConstruct.deadLetterQueue;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/__snapshots__/events-rule-sqs-queue.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/__snapshots__/events-rule-sqs-queue.test.js.snap
@@ -3,13 +3,13 @@
 exports[`check eventbus property, snapshot & eventbus exists 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedCustomEventBus29FCEF5E": Object {
+    "testeventsrulesqsnewbustesteventsrulesqsnewbusWCustomEventBus36EDC929": Object {
       "Properties": Object {
-        "Name": "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedCustomEventBus7A98350A",
+        "Name": "testeventsrulesqsnewbustesteventsrulesqsnewbusWCustomEventBus20358A3F",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedEncryptionKeyF5E6BEBF": Object {
+    "testeventsrulesqsnewbustesteventsrulesqsnewbusWEncryptionKey35D0A000": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -74,10 +74,10 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedEventsRule06176ECD": Object {
+    "testeventsrulesqsnewbustesteventsrulesqsnewbusWEventsRule5EA2E0A7": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedCustomEventBus29FCEF5E",
+          "Ref": "testeventsrulesqsnewbustesteventsrulesqsnewbusWCustomEventBus36EDC929",
         },
         "EventPattern": Object {
           "source": Array [
@@ -89,13 +89,13 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueue9D5164C2",
+                "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueue210AA2B8",
                 "Arn",
               ],
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueue9D5164C2",
+                "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueue210AA2B8",
                 "QueueName",
               ],
             },
@@ -104,7 +104,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappeddeadLetterQueue1A7A6517": Object {
+    "testeventsrulesqsnewbustesteventsrulesqsnewbusWdeadLetterQueueFA2AF8C1": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": "alias/aws/sqs",
@@ -112,7 +112,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappeddeadLetterQueuePolicy975CA53B": Object {
+    "testeventsrulesqsnewbustesteventsrulesqsnewbusWdeadLetterQueuePolicy16B47C96": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -147,7 +147,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappeddeadLetterQueue1A7A6517",
+                  "testeventsrulesqsnewbustesteventsrulesqsnewbusWdeadLetterQueueFA2AF8C1",
                   "Arn",
                 ],
               },
@@ -166,7 +166,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappeddeadLetterQueue1A7A6517",
+                  "testeventsrulesqsnewbustesteventsrulesqsnewbusWdeadLetterQueueFA2AF8C1",
                   "Arn",
                 ],
               },
@@ -177,25 +177,25 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappeddeadLetterQueue1A7A6517",
+            "Ref": "testeventsrulesqsnewbustesteventsrulesqsnewbusWdeadLetterQueueFA2AF8C1",
           },
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueue9D5164C2": Object {
+    "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueue210AA2B8": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedEncryptionKeyF5E6BEBF",
+            "testeventsrulesqsnewbustesteventsrulesqsnewbusWEncryptionKey35D0A000",
             "Arn",
           ],
         },
         "RedrivePolicy": Object {
           "deadLetterTargetArn": Object {
             "Fn::GetAtt": Array [
-              "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappeddeadLetterQueue1A7A6517",
+              "testeventsrulesqsnewbustesteventsrulesqsnewbusWdeadLetterQueueFA2AF8C1",
               "Arn",
             ],
           },
@@ -205,7 +205,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueuePolicyDFD135EE": Object {
+    "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueuePolicy93F3F8EF": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -240,7 +240,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueue9D5164C2",
+                  "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueue210AA2B8",
                   "Arn",
                 ],
               },
@@ -259,7 +259,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueue9D5164C2",
+                  "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueue210AA2B8",
                   "Arn",
                 ],
               },
@@ -277,7 +277,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueue9D5164C2",
+                  "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueue210AA2B8",
                   "Arn",
                 ],
               },
@@ -287,7 +287,7 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testeventsrulesqsnewbustesteventsrulesqsnewbuswrappedqueue9D5164C2",
+            "Ref": "testeventsrulesqsnewbustesteventsrulesqsnewbusWqueue210AA2B8",
           },
         ],
       },
@@ -300,13 +300,13 @@ Object {
 exports[`check multiple constructs in a single stack 1`] = `
 Object {
   "Resources": Object {
-    "testneweventsrulesqs1testneweventsrulesqs1wrappedCustomEventBus9D02CFA6": Object {
+    "testneweventsrulesqs1testneweventsrulesqs1WCustomEventBusB554EC44": Object {
       "Properties": Object {
-        "Name": "testneweventsrulesqs1testneweventsrulesqs1wrappedCustomEventBusEC6121F4",
+        "Name": "testneweventsrulesqs1testneweventsrulesqs1WCustomEventBusBFC0396B",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulesqs1testneweventsrulesqs1wrappedEncryptionKey863D30E3": Object {
+    "testneweventsrulesqs1testneweventsrulesqs1WEncryptionKeyE1E6195E": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -371,10 +371,10 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulesqs1testneweventsrulesqs1wrappedEventsRule016672B3": Object {
+    "testneweventsrulesqs1testneweventsrulesqs1WEventsRule2830870B": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulesqs1testneweventsrulesqs1wrappedCustomEventBus9D02CFA6",
+          "Ref": "testneweventsrulesqs1testneweventsrulesqs1WCustomEventBusB554EC44",
         },
         "EventPattern": Object {
           "source": Array [
@@ -386,13 +386,13 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulesqs1testneweventsrulesqs1wrappedqueueD6E123E2",
+                "testneweventsrulesqs1testneweventsrulesqs1WqueueFC4AA923",
                 "Arn",
               ],
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulesqs1testneweventsrulesqs1wrappedqueueD6E123E2",
+                "testneweventsrulesqs1testneweventsrulesqs1WqueueFC4AA923",
                 "QueueName",
               ],
             },
@@ -401,7 +401,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulesqs1testneweventsrulesqs1wrappeddeadLetterQueueDBE8CACA": Object {
+    "testneweventsrulesqs1testneweventsrulesqs1WdeadLetterQueueDD243050": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": "alias/aws/sqs",
@@ -409,7 +409,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testneweventsrulesqs1testneweventsrulesqs1wrappeddeadLetterQueuePolicy420A14F0": Object {
+    "testneweventsrulesqs1testneweventsrulesqs1WdeadLetterQueuePolicyE9629A27": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -444,7 +444,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs1testneweventsrulesqs1wrappeddeadLetterQueueDBE8CACA",
+                  "testneweventsrulesqs1testneweventsrulesqs1WdeadLetterQueueDD243050",
                   "Arn",
                 ],
               },
@@ -463,7 +463,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs1testneweventsrulesqs1wrappeddeadLetterQueueDBE8CACA",
+                  "testneweventsrulesqs1testneweventsrulesqs1WdeadLetterQueueDD243050",
                   "Arn",
                 ],
               },
@@ -474,25 +474,25 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testneweventsrulesqs1testneweventsrulesqs1wrappeddeadLetterQueueDBE8CACA",
+            "Ref": "testneweventsrulesqs1testneweventsrulesqs1WdeadLetterQueueDD243050",
           },
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "testneweventsrulesqs1testneweventsrulesqs1wrappedqueueD6E123E2": Object {
+    "testneweventsrulesqs1testneweventsrulesqs1WqueueFC4AA923": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulesqs1testneweventsrulesqs1wrappedEncryptionKey863D30E3",
+            "testneweventsrulesqs1testneweventsrulesqs1WEncryptionKeyE1E6195E",
             "Arn",
           ],
         },
         "RedrivePolicy": Object {
           "deadLetterTargetArn": Object {
             "Fn::GetAtt": Array [
-              "testneweventsrulesqs1testneweventsrulesqs1wrappeddeadLetterQueueDBE8CACA",
+              "testneweventsrulesqs1testneweventsrulesqs1WdeadLetterQueueDD243050",
               "Arn",
             ],
           },
@@ -502,7 +502,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testneweventsrulesqs1testneweventsrulesqs1wrappedqueuePolicy8D992E2C": Object {
+    "testneweventsrulesqs1testneweventsrulesqs1WqueuePolicy420A5BF4": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -537,7 +537,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs1testneweventsrulesqs1wrappedqueueD6E123E2",
+                  "testneweventsrulesqs1testneweventsrulesqs1WqueueFC4AA923",
                   "Arn",
                 ],
               },
@@ -556,7 +556,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs1testneweventsrulesqs1wrappedqueueD6E123E2",
+                  "testneweventsrulesqs1testneweventsrulesqs1WqueueFC4AA923",
                   "Arn",
                 ],
               },
@@ -574,7 +574,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs1testneweventsrulesqs1wrappedqueueD6E123E2",
+                  "testneweventsrulesqs1testneweventsrulesqs1WqueueFC4AA923",
                   "Arn",
                 ],
               },
@@ -584,19 +584,19 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testneweventsrulesqs1testneweventsrulesqs1wrappedqueueD6E123E2",
+            "Ref": "testneweventsrulesqs1testneweventsrulesqs1WqueueFC4AA923",
           },
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "testneweventsrulesqs2testneweventsrulesqs2wrappedCustomEventBusA8D31D69": Object {
+    "testneweventsrulesqs2testneweventsrulesqs2WCustomEventBusC4846389": Object {
       "Properties": Object {
-        "Name": "testneweventsrulesqs2testneweventsrulesqs2wrappedCustomEventBusA0895C25",
+        "Name": "testneweventsrulesqs2testneweventsrulesqs2WCustomEventBus3B4DC433",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulesqs2testneweventsrulesqs2wrappedEncryptionKeyE63D6087": Object {
+    "testneweventsrulesqs2testneweventsrulesqs2WEncryptionKey2A055286": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -661,10 +661,10 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulesqs2testneweventsrulesqs2wrappedEventsRule2C8B47C2": Object {
+    "testneweventsrulesqs2testneweventsrulesqs2WEventsRuleC179CF04": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulesqs2testneweventsrulesqs2wrappedCustomEventBusA8D31D69",
+          "Ref": "testneweventsrulesqs2testneweventsrulesqs2WCustomEventBusC4846389",
         },
         "EventPattern": Object {
           "source": Array [
@@ -676,13 +676,13 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulesqs2testneweventsrulesqs2wrappedqueue8496F5CD",
+                "testneweventsrulesqs2testneweventsrulesqs2Wqueue129496E7",
                 "Arn",
               ],
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulesqs2testneweventsrulesqs2wrappedqueue8496F5CD",
+                "testneweventsrulesqs2testneweventsrulesqs2Wqueue129496E7",
                 "QueueName",
               ],
             },
@@ -691,7 +691,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulesqs2testneweventsrulesqs2wrappeddeadLetterQueueA3699350": Object {
+    "testneweventsrulesqs2testneweventsrulesqs2WdeadLetterQueue6F02DB90": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": "alias/aws/sqs",
@@ -699,7 +699,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testneweventsrulesqs2testneweventsrulesqs2wrappeddeadLetterQueuePolicyB13FA08A": Object {
+    "testneweventsrulesqs2testneweventsrulesqs2WdeadLetterQueuePolicyF7263C45": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -734,7 +734,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs2testneweventsrulesqs2wrappeddeadLetterQueueA3699350",
+                  "testneweventsrulesqs2testneweventsrulesqs2WdeadLetterQueue6F02DB90",
                   "Arn",
                 ],
               },
@@ -753,7 +753,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs2testneweventsrulesqs2wrappeddeadLetterQueueA3699350",
+                  "testneweventsrulesqs2testneweventsrulesqs2WdeadLetterQueue6F02DB90",
                   "Arn",
                 ],
               },
@@ -764,25 +764,25 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testneweventsrulesqs2testneweventsrulesqs2wrappeddeadLetterQueueA3699350",
+            "Ref": "testneweventsrulesqs2testneweventsrulesqs2WdeadLetterQueue6F02DB90",
           },
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "testneweventsrulesqs2testneweventsrulesqs2wrappedqueue8496F5CD": Object {
+    "testneweventsrulesqs2testneweventsrulesqs2Wqueue129496E7": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulesqs2testneweventsrulesqs2wrappedEncryptionKeyE63D6087",
+            "testneweventsrulesqs2testneweventsrulesqs2WEncryptionKey2A055286",
             "Arn",
           ],
         },
         "RedrivePolicy": Object {
           "deadLetterTargetArn": Object {
             "Fn::GetAtt": Array [
-              "testneweventsrulesqs2testneweventsrulesqs2wrappeddeadLetterQueueA3699350",
+              "testneweventsrulesqs2testneweventsrulesqs2WdeadLetterQueue6F02DB90",
               "Arn",
             ],
           },
@@ -792,7 +792,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testneweventsrulesqs2testneweventsrulesqs2wrappedqueuePolicy74546DC4": Object {
+    "testneweventsrulesqs2testneweventsrulesqs2WqueuePolicy23E89E2B": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -827,7 +827,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs2testneweventsrulesqs2wrappedqueue8496F5CD",
+                  "testneweventsrulesqs2testneweventsrulesqs2Wqueue129496E7",
                   "Arn",
                 ],
               },
@@ -846,7 +846,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs2testneweventsrulesqs2wrappedqueue8496F5CD",
+                  "testneweventsrulesqs2testneweventsrulesqs2Wqueue129496E7",
                   "Arn",
                 ],
               },
@@ -864,7 +864,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testneweventsrulesqs2testneweventsrulesqs2wrappedqueue8496F5CD",
+                  "testneweventsrulesqs2testneweventsrulesqs2Wqueue129496E7",
                   "Arn",
                 ],
               },
@@ -874,7 +874,7 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testneweventsrulesqs2testneweventsrulesqs2wrappedqueue8496F5CD",
+            "Ref": "testneweventsrulesqs2testneweventsrulesqs2Wqueue129496E7",
           },
         ],
       },
@@ -887,7 +887,7 @@ Object {
 exports[`snapshot test EventsRuleToSqs default params 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulesqstesteventsrulesqswrappedEncryptionKey55835B42": Object {
+    "testeventsrulesqstesteventsrulesqsWEncryptionKey59B6B2A9": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -952,7 +952,7 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulesqstesteventsrulesqswrappedEventsRuleC8FC3158": Object {
+    "testeventsrulesqstesteventsrulesqsWEventsRuleC50FD0CC": Object {
       "Properties": Object {
         "ScheduleExpression": "rate(5 minutes)",
         "State": "ENABLED",
@@ -960,13 +960,13 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+                "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
                 "Arn",
               ],
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+                "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
                 "QueueName",
               ],
             },
@@ -975,7 +975,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7": Object {
+    "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": "alias/aws/sqs",
@@ -983,7 +983,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueuePolicy543CB683": Object {
+    "testeventsrulesqstesteventsrulesqsWdeadLetterQueuePolicyCE8DDEE8": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1018,7 +1018,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+                  "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
                   "Arn",
                 ],
               },
@@ -1037,7 +1037,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+                  "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
                   "Arn",
                 ],
               },
@@ -1048,25 +1048,25 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+            "Ref": "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
           },
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B": Object {
+    "testeventsrulesqstesteventsrulesqsWqueue0E3B047B": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testeventsrulesqstesteventsrulesqswrappedEncryptionKey55835B42",
+            "testeventsrulesqstesteventsrulesqsWEncryptionKey59B6B2A9",
             "Arn",
           ],
         },
         "RedrivePolicy": Object {
           "deadLetterTargetArn": Object {
             "Fn::GetAtt": Array [
-              "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+              "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
               "Arn",
             ],
           },
@@ -1076,7 +1076,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testeventsrulesqstesteventsrulesqswrappedqueuePolicy8E19BB24": Object {
+    "testeventsrulesqstesteventsrulesqsWqueuePolicyD4F6F330": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1111,7 +1111,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+                  "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
                   "Arn",
                 ],
               },
@@ -1130,7 +1130,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+                  "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
                   "Arn",
                 ],
               },
@@ -1148,7 +1148,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+                  "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
                   "Arn",
                 ],
               },
@@ -1158,7 +1158,7 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+            "Ref": "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
           },
         ],
       },
@@ -1177,7 +1177,7 @@ Object {
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testexistingeventsrulesqstestexistingeventsrulesqswrappedEncryptionKeyF56A8317": Object {
+    "testexistingeventsrulesqstestexistingeventsrulesqsWEncryptionKey1C1F8ECD": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "EnableKeyRotation": true,
@@ -1242,7 +1242,7 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Retain",
     },
-    "testexistingeventsrulesqstestexistingeventsrulesqswrappedEventsRuleD53151C0": Object {
+    "testexistingeventsrulesqstestexistingeventsrulesqsWEventsRuleC773C4FF": Object {
       "Properties": Object {
         "EventBusName": Object {
           "Ref": "testexistingeventbusC6E4A2D0",
@@ -1257,13 +1257,13 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueue2D3A6826",
+                "testexistingeventsrulesqstestexistingeventsrulesqsWqueue288A816F",
                 "Arn",
               ],
             },
             "Id": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueue2D3A6826",
+                "testexistingeventsrulesqstestexistingeventsrulesqsWqueue288A816F",
                 "QueueName",
               ],
             },
@@ -1272,7 +1272,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testexistingeventsrulesqstestexistingeventsrulesqswrappeddeadLetterQueueE2FC125B": Object {
+    "testexistingeventsrulesqstestexistingeventsrulesqsWdeadLetterQueue781BE9BC": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": "alias/aws/sqs",
@@ -1280,7 +1280,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testexistingeventsrulesqstestexistingeventsrulesqswrappeddeadLetterQueuePolicy481EEFB5": Object {
+    "testexistingeventsrulesqstestexistingeventsrulesqsWdeadLetterQueuePolicy7068A9EE": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1315,7 +1315,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testexistingeventsrulesqstestexistingeventsrulesqswrappeddeadLetterQueueE2FC125B",
+                  "testexistingeventsrulesqstestexistingeventsrulesqsWdeadLetterQueue781BE9BC",
                   "Arn",
                 ],
               },
@@ -1334,7 +1334,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testexistingeventsrulesqstestexistingeventsrulesqswrappeddeadLetterQueueE2FC125B",
+                  "testexistingeventsrulesqstestexistingeventsrulesqsWdeadLetterQueue781BE9BC",
                   "Arn",
                 ],
               },
@@ -1345,25 +1345,25 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testexistingeventsrulesqstestexistingeventsrulesqswrappeddeadLetterQueueE2FC125B",
+            "Ref": "testexistingeventsrulesqstestexistingeventsrulesqsWdeadLetterQueue781BE9BC",
           },
         ],
       },
       "Type": "AWS::SQS::QueuePolicy",
     },
-    "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueue2D3A6826": Object {
+    "testexistingeventsrulesqstestexistingeventsrulesqsWqueue288A816F": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "KmsMasterKeyId": Object {
           "Fn::GetAtt": Array [
-            "testexistingeventsrulesqstestexistingeventsrulesqswrappedEncryptionKeyF56A8317",
+            "testexistingeventsrulesqstestexistingeventsrulesqsWEncryptionKey1C1F8ECD",
             "Arn",
           ],
         },
         "RedrivePolicy": Object {
           "deadLetterTargetArn": Object {
             "Fn::GetAtt": Array [
-              "testexistingeventsrulesqstestexistingeventsrulesqswrappeddeadLetterQueueE2FC125B",
+              "testexistingeventsrulesqstestexistingeventsrulesqsWdeadLetterQueue781BE9BC",
               "Arn",
             ],
           },
@@ -1373,7 +1373,7 @@ Object {
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueuePolicy181CF4C8": Object {
+    "testexistingeventsrulesqstestexistingeventsrulesqsWqueuePolicyF5486A18": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1408,7 +1408,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueue2D3A6826",
+                  "testexistingeventsrulesqstestexistingeventsrulesqsWqueue288A816F",
                   "Arn",
                 ],
               },
@@ -1427,7 +1427,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueue2D3A6826",
+                  "testexistingeventsrulesqstestexistingeventsrulesqsWqueue288A816F",
                   "Arn",
                 ],
               },
@@ -1445,7 +1445,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueue2D3A6826",
+                  "testexistingeventsrulesqstestexistingeventsrulesqsWqueue288A816F",
                   "Arn",
                 ],
               },
@@ -1455,7 +1455,7 @@ Object {
         },
         "Queues": Array [
           Object {
-            "Ref": "testexistingeventsrulesqstestexistingeventsrulesqswrappedqueue2D3A6826",
+            "Ref": "testexistingeventsrulesqstestexistingeventsrulesqsWqueue288A816F",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/events-rule-sqs-queue.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/events-rule-sqs-queue.test.ts
@@ -51,14 +51,14 @@ test('check the sqs queue properties', () => {
   expect(stack).toHaveResource('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
-        "testeventsrulesqstesteventsrulesqswrappedEncryptionKey55835B42",
+        "testeventsrulesqstesteventsrulesqsWEncryptionKey59B6B2A9",
         "Arn"
       ]
     },
     RedrivePolicy: {
       deadLetterTargetArn: {
         "Fn::GetAtt": [
-          "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+          "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
           "Arn"
         ]
       },
@@ -92,7 +92,7 @@ test('check the sqs queue properties with existing KMS key', () => {
     RedrivePolicy: {
       deadLetterTargetArn: {
         "Fn::GetAtt": [
-          "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+          "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
           "Arn"
         ]
       },
@@ -200,7 +200,7 @@ test('check if the event rule has permission/policy in place in sqs queue for it
           },
           Resource:  {
             "Fn::GetAtt": [
-              "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+              "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
               "Arn",
             ],
           },
@@ -219,7 +219,7 @@ test('check if the event rule has permission/policy in place in sqs queue for it
           },
           Resource:  {
             "Fn::GetAtt": [
-              "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+              "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
               "Arn",
             ],
           },
@@ -237,7 +237,7 @@ test('check if the event rule has permission/policy in place in sqs queue for it
           },
           Resource: {
             "Fn::GetAtt": [
-              "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+              "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
               "Arn"
             ]
           }
@@ -247,7 +247,7 @@ test('check if the event rule has permission/policy in place in sqs queue for it
     },
     Queues: [
       {
-        Ref: "testeventsrulesqstesteventsrulesqswrappedqueue3820F81B",
+        Ref: "testeventsrulesqstesteventsrulesqsWqueue0E3B047B",
       }
     ]
   });
@@ -290,7 +290,7 @@ test('check if the dead letter queue policy is setup', () => {
           },
           Resource:  {
             "Fn::GetAtt": [
-              "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+              "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
               "Arn",
             ],
           },
@@ -309,7 +309,7 @@ test('check if the dead letter queue policy is setup', () => {
           },
           Resource:  {
             "Fn::GetAtt": [
-              "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+              "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
               "Arn",
             ],
           },
@@ -320,7 +320,7 @@ test('check if the dead letter queue policy is setup', () => {
     },
     Queues: [
       {
-        Ref: "testeventsrulesqstesteventsrulesqswrappeddeadLetterQueue6B3B63F7",
+        Ref: "testeventsrulesqstesteventsrulesqsWdeadLetterQueue6C5AAA92",
       },
     ]
   });

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-existing-bus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-existing-bus.expected.json
@@ -116,7 +116,7 @@
         "Name": "eventsruleexistingbusexistingeventbusE1A2652B"
       }
     },
-    "constructconstructwrappedEventsRuleCFCBC820": {
+    "constructconstructWEventsRule8EB974AE": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-existing-queue.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-existing-queue.expected.json
@@ -110,7 +110,7 @@
         ]
       }
     },
-    "constructconstructwrappedEventsRuleCFCBC820": {
+    "constructconstructWEventsRule8EB974AE": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-new-bus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-new-bus.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "ersqsersqswrappeddeadLetterQueueDA0DC0E2": {
+    "ersqsersqsWdeadLetterQueueB06870B6": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": "alias/aws/sqs"
@@ -8,7 +8,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "ersqsersqswrappeddeadLetterQueuePolicy95833FD0": {
+    "ersqsersqsWdeadLetterQueuePolicyFA1CF12F": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -44,7 +44,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "ersqsersqswrappeddeadLetterQueueDA0DC0E2",
+                  "ersqsersqsWdeadLetterQueueB06870B6",
                   "Arn"
                 ]
               },
@@ -63,7 +63,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "ersqsersqswrappeddeadLetterQueueDA0DC0E2",
+                  "ersqsersqsWdeadLetterQueueB06870B6",
                   "Arn"
                 ]
               },
@@ -74,12 +74,12 @@
         },
         "Queues": [
           {
-            "Ref": "ersqsersqswrappeddeadLetterQueueDA0DC0E2"
+            "Ref": "ersqsersqsWdeadLetterQueueB06870B6"
           }
         ]
       }
     },
-    "ersqsersqswrappedEncryptionKeyB90DDAF7": {
+    "ersqsersqsWEncryptionKeyD63FAFB3": {
       "Type": "AWS::KMS::Key",
       "Properties": {
         "KeyPolicy": {
@@ -144,19 +144,19 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "ersqsersqswrappedqueue77F78672": {
+    "ersqsersqsWqueue881EC5DE": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": {
           "Fn::GetAtt": [
-            "ersqsersqswrappedEncryptionKeyB90DDAF7",
+            "ersqsersqsWEncryptionKeyD63FAFB3",
             "Arn"
           ]
         },
         "RedrivePolicy": {
           "deadLetterTargetArn": {
             "Fn::GetAtt": [
-              "ersqsersqswrappeddeadLetterQueueDA0DC0E2",
+              "ersqsersqsWdeadLetterQueueB06870B6",
               "Arn"
             ]
           },
@@ -166,7 +166,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "ersqsersqswrappedqueuePolicy1DDD6C29": {
+    "ersqsersqsWqueuePolicyC4BDE85A": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -202,7 +202,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "ersqsersqswrappedqueue77F78672",
+                  "ersqsersqsWqueue881EC5DE",
                   "Arn"
                 ]
               },
@@ -221,7 +221,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "ersqsersqswrappedqueue77F78672",
+                  "ersqsersqsWqueue881EC5DE",
                   "Arn"
                 ]
               },
@@ -239,7 +239,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "ersqsersqswrappedqueue77F78672",
+                  "ersqsersqsWqueue881EC5DE",
                   "Arn"
                 ]
               }
@@ -249,22 +249,22 @@
         },
         "Queues": [
           {
-            "Ref": "ersqsersqswrappedqueue77F78672"
+            "Ref": "ersqsersqsWqueue881EC5DE"
           }
         ]
       }
     },
-    "ersqsersqswrappedCustomEventBus58DA49B4": {
+    "ersqsersqsWCustomEventBus3249194C": {
       "Type": "AWS::Events::EventBus",
       "Properties": {
-        "Name": "eventsrulenewbusersqsersqswrappedCustomEventBusC1530AC9"
+        "Name": "eventsrulenewbusersqsersqsWCustomEventBusA92E8C83"
       }
     },
-    "ersqsersqswrappedEventsRule6C5B7B89": {
+    "ersqsersqsWEventsRule017C5D22": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
-          "Ref": "ersqsersqswrappedCustomEventBus58DA49B4"
+          "Ref": "ersqsersqsWCustomEventBus3249194C"
         },
         "EventPattern": {
           "source": [
@@ -276,13 +276,13 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "ersqsersqswrappedqueue77F78672",
+                "ersqsersqsWqueue881EC5DE",
                 "Arn"
               ]
             },
             "Id": {
               "Fn::GetAtt": [
-                "ersqsersqswrappedqueue77F78672",
+                "ersqsersqsWqueue881EC5DE",
                 "QueueName"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-no-arg.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/test/integ.events-rule-no-arg.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "testtestwrappeddeadLetterQueue36E8394D": {
+    "testtestWdeadLetterQueueADA5E2B4": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": "alias/aws/sqs"
@@ -8,7 +8,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "testtestwrappeddeadLetterQueuePolicyEAD361CF": {
+    "testtestWdeadLetterQueuePolicy146CFBB4": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -44,7 +44,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappeddeadLetterQueue36E8394D",
+                  "testtestWdeadLetterQueueADA5E2B4",
                   "Arn"
                 ]
               },
@@ -63,7 +63,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappeddeadLetterQueue36E8394D",
+                  "testtestWdeadLetterQueueADA5E2B4",
                   "Arn"
                 ]
               },
@@ -74,12 +74,12 @@
         },
         "Queues": [
           {
-            "Ref": "testtestwrappeddeadLetterQueue36E8394D"
+            "Ref": "testtestWdeadLetterQueueADA5E2B4"
           }
         ]
       }
     },
-    "testtestwrappedEncryptionKey3FF098D5": {
+    "testtestWEncryptionKeyC6B126B6": {
       "Type": "AWS::KMS::Key",
       "Properties": {
         "KeyPolicy": {
@@ -144,19 +144,19 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "testtestwrappedqueue64D2F079": {
+    "testtestWqueue5267657C": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": {
           "Fn::GetAtt": [
-            "testtestwrappedEncryptionKey3FF098D5",
+            "testtestWEncryptionKeyC6B126B6",
             "Arn"
           ]
         },
         "RedrivePolicy": {
           "deadLetterTargetArn": {
             "Fn::GetAtt": [
-              "testtestwrappeddeadLetterQueue36E8394D",
+              "testtestWdeadLetterQueueADA5E2B4",
               "Arn"
             ]
           },
@@ -166,7 +166,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "testtestwrappedqueuePolicyF9990682": {
+    "testtestWqueuePolicy5769D7F4": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
@@ -202,7 +202,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedqueue64D2F079",
+                  "testtestWqueue5267657C",
                   "Arn"
                 ]
               },
@@ -221,7 +221,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedqueue64D2F079",
+                  "testtestWqueue5267657C",
                   "Arn"
                 ]
               },
@@ -239,7 +239,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "testtestwrappedqueue64D2F079",
+                  "testtestWqueue5267657C",
                   "Arn"
                 ]
               }
@@ -249,12 +249,12 @@
         },
         "Queues": [
           {
-            "Ref": "testtestwrappedqueue64D2F079"
+            "Ref": "testtestWqueue5267657C"
           }
         ]
       }
     },
-    "testtestwrappedEventsRule9009C17B": {
+    "testtestWEventsRuleDF9938A8": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -263,13 +263,13 @@
           {
             "Arn": {
               "Fn::GetAtt": [
-                "testtestwrappedqueue64D2F079",
+                "testtestWqueue5267657C",
                 "Arn"
               ]
             },
             "Id": {
               "Fn::GetAtt": [
-                "testtestwrappedqueue64D2F079",
+                "testtestWqueue5267657C",
                 "QueueName"
               ]
             }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/lib/index.ts
@@ -78,7 +78,7 @@ export class EventsRuleToStepFunction extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToStepFunctionProps) {
     super(scope, id);
     const convertedProps: EventsRuleToStepFunctionProps = { ...props };
-    const wrappedConstruct: EventsRuleToStepFunction = new EventbridgeToStepfunctions(this, `${id}-wrapped`, convertedProps);
+    const wrappedConstruct: EventsRuleToStepFunction = new EventbridgeToStepfunctions(this, `${id}W`, convertedProps);
 
     this.stateMachine = wrappedConstruct.stateMachine;
     this.stateMachineLogGroup = wrappedConstruct.stateMachineLogGroup;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/lib/index.ts
@@ -78,6 +78,11 @@ export class EventsRuleToStepFunction extends Construct {
   constructor(scope: Construct, id: string, props: EventsRuleToStepFunctionProps) {
     super(scope, id);
     const convertedProps: EventsRuleToStepFunctionProps = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new EventbridgeToStepfunctions instead of EventsRuleToStepFunction)
     const wrappedConstruct: EventsRuleToStepFunction = new EventbridgeToStepfunctions(this, `${id}W`, convertedProps);
 
     this.stateMachine = wrappedConstruct.stateMachine;

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/lib/index.ts
@@ -80,7 +80,7 @@ export class EventsRuleToStepFunction extends Construct {
     const convertedProps: EventsRuleToStepFunctionProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new EventbridgeToStepfunctions instead of EventsRuleToStepFunction)
     const wrappedConstruct: EventsRuleToStepFunction = new EventbridgeToStepfunctions(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/__snapshots__/events-rule-step-function.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/__snapshots__/events-rule-step-function.test.js.snap
@@ -3,16 +3,16 @@
 exports[`check eventbus property, snapshot & eventbus exists 1`] = `
 Object {
   "Resources": Object {
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedCustomEventBusA80A6AE6": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWCustomEventBus9A8EB44C": Object {
       "Properties": Object {
-        "Name": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedCustomEventBus9374EFBE",
+        "Name": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWCustomEventBus96725ED9",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedEventsRule5AF7B7F9": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWEventsRule9CBD73A7": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedCustomEventBusA80A6AE6",
+          "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWCustomEventBus9A8EB44C",
         },
         "EventPattern": Object {
           "source": Array [
@@ -23,12 +23,12 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachine434BD3C9",
+              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachine985605C1",
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedEventsRuleRole87D54C4C",
+                "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWEventsRuleRole43E83332",
                 "Arn",
               ],
             },
@@ -37,7 +37,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedEventsRuleRole87D54C4C": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWEventsRuleRole43E83332": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -54,7 +54,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedEventsRuleRoleDefaultPolicyCE20CB1C": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWEventsRuleRoleDefaultPolicy88C45E8E": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -62,22 +62,22 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachine434BD3C9",
+                "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachine985605C1",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedEventsRuleRoleDefaultPolicyCE20CB1C",
+        "PolicyName": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWEventsRuleRoleDefaultPolicy88C45E8E",
         "Roles": Array [
           Object {
-            "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedEventsRuleRole87D54C4C",
+            "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWEventsRuleRole43E83332",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedExecutionAbortedAlarm573E02EB": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWExecutionAbortedAlarm3EC27335": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -85,7 +85,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachine434BD3C9",
+              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachine985605C1",
             },
           },
         ],
@@ -98,7 +98,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedExecutionFailedAlarm2613A16E": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWExecutionFailedAlarmF5EBDDC8": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -106,7 +106,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachine434BD3C9",
+              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachine985605C1",
             },
           },
         ],
@@ -119,7 +119,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedExecutionThrottledAlarmBDF47911": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWExecutionThrottledAlarm01F170A3": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -127,7 +127,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachine434BD3C9",
+              "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachine985605C1",
             },
           },
         ],
@@ -140,10 +140,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachine434BD3C9": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachine985605C1": Object {
       "DependsOn": Array [
-        "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineRoleDefaultPolicy36BEF6F1",
-        "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineRole24A13831",
+        "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineRoleDefaultPolicyA62A4445",
+        "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineRoleE4E8523D",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -153,7 +153,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineLogGroupFB62D721",
+                    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineLogGroupA9B344FF",
                     "Arn",
                   ],
                 },
@@ -164,14 +164,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineRole24A13831",
+            "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineRoleE4E8523D",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineLogGroupFB62D721": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineLogGroupA9B344FF": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -188,40 +188,12 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaulttesteventrulesstepfunctionseventbuswrappedstatemachinelog9d0089f8aa0c",
+        "LogGroupName": "/aws/vendedlogs/states/defaulttesteventrulesstepfunctionseventbuswstatemachinelog45e67f327ac7",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineRole24A13831": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "states.",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ".amazonaws.com",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineRoleDefaultPolicy36BEF6F1": Object {
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineRoleDefaultPolicyA62A4445": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -277,14 +249,42 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineRoleDefaultPolicy36BEF6F1",
+        "PolicyName": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineRoleDefaultPolicyA62A4445",
         "Roles": Array [
           Object {
-            "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbuswrappedStateMachineRole24A13831",
+            "Ref": "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineRoleE4E8523D",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "testeventrulesstepfunctionseventbustesteventrulesstepfunctionseventbusWStateMachineRoleE4E8523D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "states.",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ".amazonaws.com",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
     },
   },
 }
@@ -293,16 +293,16 @@ Object {
 exports[`check multiple constructs in a single stack 1`] = `
 Object {
   "Resources": Object {
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedCustomEventBusD8193D14": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WCustomEventBus1DFFF478": Object {
       "Properties": Object {
-        "Name": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedCustomEventBus811D23A6",
+        "Name": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WCustomEventBus87A0BE3B",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedEventsRule70206C5C": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WEventsRuleDF6D8C33": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedCustomEventBusD8193D14",
+          "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WCustomEventBus1DFFF478",
         },
         "EventPattern": Object {
           "source": Array [
@@ -313,12 +313,12 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachine9BCFD286",
+              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachine0B65F147",
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedEventsRuleRole4D263A39",
+                "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WEventsRuleRole98D83521",
                 "Arn",
               ],
             },
@@ -327,7 +327,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedEventsRuleRole4D263A39": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WEventsRuleRole98D83521": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -344,7 +344,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedEventsRuleRoleDefaultPolicy0EBFE184": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WEventsRuleRoleDefaultPolicy72754402": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -352,22 +352,22 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachine9BCFD286",
+                "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachine0B65F147",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedEventsRuleRoleDefaultPolicy0EBFE184",
+        "PolicyName": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WEventsRuleRoleDefaultPolicy72754402",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedEventsRuleRole4D263A39",
+            "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WEventsRuleRole98D83521",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedExecutionAbortedAlarmBAA68B71": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WExecutionAbortedAlarmAFF2B2A4": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -375,7 +375,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachine9BCFD286",
+              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachine0B65F147",
             },
           },
         ],
@@ -388,7 +388,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedExecutionFailedAlarmA2BFF049": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WExecutionFailedAlarmA2DD093E": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -396,7 +396,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachine9BCFD286",
+              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachine0B65F147",
             },
           },
         ],
@@ -409,7 +409,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedExecutionThrottledAlarm0B7ABDD5": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WExecutionThrottledAlarm9DFC597D": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -417,7 +417,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachine9BCFD286",
+              "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachine0B65F147",
             },
           },
         ],
@@ -430,10 +430,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachine9BCFD286": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachine0B65F147": Object {
       "DependsOn": Array [
-        "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineRoleDefaultPolicyD0996880",
-        "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineRole8997E8A1",
+        "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineRoleDefaultPolicyC52599AF",
+        "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineRole05A37DB2",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState1\\",\\"States\\":{\\"StartState1\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -443,7 +443,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineLogGroupC572A3F3",
+                    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineLogGroup8814D6B7",
                     "Arn",
                   ],
                 },
@@ -454,14 +454,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineRole8997E8A1",
+            "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineRole05A37DB2",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineLogGroupC572A3F3": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineLogGroup8814D6B7": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -478,12 +478,12 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaulttestneweventsrulestepfunctions1wrappedstatemachinelogae8b8f8756a7",
+        "LogGroupName": "/aws/vendedlogs/states/defaulttestneweventsrulestepfunctions1wstatemachinelog97c26b319582",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineRole8997E8A1": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineRole05A37DB2": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -511,7 +511,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineRoleDefaultPolicyD0996880": Object {
+    "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineRoleDefaultPolicyC52599AF": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -567,25 +567,25 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineRoleDefaultPolicyD0996880",
+        "PolicyName": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineRoleDefaultPolicyC52599AF",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1wrappedStateMachineRole8997E8A1",
+            "Ref": "testneweventsrulestepfunctions1testneweventsrulestepfunctions1WStateMachineRole05A37DB2",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedCustomEventBus4CD087AA": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WCustomEventBus78F90360": Object {
       "Properties": Object {
-        "Name": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedCustomEventBus21A7EEDC",
+        "Name": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WCustomEventBusE072453C",
       },
       "Type": "AWS::Events::EventBus",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedEventsRule4712CD41": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WEventsRule6651A8FD": Object {
       "Properties": Object {
         "EventBusName": Object {
-          "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedCustomEventBus4CD087AA",
+          "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WCustomEventBus78F90360",
         },
         "EventPattern": Object {
           "source": Array [
@@ -596,12 +596,12 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachine12C67230",
+              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachine19B33D06",
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedEventsRuleRole5D364ED6",
+                "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WEventsRuleRole61AF2B20",
                 "Arn",
               ],
             },
@@ -610,7 +610,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedEventsRuleRole5D364ED6": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WEventsRuleRole61AF2B20": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -627,7 +627,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedEventsRuleRoleDefaultPolicy2F13E3B2": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WEventsRuleRoleDefaultPolicy8B46CAA2": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -635,22 +635,22 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachine12C67230",
+                "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachine19B33D06",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedEventsRuleRoleDefaultPolicy2F13E3B2",
+        "PolicyName": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WEventsRuleRoleDefaultPolicy8B46CAA2",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedEventsRuleRole5D364ED6",
+            "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WEventsRuleRole61AF2B20",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedExecutionAbortedAlarm04F6AF08": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WExecutionAbortedAlarm308A499D": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -658,7 +658,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachine12C67230",
+              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachine19B33D06",
             },
           },
         ],
@@ -671,7 +671,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedExecutionFailedAlarm7C8C3E4C": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WExecutionFailedAlarm9A88CE2D": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -679,7 +679,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachine12C67230",
+              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachine19B33D06",
             },
           },
         ],
@@ -692,7 +692,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedExecutionThrottledAlarm5D0A68C6": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WExecutionThrottledAlarmD30B2A78": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -700,7 +700,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachine12C67230",
+              "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachine19B33D06",
             },
           },
         ],
@@ -713,10 +713,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachine12C67230": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachine19B33D06": Object {
       "DependsOn": Array [
-        "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineRoleDefaultPolicy036B7586",
-        "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineRole2ED2E3B8",
+        "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineRoleDefaultPolicy1C779334",
+        "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineRole749D8D3F",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState2\\",\\"States\\":{\\"StartState2\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -726,7 +726,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineLogGroup59D986DB",
+                    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineLogGroup790F52EC",
                     "Arn",
                   ],
                 },
@@ -737,14 +737,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineRole2ED2E3B8",
+            "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineRole749D8D3F",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineLogGroup59D986DB": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineLogGroup790F52EC": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -761,12 +761,12 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaulttestneweventsrulestepfunctions2wrappedstatemachinelogf3fa199ba576",
+        "LogGroupName": "/aws/vendedlogs/states/defaulttestneweventsrulestepfunctions2wstatemachinelogf9e3049f13b4",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineRole2ED2E3B8": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineRole749D8D3F": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -794,7 +794,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineRoleDefaultPolicy036B7586": Object {
+    "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineRoleDefaultPolicy1C779334": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -850,10 +850,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineRoleDefaultPolicy036B7586",
+        "PolicyName": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineRoleDefaultPolicy1C779334",
         "Roles": Array [
           Object {
-            "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2wrappedStateMachineRole2ED2E3B8",
+            "Ref": "testneweventsrulestepfunctions2testneweventsrulestepfunctions2WStateMachineRole749D8D3F",
           },
         ],
       },
@@ -866,19 +866,19 @@ Object {
 exports[`snapshot test EventsRuleToStepFunction default params 1`] = `
 Object {
   "Resources": Object {
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedEventsRuleA83249AC": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWEventsRule8B362B1C": Object {
       "Properties": Object {
         "ScheduleExpression": "rate(5 minutes)",
         "State": "ENABLED",
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C",
+              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64",
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedEventsRuleRole30B14737",
+                "testeventsrulestepfunctiontesteventsrulestepfunctionWEventsRuleRole992B57E4",
                 "Arn",
               ],
             },
@@ -887,7 +887,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedEventsRuleRole30B14737": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWEventsRuleRole992B57E4": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -904,7 +904,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedEventsRuleRoleDefaultPolicy7AE3374D": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWEventsRuleRoleDefaultPolicyFBE4056E": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -912,22 +912,22 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C",
+                "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedEventsRuleRoleDefaultPolicy7AE3374D",
+        "PolicyName": "testeventsrulestepfunctiontesteventsrulestepfunctionWEventsRuleRoleDefaultPolicyFBE4056E",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedEventsRuleRole30B14737",
+            "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionWEventsRuleRole992B57E4",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedExecutionAbortedAlarmCFC550AC": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWExecutionAbortedAlarm3FAB3CF0": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -935,7 +935,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C",
+              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64",
             },
           },
         ],
@@ -948,7 +948,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedExecutionFailedAlarm2CFF319F": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWExecutionFailedAlarm6E85FA5A": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -956,7 +956,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C",
+              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64",
             },
           },
         ],
@@ -969,7 +969,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedExecutionThrottledAlarm23E5CBB2": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWExecutionThrottledAlarm4368F45A": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -977,7 +977,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C",
+              "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64",
             },
           },
         ],
@@ -990,10 +990,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64": Object {
       "DependsOn": Array [
-        "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineRoleDefaultPolicy8771AABE",
-        "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineRoleA594A66E",
+        "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineRoleDefaultPolicy517315B3",
+        "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineRole594689FA",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -1003,7 +1003,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineLogGroup53FEF40C",
+                    "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineLogGroupA5BA56B5",
                     "Arn",
                   ],
                 },
@@ -1014,14 +1014,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineRoleA594A66E",
+            "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineRole594689FA",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineLogGroup53FEF40C": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineLogGroupA5BA56B5": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -1038,12 +1038,12 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaulttesteventsrulestepfunctionwrappedstatemachinelog329719d9adc9",
+        "LogGroupName": "/aws/vendedlogs/states/defaulttesteventsrulestepfunctionwstatemachineloge7a646a2b77b",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineRoleA594A66E": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineRole594689FA": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1071,7 +1071,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineRoleDefaultPolicy8771AABE": Object {
+    "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineRoleDefaultPolicy517315B3": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -1127,10 +1127,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineRoleDefaultPolicy8771AABE",
+        "PolicyName": "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineRoleDefaultPolicy517315B3",
         "Roles": Array [
           Object {
-            "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachineRoleA594A66E",
+            "Ref": "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachineRole594689FA",
           },
         ],
       },
@@ -1143,7 +1143,7 @@ Object {
 exports[`snapshot test EventsRuleToStepfunctions existing event bus params 1`] = `
 Object {
   "Resources": Object {
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedEventsRuleC9B681F5": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWEventsRule85E7CC2B": Object {
       "Properties": Object {
         "EventBusName": Object {
           "Ref": "testexistingneweventbusB9898D2B",
@@ -1157,12 +1157,12 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachine5D46233F",
+              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachine08CB895B",
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedEventsRuleRole5A613617",
+                "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWEventsRuleRole0F7C77E1",
                 "Arn",
               ],
             },
@@ -1171,7 +1171,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedEventsRuleRole5A613617": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWEventsRuleRole0F7C77E1": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1188,7 +1188,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedEventsRuleRoleDefaultPolicyF26F34F2": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWEventsRuleRoleDefaultPolicy0F0C57E0": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1196,22 +1196,22 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachine5D46233F",
+                "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachine08CB895B",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedEventsRuleRoleDefaultPolicyF26F34F2",
+        "PolicyName": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWEventsRuleRoleDefaultPolicy0F0C57E0",
         "Roles": Array [
           Object {
-            "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedEventsRuleRole5A613617",
+            "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWEventsRuleRole0F7C77E1",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedExecutionAbortedAlarm501E521F": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWExecutionAbortedAlarm25B0859F": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -1219,7 +1219,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachine5D46233F",
+              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachine08CB895B",
             },
           },
         ],
@@ -1232,7 +1232,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedExecutionFailedAlarm34F832F4": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWExecutionFailedAlarm212909CA": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -1240,7 +1240,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachine5D46233F",
+              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachine08CB895B",
             },
           },
         ],
@@ -1253,7 +1253,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedExecutionThrottledAlarmBB941DB3": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWExecutionThrottledAlarmD70DAD50": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -1261,7 +1261,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachine5D46233F",
+              "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachine08CB895B",
             },
           },
         ],
@@ -1274,10 +1274,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachine5D46233F": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachine08CB895B": Object {
       "DependsOn": Array [
-        "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineRoleDefaultPolicy8FD41E5E",
-        "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineRole17CEE97B",
+        "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineRoleDefaultPolicyF4942FB8",
+        "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineRole6468A596",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -1287,7 +1287,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineLogGroup03F5535A",
+                    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineLogGroupF95FB577",
                     "Arn",
                   ],
                 },
@@ -1298,14 +1298,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineRole17CEE97B",
+            "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineRole6468A596",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineLogGroup03F5535A": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineLogGroupF95FB577": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -1322,12 +1322,12 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaulttestexistingeventsrulestepfunctionswrappedstatemachinelog5a1e69f0fce9",
+        "LogGroupName": "/aws/vendedlogs/states/defaulttestexistingeventsrulestepfunctionswstatemachinelog84f35cce0b0f",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineRole17CEE97B": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineRole6468A596": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1355,7 +1355,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineRoleDefaultPolicy8FD41E5E": Object {
+    "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineRoleDefaultPolicyF4942FB8": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -1411,10 +1411,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineRoleDefaultPolicy8FD41E5E",
+        "PolicyName": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineRoleDefaultPolicyF4942FB8",
         "Roles": Array [
           Object {
-            "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionswrappedStateMachineRole17CEE97B",
+            "Ref": "testexistingeventsrulestepfunctionstestexistingeventsrulestepfunctionsWStateMachineRole6468A596",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/events-rule-step-function.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/events-rule-step-function.test.ts
@@ -72,7 +72,7 @@ test('check events rule role policy permissions', () => {
           Action: "states:StartExecution",
           Effect: "Allow",
           Resource: {
-            Ref: "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C"
+            Ref: "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64"
           }
         }
       ],
@@ -92,12 +92,12 @@ test('check events rule properties', () => {
     Targets: [
       {
         Arn: {
-          Ref: "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedStateMachine630E5B8C"
+          Ref: "testeventsrulestepfunctiontesteventsrulestepfunctionWStateMachine64FD5A64"
         },
         Id: "Target0",
         RoleArn: {
           "Fn::GetAtt": [
-            "testeventsrulestepfunctiontesteventsrulestepfunctionwrappedEventsRuleRole30B14737",
+            "testeventsrulestepfunctiontesteventsrulestepfunctionWEventsRuleRole992B57E4",
             "Arn"
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-no-argument.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-no-argument.expected.json
@@ -1,9 +1,9 @@
 {
   "Resources": {
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineLogGroup320F554C": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineLogGroup600D6F22": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionnoargumenttesteventsrulestepfunctionconstructwrappedstatemachinelog07f4f9869a40"
+        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionnoargumenttesteventsrulestepfunctionconstructwstatemachinelog825337e176ed"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -22,7 +22,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineRoleB98FCE58": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineRole4754DBBF": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -50,7 +50,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineRoleDefaultPolicy6CBF7E35": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineRoleDefaultPolicy79AC1A05": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -97,10 +97,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineRoleDefaultPolicy6CBF7E35",
+        "PolicyName": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineRoleDefaultPolicy79AC1A05",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineRoleB98FCE58"
+            "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineRole4754DBBF"
           }
         ]
       },
@@ -115,12 +115,12 @@
         }
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachine5ED8C777": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachine0424229E": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineRoleB98FCE58",
+            "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineRole4754DBBF",
             "Arn"
           ]
         },
@@ -131,7 +131,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineLogGroup320F554C",
+                    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineLogGroup600D6F22",
                     "Arn"
                   ]
                 }
@@ -142,11 +142,11 @@
         }
       },
       "DependsOn": [
-        "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineRoleDefaultPolicy6CBF7E35",
-        "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachineRoleB98FCE58"
+        "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineRoleDefaultPolicy79AC1A05",
+        "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachineRole4754DBBF"
       ]
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedEventsRuleRoleB9781881": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWEventsRuleRole1639AF0D": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -163,7 +163,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedEventsRuleRoleDefaultPolicy829CA63F": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWEventsRuleRoleDefaultPolicyA7B5D8EB": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -172,21 +172,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachine5ED8C777"
+                "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachine0424229E"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedEventsRuleRoleDefaultPolicy829CA63F",
+        "PolicyName": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWEventsRuleRoleDefaultPolicyA7B5D8EB",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedEventsRuleRoleB9781881"
+            "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWEventsRuleRole1639AF0D"
           }
         ]
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedEventsRuleA150B140": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWEventsRule31D6F54E": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -194,12 +194,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachine5ED8C777"
+              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachine0424229E"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedEventsRuleRoleB9781881",
+                "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWEventsRuleRole1639AF0D",
                 "Arn"
               ]
             }
@@ -207,7 +207,7 @@
         ]
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedExecutionFailedAlarmB9B5EE2C": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWExecutionFailedAlarm141B94C4": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -217,7 +217,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachine5ED8C777"
+              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachine0424229E"
             }
           }
         ],
@@ -228,7 +228,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedExecutionThrottledAlarm13F2FFC3": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWExecutionThrottledAlarmB477D6C0": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -238,7 +238,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachine5ED8C777"
+              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachine0424229E"
             }
           }
         ],
@@ -249,7 +249,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedExecutionAbortedAlarm46957545": {
+    "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWExecutionAbortedAlarm5513A636": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -259,7 +259,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructwrappedStateMachine5ED8C777"
+              "Ref": "testeventsrulestepfunctionconstructtesteventsrulestepfunctionconstructWStateMachine0424229E"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-with-lambda.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-step-function-with-lambda.expected.json
@@ -170,10 +170,10 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineLogGroupF98CF7C2": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineLogGroup329EB706": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionwithlambdatesteventsrulestepfunctionandlambdaconstructwrappedstatemachinelog1a23ab551f93"
+        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionwithlambdatesteventsrulestepfunctionandlambdaconstructwstatemachinelog11b9b268119b"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -192,7 +192,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineRole28BAF772": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineRoleE82CDD66": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -220,7 +220,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineRoleDefaultPolicy398BF515": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineRoleDefaultPolicyD95C5158": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -277,10 +277,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "eventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineRoleDefaultPolicy398BF515",
+        "PolicyName": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineRoleDefaultPolicyD95C5158",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineRole28BAF772"
+            "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineRoleE82CDD66"
           }
         ]
       },
@@ -295,12 +295,12 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineB8975D80": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachine33649A38": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineRole28BAF772",
+            "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineRoleE82CDD66",
             "Arn"
           ]
         },
@@ -329,7 +329,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineLogGroupF98CF7C2",
+                    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineLogGroup329EB706",
                     "Arn"
                   ]
                 }
@@ -340,11 +340,11 @@
         }
       },
       "DependsOn": [
-        "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineRoleDefaultPolicy398BF515",
-        "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineRole28BAF772"
+        "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineRoleDefaultPolicyD95C5158",
+        "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachineRoleE82CDD66"
       ]
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedEventsRuleRole59CC2DE2": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWEventsRuleRole793B243C": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -361,7 +361,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedEventsRuleRoleDefaultPolicy0A2282DD": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWEventsRuleRoleDefaultPolicy6FE8604C": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -370,21 +370,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineB8975D80"
+                "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachine33649A38"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "steventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedEventsRuleRoleDefaultPolicy0A2282DD",
+        "PolicyName": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWEventsRuleRoleDefaultPolicy6FE8604C",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedEventsRuleRole59CC2DE2"
+            "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWEventsRuleRole793B243C"
           }
         ]
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedEventsRule89B5923E": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWEventsRuleE80B0F65": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "ScheduleExpression": "rate(5 minutes)",
@@ -392,12 +392,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineB8975D80"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachine33649A38"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedEventsRuleRole59CC2DE2",
+                "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWEventsRuleRole793B243C",
                 "Arn"
               ]
             }
@@ -405,7 +405,7 @@
         ]
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedExecutionFailedAlarm7AFE442D": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWExecutionFailedAlarm61687327": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -415,7 +415,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineB8975D80"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachine33649A38"
             }
           }
         ],
@@ -426,7 +426,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedExecutionThrottledAlarm14CDD433": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWExecutionThrottledAlarmA166FA6F": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -436,7 +436,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineB8975D80"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachine33649A38"
             }
           }
         ],
@@ -447,7 +447,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedExecutionAbortedAlarm9BC00D54": {
+    "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWExecutionAbortedAlarm171C8710": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -457,7 +457,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructwrappedStateMachineB8975D80"
+              "Ref": "testeventsrulestepfunctionandlambdaconstructtesteventsrulestepfunctionandlambdaconstructWStateMachine33649A38"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-stepfunctions-existing-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-stepfunctions-existing-eventbus.expected.json
@@ -176,10 +176,10 @@
         "Name": "eventsrulestepfunctionsexistingeventbusexistingeventbus1ED36585"
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineLogGroup5EE95752": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineLogGroupCB5738F2": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionsexistingeventbustesteventsrulestepfunctionsneweventbusconstructwrappedstatemachinelog43b70fb6cbef"
+        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionsexistingeventbustesteventsrulestepfunctionsneweventbusconstructwstatemachinelog58fb58335a86"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -198,7 +198,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -226,7 +226,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRoleDefaultPolicy1A3825B6": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRoleDefaultPolicy066367F6": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -283,10 +283,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "rulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRoleDefaultPolicy1A3825B6",
+        "PolicyName": "eventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRoleDefaultPolicy066367F6",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E"
+            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB"
           }
         ]
       },
@@ -301,12 +301,12 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E",
+            "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB",
             "Arn"
           ]
         },
@@ -335,7 +335,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineLogGroup5EE95752",
+                    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineLogGroupCB5738F2",
                     "Arn"
                   ]
                 }
@@ -346,11 +346,11 @@
         }
       },
       "DependsOn": [
-        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRoleDefaultPolicy1A3825B6",
-        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E"
+        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRoleDefaultPolicy066367F6",
+        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB"
       ]
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleEAAE2E76": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleC458F838": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -367,7 +367,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleDefaultPolicyF5BF6008": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleDefaultPolicy4F6F964E": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -376,21 +376,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+                "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleDefaultPolicyF5BF6008",
+        "PolicyName": "steventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleDefaultPolicy4F6F964E",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleEAAE2E76"
+            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleC458F838"
           }
         ]
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRule4D5AF227": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRule2EC401DF": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
@@ -405,12 +405,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleEAAE2E76",
+                "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleC458F838",
                 "Arn"
               ]
             }
@@ -418,7 +418,7 @@
         ]
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedExecutionFailedAlarm021FECF4": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWExecutionFailedAlarm0B7D7949": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -428,7 +428,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             }
           }
         ],
@@ -439,7 +439,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedExecutionThrottledAlarmFFC1C9DA": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWExecutionThrottledAlarm3EFC2C2B": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -449,7 +449,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             }
           }
         ],
@@ -460,7 +460,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedExecutionAbortedAlarmF3A957F6": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWExecutionAbortedAlarm265CDD35": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -470,7 +470,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-stepfunctions-new-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/test/integ.events-rule-stepfunctions-new-eventbus.expected.json
@@ -170,10 +170,10 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineLogGroup5EE95752": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineLogGroupCB5738F2": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionsneweventbustesteventsrulestepfunctionsneweventbusconstructwrappedstatemachinelog7010377640a2"
+        "LogGroupName": "/aws/vendedlogs/states/eventsrulestepfunctionsneweventbustesteventsrulestepfunctionsneweventbusconstructwstatemachinelog4adfe2caac8e"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -192,7 +192,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -220,7 +220,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRoleDefaultPolicy1A3825B6": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRoleDefaultPolicy066367F6": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -277,10 +277,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "rulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRoleDefaultPolicy1A3825B6",
+        "PolicyName": "eventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRoleDefaultPolicy066367F6",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E"
+            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB"
           }
         ]
       },
@@ -295,12 +295,12 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E",
+            "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB",
             "Arn"
           ]
         },
@@ -329,7 +329,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineLogGroup5EE95752",
+                    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineLogGroupCB5738F2",
                     "Arn"
                   ]
                 }
@@ -340,11 +340,11 @@
         }
       },
       "DependsOn": [
-        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRoleDefaultPolicy1A3825B6",
-        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachineRole164E896E"
+        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRoleDefaultPolicy066367F6",
+        "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachineRole684708AB"
       ]
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleEAAE2E76": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleC458F838": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -361,7 +361,7 @@
         }
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleDefaultPolicyF5BF6008": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleDefaultPolicy4F6F964E": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -370,31 +370,31 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+                "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleDefaultPolicyF5BF6008",
+        "PolicyName": "steventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleDefaultPolicy4F6F964E",
         "Roles": [
           {
-            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleEAAE2E76"
+            "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleC458F838"
           }
         ]
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedCustomEventBus5015FEDD": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWCustomEventBusCEDEBDA4": {
       "Type": "AWS::Events::EventBus",
       "Properties": {
-        "Name": "eventsrulestepfunctionsneweventbustesteventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedCustomEventBus8E386F00"
+        "Name": "eventsrulestepfunctionsneweventbustesteventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWCustomEventBus7D1AA353"
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRule4D5AF227": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRule2EC401DF": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventBusName": {
-          "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedCustomEventBus5015FEDD"
+          "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWCustomEventBusCEDEBDA4"
         },
         "EventPattern": {
           "source": [
@@ -405,12 +405,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedEventsRuleRoleEAAE2E76",
+                "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWEventsRuleRoleC458F838",
                 "Arn"
               ]
             }
@@ -418,7 +418,7 @@
         ]
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedExecutionFailedAlarm021FECF4": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWExecutionFailedAlarm0B7D7949": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -428,7 +428,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             }
           }
         ],
@@ -439,7 +439,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedExecutionThrottledAlarmFFC1C9DA": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWExecutionThrottledAlarm3EFC2C2B": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -449,7 +449,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             }
           }
         ],
@@ -460,7 +460,7 @@
         "Threshold": 1
       }
     },
-    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedExecutionAbortedAlarmF3A957F6": {
+    "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWExecutionAbortedAlarm265CDD35": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -470,7 +470,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructwrappedStateMachine61D05A7B"
+              "Ref": "testeventsrulestepfunctionsneweventbusconstructtesteventsrulestepfunctionsneweventbusconstructWStateMachine3577BCB1"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/lib/index.ts
@@ -98,7 +98,7 @@ export class LambdaToStepFunction extends Construct {
   constructor(scope: Construct, id: string, props: LambdaToStepFunctionProps) {
     super(scope, id);
     const convertedProps: LambdaToStepFunctionProps = { ...props };
-    const wrappedConstruct: LambdaToStepFunction = new LambdaToStepfunctions(this, `${id}-wrapped`, convertedProps);
+    const wrappedConstruct: LambdaToStepFunction = new LambdaToStepfunctions(this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;
     this.stateMachine = wrappedConstruct.stateMachine;

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/lib/index.ts
@@ -100,7 +100,7 @@ export class LambdaToStepFunction extends Construct {
     const convertedProps: LambdaToStepFunctionProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new LambdaToStepfunctions instead of LambdaToStepFunction)
     const wrappedConstruct: LambdaToStepFunction = new LambdaToStepfunctions(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/lib/index.ts
@@ -98,6 +98,11 @@ export class LambdaToStepFunction extends Construct {
   constructor(scope: Construct, id: string, props: LambdaToStepFunctionProps) {
     super(scope, id);
     const convertedProps: LambdaToStepFunctionProps = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new LambdaToStepfunctions instead of LambdaToStepFunction)
     const wrappedConstruct: LambdaToStepFunction = new LambdaToStepfunctions(this, `${id}W`, convertedProps);
 
     this.lambdaFunction = wrappedConstruct.lambdaFunction;

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/__snapshots__/lambda-step-function.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/__snapshots__/lambda-step-function.test.js.snap
@@ -84,7 +84,7 @@ Object {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "LAMBDA_NAME": "existing-function",
             "STATE_MACHINE_ARN": Object {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D",
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19",
             },
           },
         },
@@ -183,7 +183,7 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D",
+                "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19",
               },
             },
           ],
@@ -198,7 +198,7 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionAbortedAlarm3410672A": Object {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionAbortedAlarmC0CADAC2": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -206,7 +206,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D",
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19",
             },
           },
         ],
@@ -219,7 +219,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionFailedAlarmD6BB272D": Object {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionFailedAlarm513E4C7C": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -227,7 +227,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D",
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19",
             },
           },
         ],
@@ -240,7 +240,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionThrottledAlarmE8079CC5": Object {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionThrottledAlarm08912C4F": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -248,7 +248,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D",
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19",
             },
           },
         ],
@@ -261,10 +261,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D": Object {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19": Object {
       "DependsOn": Array [
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48",
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06",
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B",
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -274,7 +274,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineLogGroupA191FCAA",
+                    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineLogGroup7291796E",
                     "Arn",
                   ],
                 },
@@ -285,14 +285,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06",
+            "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineLogGroupA191FCAA": Object {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineLogGroup7291796E": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -309,12 +309,12 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaulttestlambdastepfunctionconstructwrappedstatemachinelog0f99e6efac09",
+        "LogGroupName": "/aws/vendedlogs/states/defaulttestlambdastepfunctionconstructwstatemachinelogbb0fcb9b20b9",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06": Object {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -342,7 +342,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48": Object {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -398,10 +398,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48",
+        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B",
         "Roles": Array [
           Object {
-            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06",
+            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39",
           },
         ],
       },
@@ -428,7 +428,7 @@ Object {
     },
   },
   "Resources": Object {
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedExecutionAbortedAlarmC7FF6F55": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWExecutionAbortedAlarmB996058D": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -436,7 +436,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE",
+              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED",
             },
           },
         ],
@@ -449,7 +449,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedExecutionFailedAlarm8067D736": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWExecutionFailedAlarmB82026F5": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -457,7 +457,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE",
+              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED",
             },
           },
         ],
@@ -470,7 +470,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedExecutionThrottledAlarm728189CD": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWExecutionThrottledAlarmD6C471DD": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -478,7 +478,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE",
+              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED",
             },
           },
         ],
@@ -491,10 +491,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionDA41BBFF": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunction9C7C68AF": Object {
       "DependsOn": Array [
-        "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionServiceRoleDefaultPolicy8FEC69D1",
-        "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionServiceRole382C2FE2",
+        "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunctionServiceRoleDefaultPolicyCA1819E5",
+        "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunctionServiceRoleD072F490",
       ],
       "Metadata": Object {
         "cfn_nag": Object {
@@ -558,14 +558,14 @@ Object {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "LAMBDA_NAME": "deploy-function",
             "STATE_MACHINE_ARN": Object {
-              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE",
+              "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED",
             },
           },
         },
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionServiceRole382C2FE2",
+            "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunctionServiceRoleD072F490",
             "Arn",
           ],
         },
@@ -576,7 +576,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionServiceRole382C2FE2": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunctionServiceRoleD072F490": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -631,7 +631,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionServiceRoleDefaultPolicy8FEC69D1": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunctionServiceRoleDefaultPolicyCA1819E5": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -657,25 +657,25 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE",
+                "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionServiceRoleDefaultPolicy8FEC69D1",
+        "PolicyName": "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunctionServiceRoleDefaultPolicyCA1819E5",
         "Roles": Array [
           Object {
-            "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedLambdaFunctionServiceRole382C2FE2",
+            "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackWLambdaFunctionServiceRoleD072F490",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED": Object {
       "DependsOn": Array [
-        "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineRoleDefaultPolicy3CB927D5",
-        "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineRoleEA410CC1",
+        "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineRoleDefaultPolicy26F2A08C",
+        "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineRole3EDB944D",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -685,7 +685,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineLogGroupE2E4A4E0",
+                    "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineLogGroup18B411CB",
                     "Arn",
                   ],
                 },
@@ -696,14 +696,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineRoleEA410CC1",
+            "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineRole3EDB944D",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineLogGroupE2E4A4E0": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineLogGroup18B411CB": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -720,12 +720,40 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaultlambdatostepfunctionstackwrappedstatemachinelogac925b19c9f2",
+        "LogGroupName": "/aws/vendedlogs/states/defaultlambdatostepfunctionstackwstatemachinelogcdfe1ad94ef3",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineRoleDefaultPolicy3CB927D5": Object {
+    "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineRole3EDB944D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "states.",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ".amazonaws.com",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineRoleDefaultPolicy26F2A08C": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -781,42 +809,14 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineRoleDefaultPolicy3CB927D5",
+        "PolicyName": "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineRoleDefaultPolicy26F2A08C",
         "Roles": Array [
           Object {
-            "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineRoleEA410CC1",
+            "Ref": "lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineRole3EDB944D",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachineRoleEA410CC1": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "states.",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ".amazonaws.com",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
     },
   },
 }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deploy-lambda.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deploy-lambda.expected.json
@@ -1,9 +1,9 @@
 {
   "Resources": {
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineLogGroupA191FCAA": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineLogGroup7291796E": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/deploylambdatestlambdastepfunctionconstructwrappedstatemachinelog3e0189e9e7e0"
+        "LogGroupName": "/aws/vendedlogs/states/deploylambdatestlambdastepfunctionconstructwstatemachinelog13078db412a6"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -22,7 +22,7 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -50,7 +50,7 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -97,10 +97,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48",
+        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06"
+            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39"
           }
         ]
       },
@@ -115,12 +115,12 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06",
+            "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39",
             "Arn"
           ]
         },
@@ -131,7 +131,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineLogGroupA191FCAA",
+                    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineLogGroup7291796E",
                     "Arn"
                   ]
                 }
@@ -142,11 +142,11 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48",
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06"
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B",
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39"
       ]
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunctionServiceRoleFC82B03A": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunctionServiceRole87B6CB40": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -201,7 +201,7 @@
         ]
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunctionServiceRoleDefaultPolicy9EA25B7D": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunctionServiceRoleDefaultPolicy87D4E46F": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -218,16 +218,16 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+                "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunctionServiceRoleDefaultPolicy9EA25B7D",
+        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunctionServiceRoleDefaultPolicy87D4E46F",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunctionServiceRoleFC82B03A"
+            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunctionServiceRole87B6CB40"
           }
         ]
       },
@@ -242,7 +242,7 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunction1021BDBD": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunction66188A61": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -285,7 +285,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunctionServiceRoleFC82B03A",
+            "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunctionServiceRole87B6CB40",
             "Arn"
           ]
         },
@@ -293,7 +293,7 @@
           "Variables": {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "STATE_MACHINE_ARN": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         },
@@ -304,8 +304,8 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunctionServiceRoleDefaultPolicy9EA25B7D",
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedLambdaFunctionServiceRoleFC82B03A"
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunctionServiceRoleDefaultPolicy87D4E46F",
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWLambdaFunctionServiceRole87B6CB40"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -326,7 +326,7 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionFailedAlarmD6BB272D": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionFailedAlarm513E4C7C": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -336,7 +336,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         ],
@@ -347,7 +347,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionThrottledAlarmE8079CC5": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionThrottledAlarm08912C4F": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -357,7 +357,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         ],
@@ -368,7 +368,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionAbortedAlarm3410672A": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionAbortedAlarmC0CADAC2": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -378,7 +378,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deployFunctionWithVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.deployFunctionWithVpc.expected.json
@@ -1,10 +1,10 @@
 {
   "Description": "Integration Test for aws-lambda-step-function",
   "Resources": {
-    "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineLogGroup77280CCE": {
+    "testlambdastepfunctionstestlambdastepfunctionsWStateMachineLogGroup2E65D2A3": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/deployfunctionwithvpctestlambdastepfunctionswrappedstatemachineloga17627d82b85"
+        "LogGroupName": "/aws/vendedlogs/states/deployfunctionwithvpctestlambdastepfunctionswstatemachineloge2de3bbf2487"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -23,7 +23,7 @@
         }
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineRole872C16F5": {
+    "testlambdastepfunctionstestlambdastepfunctionsWStateMachineRoleA5B28910": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -51,7 +51,7 @@
         }
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineRoleDefaultPolicy26E1CFCD": {
+    "testlambdastepfunctionstestlambdastepfunctionsWStateMachineRoleDefaultPolicy2C2F2A42": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -98,10 +98,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineRoleDefaultPolicy26E1CFCD",
+        "PolicyName": "testlambdastepfunctionstestlambdastepfunctionsWStateMachineRoleDefaultPolicy2C2F2A42",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineRole872C16F5"
+            "Ref": "testlambdastepfunctionstestlambdastepfunctionsWStateMachineRoleA5B28910"
           }
         ]
       },
@@ -116,12 +116,12 @@
         }
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineB4F6BA60": {
+    "testlambdastepfunctionstestlambdastepfunctionsWStateMachine95B94E44": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineRole872C16F5",
+            "testlambdastepfunctionstestlambdastepfunctionsWStateMachineRoleA5B28910",
             "Arn"
           ]
         },
@@ -132,7 +132,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineLogGroup77280CCE",
+                    "testlambdastepfunctionstestlambdastepfunctionsWStateMachineLogGroup2E65D2A3",
                     "Arn"
                   ]
                 }
@@ -143,11 +143,11 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineRoleDefaultPolicy26E1CFCD",
-        "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineRole872C16F5"
+        "testlambdastepfunctionstestlambdastepfunctionsWStateMachineRoleDefaultPolicy2C2F2A42",
+        "testlambdastepfunctionstestlambdastepfunctionsWStateMachineRoleA5B28910"
       ]
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionServiceRole2D5B228F": {
+    "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunctionServiceRole4078B96B": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -202,7 +202,7 @@
         ]
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionServiceRoleDefaultPolicy21DEEB26": {
+    "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunctionServiceRoleDefaultPolicy17583F4E": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -230,16 +230,16 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineB4F6BA60"
+                "Ref": "testlambdastepfunctionstestlambdastepfunctionsWStateMachine95B94E44"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionServiceRoleDefaultPolicy21DEEB26",
+        "PolicyName": "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunctionServiceRoleDefaultPolicy17583F4E",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionServiceRole2D5B228F"
+            "Ref": "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunctionServiceRole4078B96B"
           }
         ]
       },
@@ -254,10 +254,10 @@
         }
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedReplaceDefaultSecurityGroupsecuritygroupFA1BF8B5": {
+    "testlambdastepfunctionstestlambdastepfunctionsWReplaceDefaultSecurityGroupsecuritygroup179A946A": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "deployFunctionWithVpc/test-lambda-stepfunctions/test-lambda-stepfunctions-wrapped/ReplaceDefaultSecurityGroup-security-group",
+        "GroupDescription": "deployFunctionWithVpc/test-lambda-stepfunctions/test-lambda-stepfunctionsW/ReplaceDefaultSecurityGroup-security-group",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",
@@ -284,7 +284,7 @@
         }
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionA6DC709D": {
+    "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunction69AF229F": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -327,7 +327,7 @@
         },
         "Role": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionServiceRole2D5B228F",
+            "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunctionServiceRole4078B96B",
             "Arn"
           ]
         },
@@ -335,7 +335,7 @@
           "Variables": {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "STATE_MACHINE_ARN": {
-              "Ref": "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineB4F6BA60"
+              "Ref": "testlambdastepfunctionstestlambdastepfunctionsWStateMachine95B94E44"
             }
           }
         },
@@ -348,7 +348,7 @@
           "SecurityGroupIds": [
             {
               "Fn::GetAtt": [
-                "testlambdastepfunctionstestlambdastepfunctionswrappedReplaceDefaultSecurityGroupsecuritygroupFA1BF8B5",
+                "testlambdastepfunctionstestlambdastepfunctionsWReplaceDefaultSecurityGroupsecuritygroup179A946A",
                 "GroupId"
               ]
             }
@@ -367,8 +367,8 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionServiceRoleDefaultPolicy21DEEB26",
-        "testlambdastepfunctionstestlambdastepfunctionswrappedLambdaFunctionServiceRole2D5B228F"
+        "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunctionServiceRoleDefaultPolicy17583F4E",
+        "testlambdastepfunctionstestlambdastepfunctionsWLambdaFunctionServiceRole4078B96B"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -389,7 +389,7 @@
         }
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedExecutionFailedAlarm8B4991FA": {
+    "testlambdastepfunctionstestlambdastepfunctionsWExecutionFailedAlarmBFA207F1": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -399,7 +399,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineB4F6BA60"
+              "Ref": "testlambdastepfunctionstestlambdastepfunctionsWStateMachine95B94E44"
             }
           }
         ],
@@ -410,7 +410,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedExecutionThrottledAlarmF14EF267": {
+    "testlambdastepfunctionstestlambdastepfunctionsWExecutionThrottledAlarm0F7BF1E9": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -420,7 +420,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineB4F6BA60"
+              "Ref": "testlambdastepfunctionstestlambdastepfunctionsWStateMachine95B94E44"
             }
           }
         ],
@@ -431,7 +431,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionstestlambdastepfunctionswrappedExecutionAbortedAlarmEC9B5853": {
+    "testlambdastepfunctionstestlambdastepfunctionsWExecutionAbortedAlarmF3E97C7F": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -441,7 +441,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionstestlambdastepfunctionswrappedStateMachineB4F6BA60"
+              "Ref": "testlambdastepfunctionstestlambdastepfunctionsWStateMachine95B94E44"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.existing-function.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/integ.existing-function.expected.json
@@ -72,7 +72,7 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+                "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
               }
             }
           ],
@@ -147,7 +147,7 @@
           "Variables": {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
             "STATE_MACHINE_ARN": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         },
@@ -180,10 +180,10 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineLogGroupA191FCAA": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineLogGroup7291796E": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/existingfunctiontestlambdastepfunctionconstructwrappedstatemachinelog8fd8faf7ac2e"
+        "LogGroupName": "/aws/vendedlogs/states/existingfunctiontestlambdastepfunctionconstructwstatemachinelog5c7ec858442a"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -202,7 +202,7 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -230,7 +230,7 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -277,10 +277,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48",
+        "PolicyName": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B",
         "Roles": [
           {
-            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06"
+            "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39"
           }
         ]
       },
@@ -295,12 +295,12 @@
         }
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06",
+            "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39",
             "Arn"
           ]
         },
@@ -311,7 +311,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineLogGroupA191FCAA",
+                    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineLogGroup7291796E",
                     "Arn"
                   ]
                 }
@@ -322,11 +322,11 @@
         }
       },
       "DependsOn": [
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRoleDefaultPolicyCED4BF48",
-        "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineRole07DDAA06"
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleDefaultPolicyF44CF55B",
+        "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineRoleC001CA39"
       ]
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionFailedAlarmD6BB272D": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionFailedAlarm513E4C7C": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -336,7 +336,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         ],
@@ -347,7 +347,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionThrottledAlarmE8079CC5": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionThrottledAlarm08912C4F": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -357,7 +357,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         ],
@@ -368,7 +368,7 @@
         "Threshold": 1
       }
     },
-    "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedExecutionAbortedAlarm3410672A": {
+    "testlambdastepfunctionconstructtestlambdastepfunctionconstructWExecutionAbortedAlarmC0CADAC2": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -378,7 +378,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructwrappedStateMachineD7DA108D"
+              "Ref": "testlambdastepfunctionconstructtestlambdastepfunctionconstructWStateMachineE1495D19"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/lambda-step-function.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-step-function/test/lambda-step-function.test.ts
@@ -50,7 +50,7 @@ test('Test deployment with new Lambda function', () => {
       Variables: {
         LAMBDA_NAME: 'deploy-function',
         STATE_MACHINE_ARN: {
-          Ref: 'lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE'
+          Ref: 'lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED'
         }
       }
     }
@@ -133,7 +133,7 @@ test('Test invocation permissions', () => {
           Action: "states:StartExecution",
           Effect: "Allow",
           Resource: {
-            Ref: "testlambdastepfunctionstacktestlambdastepfunctionstackwrappedStateMachine5EFFCECB"
+            Ref: "testlambdastepfunctionstacktestlambdastepfunctionstackWStateMachine924A396A"
           }
         }
       ],
@@ -235,7 +235,7 @@ test('Test lambda function custom environment variable', () => {
       Variables: {
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
         CUSTOM_STATE_MAHINCE: {
-          Ref: 'lambdatostepfunctionstacklambdatostepfunctionstackwrappedStateMachine0E6FBDAE'
+          Ref: 'lambdatostepfunctionstacklambdatostepfunctionstackWStateMachineB28C4CED'
         }
       }
     }
@@ -267,7 +267,7 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
       SecurityGroupIds: [
         {
           "Fn::GetAtt": [
-            "lambdatostepfunctionstacklambdatostepfunctionstackwrappedReplaceDefaultSecurityGroupsecuritygroup69C944EB",
+            "lambdatostepfunctionstacklambdatostepfunctionstackWReplaceDefaultSecurityGroupsecuritygroupC4A04662",
             "GroupId",
           ],
         },
@@ -326,7 +326,7 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
       SecurityGroupIds: [
         {
           "Fn::GetAtt": [
-            "lambdatostepfunctionstacklambdatostepfunctionstackwrappedReplaceDefaultSecurityGroupsecuritygroup69C944EB",
+            "lambdatostepfunctionstacklambdatostepfunctionstackWReplaceDefaultSecurityGroupsecuritygroupC4A04662",
             "GroupId",
           ],
         },
@@ -383,7 +383,7 @@ test("Test minimal deployment with an existing VPC", () => {
       SecurityGroupIds: [
         {
           "Fn::GetAtt": [
-            "lambdatostepfunctionstacklambdatostepfunctionstackwrappedReplaceDefaultSecurityGroupsecuritygroup69C944EB",
+            "lambdatostepfunctionstacklambdatostepfunctionstackWReplaceDefaultSecurityGroupsecuritygroupC4A04662",
             "GroupId",
           ],
         },

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
@@ -89,6 +89,11 @@ export class S3ToStepFunction extends Construct {
   constructor(scope: Construct, id: string, props: S3ToStepFunctionProps) {
     super(scope, id);
     const convertedProps: S3ToStepFunctionProps = { ...props };
+
+    // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // it in place of the older named version. They are functionally identical, aside from the types no other changes
+    // will be required.  (eg - new S3ToStepfunctions instead of S3ToStepFunction)
     const wrappedConstruct: S3ToStepFunction = new S3ToStepfunctions(this, `${id}W`, convertedProps);
 
     this.stateMachine = wrappedConstruct.stateMachine;

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
@@ -89,7 +89,7 @@ export class S3ToStepFunction extends Construct {
   constructor(scope: Construct, id: string, props: S3ToStepFunctionProps) {
     super(scope, id);
     const convertedProps: S3ToStepFunctionProps = { ...props };
-    const wrappedConstruct: S3ToStepFunction = new S3ToStepfunctions(this, `${id}-wrapped`, convertedProps);
+    const wrappedConstruct: S3ToStepFunction = new S3ToStepfunctions(this, `${id}W`, convertedProps);
 
     this.stateMachine = wrappedConstruct.stateMachine;
     this.stateMachineLogGroup = wrappedConstruct.stateMachineLogGroup;

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/lib/index.ts
@@ -91,7 +91,7 @@ export class S3ToStepFunction extends Construct {
     const convertedProps: S3ToStepFunctionProps = { ...props };
 
     // W (for 'wrapped') is added to the id so that the id's of the constructs with the old and new names don't collide
-    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate 
+    // If this character pushes you beyond the 64 character limit, just import the new named construct and instantiate
     // it in place of the older named version. They are functionally identical, aside from the types no other changes
     // will be required.  (eg - new S3ToStepfunctions instead of S3ToStepFunction)
     const wrappedConstruct: S3ToStepFunction = new S3ToStepfunctions(this, `${id}W`, convertedProps);

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/__snapshots__/s3-step-function.test.js.snap
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/__snapshots__/s3-step-function.test.js.snap
@@ -3,7 +3,7 @@
 exports[`snapshot test S3ToStepFunction default params 1`] = `
 Object {
   "Resources": Object {
-    "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3Bucket36BB1A41": Object {
+    "tests3stepfunctiontests3stepfunctionWCloudTrailS3Bucket24C50489": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketEncryption": Object {
@@ -30,7 +30,7 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3LoggingBucket6AF72EAB",
+            "Ref": "tests3stepfunctiontests3stepfunctionWCloudTrailS3LoggingBucket449D5AB7",
           },
         },
         "PublicAccessBlockConfiguration": Object {
@@ -46,10 +46,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3BucketPolicy58F28977": Object {
+    "tests3stepfunctiontests3stepfunctionWCloudTrailS3BucketPolicy9ACF9ADC": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3Bucket36BB1A41",
+          "Ref": "tests3stepfunctiontests3stepfunctionWCloudTrailS3Bucket24C50489",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -71,7 +71,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3Bucket36BB1A41",
+                          "tests3stepfunctiontests3stepfunctionWCloudTrailS3Bucket24C50489",
                           "Arn",
                         ],
                       },
@@ -81,7 +81,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3Bucket36BB1A41",
+                    "tests3stepfunctiontests3stepfunctionWCloudTrailS3Bucket24C50489",
                     "Arn",
                   ],
                 },
@@ -96,7 +96,7 @@ Object {
               },
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3Bucket36BB1A41",
+                  "tests3stepfunctiontests3stepfunctionWCloudTrailS3Bucket24C50489",
                   "Arn",
                 ],
               },
@@ -118,7 +118,7 @@ Object {
                   Array [
                     Object {
                       "Fn::GetAtt": Array [
-                        "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3Bucket36BB1A41",
+                        "tests3stepfunctiontests3stepfunctionWCloudTrailS3Bucket24C50489",
                         "Arn",
                       ],
                     },
@@ -137,7 +137,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3LoggingBucket6AF72EAB": Object {
+    "tests3stepfunctiontests3stepfunctionWCloudTrailS3LoggingBucket449D5AB7": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -173,10 +173,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3LoggingBucketPolicyB2A29099": Object {
+    "tests3stepfunctiontests3stepfunctionWCloudTrailS3LoggingBucketPolicy7547A73F": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3LoggingBucket6AF72EAB",
+          "Ref": "tests3stepfunctiontests3stepfunctionWCloudTrailS3LoggingBucket449D5AB7",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -198,7 +198,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3LoggingBucket6AF72EAB",
+                          "tests3stepfunctiontests3stepfunctionWCloudTrailS3LoggingBucket449D5AB7",
                           "Arn",
                         ],
                       },
@@ -208,7 +208,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3LoggingBucket6AF72EAB",
+                    "tests3stepfunctiontests3stepfunctionWCloudTrailS3LoggingBucket449D5AB7",
                     "Arn",
                   ],
                 },
@@ -221,7 +221,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedS3BucketAB38FBAE": Object {
+    "tests3stepfunctiontests3stepfunctionWS3Bucket9BE64924": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketEncryption": Object {
@@ -248,7 +248,7 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "tests3stepfunctiontests3stepfunctionwrappedS3LoggingBucket41A6693F",
+            "Ref": "tests3stepfunctiontests3stepfunctionWS3LoggingBucketB716417C",
           },
         },
         "PublicAccessBlockConfiguration": Object {
@@ -264,10 +264,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedS3BucketPolicyA8AB98B3": Object {
+    "tests3stepfunctiontests3stepfunctionWS3BucketPolicy6A88EABC": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "tests3stepfunctiontests3stepfunctionwrappedS3BucketAB38FBAE",
+          "Ref": "tests3stepfunctiontests3stepfunctionWS3Bucket9BE64924",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -289,7 +289,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "tests3stepfunctiontests3stepfunctionwrappedS3BucketAB38FBAE",
+                          "tests3stepfunctiontests3stepfunctionWS3Bucket9BE64924",
                           "Arn",
                         ],
                       },
@@ -299,7 +299,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "tests3stepfunctiontests3stepfunctionwrappedS3BucketAB38FBAE",
+                    "tests3stepfunctiontests3stepfunctionWS3Bucket9BE64924",
                     "Arn",
                   ],
                 },
@@ -312,9 +312,9 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedS3EventsTrailF4ABB84A": Object {
+    "tests3stepfunctiontests3stepfunctionWS3EventsTrailA0FDE626": Object {
       "DependsOn": Array [
-        "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3BucketPolicy58F28977",
+        "tests3stepfunctiontests3stepfunctionWCloudTrailS3BucketPolicy9ACF9ADC",
       ],
       "Properties": Object {
         "EnableLogFileValidation": true,
@@ -330,7 +330,7 @@ Object {
                       Array [
                         Object {
                           "Fn::GetAtt": Array [
-                            "tests3stepfunctiontests3stepfunctionwrappedS3BucketAB38FBAE",
+                            "tests3stepfunctiontests3stepfunctionWS3Bucket9BE64924",
                             "Arn",
                           ],
                         },
@@ -349,12 +349,12 @@ Object {
         "IsLogging": true,
         "IsMultiRegionTrail": true,
         "S3BucketName": Object {
-          "Ref": "tests3stepfunctiontests3stepfunctionwrappedCloudTrailS3Bucket36BB1A41",
+          "Ref": "tests3stepfunctiontests3stepfunctionWCloudTrailS3Bucket24C50489",
         },
       },
       "Type": "AWS::CloudTrail::Trail",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedS3LoggingBucket41A6693F": Object {
+    "tests3stepfunctiontests3stepfunctionWS3LoggingBucketB716417C": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -390,10 +390,10 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedS3LoggingBucketPolicyD64FEE47": Object {
+    "tests3stepfunctiontests3stepfunctionWS3LoggingBucketPolicy8E5E6292": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "tests3stepfunctiontests3stepfunctionwrappedS3LoggingBucket41A6693F",
+          "Ref": "tests3stepfunctiontests3stepfunctionWS3LoggingBucketB716417C",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -415,7 +415,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "tests3stepfunctiontests3stepfunctionwrappedS3LoggingBucket41A6693F",
+                          "tests3stepfunctiontests3stepfunctionWS3LoggingBucketB716417C",
                           "Arn",
                         ],
                       },
@@ -425,7 +425,7 @@ Object {
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "tests3stepfunctiontests3stepfunctionwrappedS3LoggingBucket41A6693F",
+                    "tests3stepfunctiontests3stepfunctionWS3LoggingBucketB716417C",
                     "Arn",
                   ],
                 },
@@ -438,7 +438,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructEventsRule024102DB": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructEventsRule2C8C073A": Object {
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -453,7 +453,7 @@ Object {
             "requestParameters": Object {
               "bucketName": Array [
                 Object {
-                  "Ref": "tests3stepfunctiontests3stepfunctionwrappedS3BucketAB38FBAE",
+                  "Ref": "tests3stepfunctiontests3stepfunctionWS3Bucket9BE64924",
                 },
               ],
             },
@@ -469,12 +469,12 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Ref": "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachine6874E63D",
+              "Ref": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineAAE00FFE",
             },
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructEventsRuleRole0706EB34",
+                "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructEventsRuleRole1B233B12",
                 "Arn",
               ],
             },
@@ -483,7 +483,7 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructEventsRuleRole0706EB34": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructEventsRuleRole1B233B12": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -500,7 +500,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructEventsRuleRoleDefaultPolicyE6DE5D78": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructEventsRuleRoleDefaultPolicyA55D44AB": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -508,22 +508,22 @@ Object {
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": Object {
-                "Ref": "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachine6874E63D",
+                "Ref": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineAAE00FFE",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructEventsRuleRoleDefaultPolicyE6DE5D78",
+        "PolicyName": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructEventsRuleRoleDefaultPolicyA55D44AB",
         "Roles": Array [
           Object {
-            "Ref": "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructEventsRuleRole0706EB34",
+            "Ref": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructEventsRuleRole1B233B12",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructExecutionAbortedAlarmA9E063A2": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructExecutionAbortedAlarm0D634092": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that aborted exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -531,7 +531,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachine6874E63D",
+              "Ref": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineAAE00FFE",
             },
           },
         ],
@@ -544,7 +544,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructExecutionFailedAlarm194F2DE7": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructExecutionFailedAlarm0292B991": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that failed exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -552,7 +552,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachine6874E63D",
+              "Ref": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineAAE00FFE",
             },
           },
         ],
@@ -565,7 +565,7 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructExecutionThrottledAlarm0C165971": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructExecutionThrottledAlarmC8F77F85": Object {
       "Properties": Object {
         "AlarmDescription": "Alarm for the number of executions that throttled exceeded the threshold of 1. ",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -573,7 +573,7 @@ Object {
           Object {
             "Name": "StateMachineArn",
             "Value": Object {
-              "Ref": "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachine6874E63D",
+              "Ref": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineAAE00FFE",
             },
           },
         ],
@@ -586,10 +586,10 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachine6874E63D": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineAAE00FFE": Object {
       "DependsOn": Array [
-        "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicyBD4C3856",
-        "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineRole12AC4737",
+        "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineRoleDefaultPolicyC73B582F",
+        "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineRoleDCB350A2",
       ],
       "Properties": Object {
         "DefinitionString": "{\\"StartAt\\":\\"StartState\\",\\"States\\":{\\"StartState\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
@@ -599,7 +599,7 @@ Object {
               "CloudWatchLogsLogGroup": Object {
                 "LogGroupArn": Object {
                   "Fn::GetAtt": Array [
-                    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineLogGroupF3D52CD5",
+                    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineLogGroupE83EECDD",
                     "Arn",
                   ],
                 },
@@ -610,14 +610,14 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineRole12AC4737",
+            "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineRoleDCB350A2",
             "Arn",
           ],
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineLogGroupF3D52CD5": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineLogGroupE83EECDD": Object {
       "DeletionPolicy": "Retain",
       "Metadata": Object {
         "cfn_nag": Object {
@@ -634,12 +634,12 @@ Object {
         },
       },
       "Properties": Object {
-        "LogGroupName": "/aws/vendedlogs/states/defaulttests3stepfunctionwrappedeventrulestepfunctionconstructstatemachinelogda6643d1acfc",
+        "LogGroupName": "/aws/vendedlogs/states/defaulttests3stepfunctionweventrulestepfunctionconstructstatemachinelogfb43dc28fae1",
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineRole12AC4737": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineRoleDCB350A2": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -667,7 +667,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicyBD4C3856": Object {
+    "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineRoleDefaultPolicyC73B582F": Object {
       "Metadata": Object {
         "cfn_nag": Object {
           "rules_to_suppress": Array [
@@ -723,10 +723,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "tepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicyBD4C3856",
+        "PolicyName": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineRoleDefaultPolicyC73B582F",
         "Roles": Array [
           Object {
-            "Ref": "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachineRole12AC4737",
+            "Ref": "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineRoleDCB350A2",
           },
         ],
       },

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.pre-existing-bucket.expected.json
@@ -37,7 +37,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3LoggingBucket1DF76A98": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3LoggingBucket0FE28A33": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -73,11 +73,11 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3LoggingBucketPolicyC2A056AD": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3LoggingBucketPolicy9C7C6620": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3LoggingBucket1DF76A98"
+          "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3LoggingBucket0FE28A33"
         },
         "PolicyDocument": {
           "Statement": [
@@ -99,7 +99,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3LoggingBucket1DF76A98",
+                          "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3LoggingBucket0FE28A33",
                           "Arn"
                         ]
                       },
@@ -109,7 +109,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3LoggingBucket1DF76A98",
+                    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3LoggingBucket0FE28A33",
                     "Arn"
                   ]
                 }
@@ -121,7 +121,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3Bucket32F7E31B": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3Bucket3EEB70B1": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -148,7 +148,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3LoggingBucket1DF76A98"
+            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3LoggingBucket0FE28A33"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -164,11 +164,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3BucketPolicy9D582977": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3BucketPolicyA31EBB8B": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3Bucket32F7E31B"
+          "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3Bucket3EEB70B1"
         },
         "PolicyDocument": {
           "Statement": [
@@ -190,7 +190,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3Bucket32F7E31B",
+                          "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3Bucket3EEB70B1",
                           "Arn"
                         ]
                       },
@@ -200,7 +200,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3Bucket32F7E31B",
+                    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3Bucket3EEB70B1",
                     "Arn"
                   ]
                 }
@@ -215,7 +215,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3Bucket32F7E31B",
+                  "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3Bucket3EEB70B1",
                   "Arn"
                 ]
               }
@@ -237,7 +237,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3Bucket32F7E31B",
+                        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3Bucket3EEB70B1",
                         "Arn"
                       ]
                     },
@@ -255,12 +255,12 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedS3EventsTrail9DB7D51F": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWS3EventsTrail9D60BAC8": {
       "Type": "AWS::CloudTrail::Trail",
       "Properties": {
         "IsLogging": true,
         "S3BucketName": {
-          "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3Bucket32F7E31B"
+          "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3Bucket3EEB70B1"
         },
         "EnableLogFileValidation": true,
         "EventSelectors": [
@@ -296,13 +296,13 @@
         "IsMultiRegionTrail": true
       },
       "DependsOn": [
-        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedCloudTrailS3BucketPolicy9D582977"
+        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWCloudTrailS3BucketPolicyA31EBB8B"
       ]
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineLogGroupFBED1AAB": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineLogGroupF215071C": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/preexistingbuckettests3stepfunctionpreexistingbucketconstructwrappedeventruleststatemachinelog6fbf04daf21b"
+        "LogGroupName": "/aws/vendedlogs/states/preexistingbuckettests3stepfunctionpreexistingbucketconstructweventrulestepfuncstatemachinelog17fbe854e125"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -321,7 +321,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineRole139C9720": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineRole379EE017": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -349,7 +349,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicy6FD42269": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineRoleDefaultPolicyCEBBD057": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -396,10 +396,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "uctwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicy6FD42269",
+        "PolicyName": "bucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineRoleDefaultPolicyCEBBD057",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineRole139C9720"
+            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineRole379EE017"
           }
         ]
       },
@@ -414,12 +414,12 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachine7A00C89E": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineD84C4ABE": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineRole139C9720",
+            "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineRole379EE017",
             "Arn"
           ]
         },
@@ -430,7 +430,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineLogGroupFBED1AAB",
+                    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineLogGroupF215071C",
                     "Arn"
                   ]
                 }
@@ -441,11 +441,11 @@
         }
       },
       "DependsOn": [
-        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicy6FD42269",
-        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachineRole139C9720"
+        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineRoleDefaultPolicyCEBBD057",
+        "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineRole379EE017"
       ]
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructEventsRuleRoleFEC99C6E": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructEventsRuleRoleB694232E": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -462,7 +462,7 @@
         }
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy2EA761FE": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy952F9C45": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -471,21 +471,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachine7A00C89E"
+                "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineD84C4ABE"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy2EA761FE",
+        "PolicyName": "ngbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy952F9C45",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructEventsRuleRoleFEC99C6E"
+            "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructEventsRuleRoleB694232E"
           }
         ]
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructEventsRule5488B0A2": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructEventsRuleB35653AA": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
@@ -517,12 +517,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachine7A00C89E"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineD84C4ABE"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructEventsRuleRoleFEC99C6E",
+                "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructEventsRuleRoleB694232E",
                 "Arn"
               ]
             }
@@ -530,7 +530,7 @@
         ]
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructExecutionFailedAlarm63BDB59B": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructExecutionFailedAlarm5C1CDF84": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -540,7 +540,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachine7A00C89E"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineD84C4ABE"
             }
           }
         ],
@@ -551,7 +551,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructExecutionThrottledAlarm625C6F34": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructExecutionThrottledAlarm999FAD0B": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -561,7 +561,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachine7A00C89E"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineD84C4ABE"
             }
           }
         ],
@@ -572,7 +572,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructExecutionAbortedAlarmE209BC2D": {
+    "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructExecutionAbortedAlarmD631F5A8": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -582,7 +582,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructwrappedtests3stepfunctionpreexistingbucketconstructwrappedeventrulestepfunctionconstructStateMachine7A00C89E"
+              "Ref": "tests3stepfunctionpreexistingbucketconstructtests3stepfunctionpreexistingbucketconstructWtests3stepfunctionpreexistingbucketconstructWeventrulestepfunctionconstructStateMachineD84C4ABE"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.s3-step-function-no-argument.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/integ.s3-step-function-no-argument.expected.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3LoggingBucket3CE8514C": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWS3LoggingBucket615E11F3": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -36,11 +36,11 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3LoggingBucketPolicy20881134": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWS3LoggingBucketPolicyC5059059": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3LoggingBucket3CE8514C"
+          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWS3LoggingBucket615E11F3"
         },
         "PolicyDocument": {
           "Statement": [
@@ -62,7 +62,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3LoggingBucket3CE8514C",
+                          "tests3stepfunctionconstructtests3stepfunctionconstructWS3LoggingBucket615E11F3",
                           "Arn"
                         ]
                       },
@@ -72,7 +72,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3LoggingBucket3CE8514C",
+                    "tests3stepfunctionconstructtests3stepfunctionconstructWS3LoggingBucket615E11F3",
                     "Arn"
                   ]
                 }
@@ -84,7 +84,7 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3Bucket743746E1": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWS3Bucket474FE3A1": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -111,7 +111,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3LoggingBucket3CE8514C"
+            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWS3LoggingBucket615E11F3"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -127,11 +127,11 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3BucketPolicyA4C4A1D3": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWS3BucketPolicy4513F8D8": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3Bucket743746E1"
+          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWS3Bucket474FE3A1"
         },
         "PolicyDocument": {
           "Statement": [
@@ -153,7 +153,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3Bucket743746E1",
+                          "tests3stepfunctionconstructtests3stepfunctionconstructWS3Bucket474FE3A1",
                           "Arn"
                         ]
                       },
@@ -163,7 +163,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3Bucket743746E1",
+                    "tests3stepfunctionconstructtests3stepfunctionconstructWS3Bucket474FE3A1",
                     "Arn"
                   ]
                 }
@@ -175,7 +175,7 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3LoggingBucketD1F7B585": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3LoggingBucketC008CB57": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "LogDeliveryWrite",
@@ -211,11 +211,11 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3LoggingBucketPolicyDB61553C": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3LoggingBucketPolicyEBACDA63": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3LoggingBucketD1F7B585"
+          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3LoggingBucketC008CB57"
         },
         "PolicyDocument": {
           "Statement": [
@@ -237,7 +237,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3LoggingBucketD1F7B585",
+                          "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3LoggingBucketC008CB57",
                           "Arn"
                         ]
                       },
@@ -247,7 +247,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3LoggingBucketD1F7B585",
+                    "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3LoggingBucketC008CB57",
                     "Arn"
                   ]
                 }
@@ -259,7 +259,7 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3Bucket1F42F6B4": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketACD4E98E": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -286,7 +286,7 @@
         },
         "LoggingConfiguration": {
           "DestinationBucketName": {
-            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3LoggingBucketD1F7B585"
+            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3LoggingBucketC008CB57"
           }
         },
         "PublicAccessBlockConfiguration": {
@@ -302,11 +302,11 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3BucketPolicy27FD1311": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketPolicy25F2E4B1": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3Bucket1F42F6B4"
+          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketACD4E98E"
         },
         "PolicyDocument": {
           "Statement": [
@@ -328,7 +328,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3Bucket1F42F6B4",
+                          "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketACD4E98E",
                           "Arn"
                         ]
                       },
@@ -338,7 +338,7 @@
                 },
                 {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3Bucket1F42F6B4",
+                    "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketACD4E98E",
                     "Arn"
                   ]
                 }
@@ -353,7 +353,7 @@
               },
               "Resource": {
                 "Fn::GetAtt": [
-                  "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3Bucket1F42F6B4",
+                  "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketACD4E98E",
                   "Arn"
                 ]
               }
@@ -375,7 +375,7 @@
                   [
                     {
                       "Fn::GetAtt": [
-                        "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3Bucket1F42F6B4",
+                        "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketACD4E98E",
                         "Arn"
                       ]
                     },
@@ -393,12 +393,12 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3EventsTrailBDDCCA02": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWS3EventsTrail64B14DA8": {
       "Type": "AWS::CloudTrail::Trail",
       "Properties": {
         "IsLogging": true,
         "S3BucketName": {
-          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3Bucket1F42F6B4"
+          "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketACD4E98E"
         },
         "EnableLogFileValidation": true,
         "EventSelectors": [
@@ -413,7 +413,7 @@
                       [
                         {
                           "Fn::GetAtt": [
-                            "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3Bucket743746E1",
+                            "tests3stepfunctionconstructtests3stepfunctionconstructWS3Bucket474FE3A1",
                             "Arn"
                           ]
                         },
@@ -432,13 +432,13 @@
         "IsMultiRegionTrail": true
       },
       "DependsOn": [
-        "tests3stepfunctionconstructtests3stepfunctionconstructwrappedCloudTrailS3BucketPolicy27FD1311"
+        "tests3stepfunctionconstructtests3stepfunctionconstructWCloudTrailS3BucketPolicy25F2E4B1"
       ]
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineLogGroup0C31372A": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineLogGroup9A7BB9BF": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/s3stepfunctionnoargumenttests3stepfunctionconstructwrappedeventrulestepfunctionconstrucstatemachinelog44e6d6ada77b"
+        "LogGroupName": "/aws/vendedlogs/states/s3stepfunctionnoargumenttests3stepfunctionconstructweventrulestepfunctionconstructstatemachinelog0385251f0c2a"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",
@@ -457,7 +457,7 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineRole39C6C92A": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineRole66E57E5E": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -485,7 +485,7 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicy405AF3DD": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineRoleDefaultPolicy48779FA2": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -532,10 +532,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicy405AF3DD",
+        "PolicyName": "tructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineRoleDefaultPolicy48779FA2",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineRole39C6C92A"
+            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineRole66E57E5E"
           }
         ]
       },
@@ -550,12 +550,12 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineB6292501": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachine1203E9BD": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineRole39C6C92A",
+            "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineRole66E57E5E",
             "Arn"
           ]
         },
@@ -566,7 +566,7 @@
               "CloudWatchLogsLogGroup": {
                 "LogGroupArn": {
                   "Fn::GetAtt": [
-                    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineLogGroup0C31372A",
+                    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineLogGroup9A7BB9BF",
                     "Arn"
                   ]
                 }
@@ -577,11 +577,11 @@
         }
       },
       "DependsOn": [
-        "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineRoleDefaultPolicy405AF3DD",
-        "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineRole39C6C92A"
+        "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineRoleDefaultPolicy48779FA2",
+        "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachineRole66E57E5E"
       ]
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructEventsRuleRoleD60F7CAA": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructEventsRuleRole726956CE": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -598,7 +598,7 @@
         }
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructEventsRuleRoleDefaultPolicyE3AADA41": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy15081360": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -607,21 +607,21 @@
               "Action": "states:StartExecution",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineB6292501"
+                "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachine1203E9BD"
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructEventsRuleRoleDefaultPolicyE3AADA41",
+        "PolicyName": "nstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructEventsRuleRoleDefaultPolicy15081360",
         "Roles": [
           {
-            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructEventsRuleRoleD60F7CAA"
+            "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructEventsRuleRole726956CE"
           }
         ]
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructEventsRule10FDBFF7": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructEventsRule469BF966": {
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
@@ -643,7 +643,7 @@
             "requestParameters": {
               "bucketName": [
                 {
-                  "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedS3Bucket743746E1"
+                  "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWS3Bucket474FE3A1"
                 }
               ]
             }
@@ -653,12 +653,12 @@
         "Targets": [
           {
             "Arn": {
-              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineB6292501"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachine1203E9BD"
             },
             "Id": "Target0",
             "RoleArn": {
               "Fn::GetAtt": [
-                "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructEventsRuleRoleD60F7CAA",
+                "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructEventsRuleRole726956CE",
                 "Arn"
               ]
             }
@@ -666,7 +666,7 @@
         ]
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructExecutionFailedAlarm0FBDCAFE": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructExecutionFailedAlarm1154DD22": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -676,7 +676,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineB6292501"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachine1203E9BD"
             }
           }
         ],
@@ -687,7 +687,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructExecutionThrottledAlarmD3596941": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructExecutionThrottledAlarm3645C655": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -697,7 +697,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineB6292501"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachine1203E9BD"
             }
           }
         ],
@@ -708,7 +708,7 @@
         "Threshold": 1
       }
     },
-    "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructExecutionAbortedAlarm0F06B4B5": {
+    "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructExecutionAbortedAlarm36625641": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -718,7 +718,7 @@
           {
             "Name": "StateMachineArn",
             "Value": {
-              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructwrappedtests3stepfunctionconstructwrappedeventrulestepfunctionconstructStateMachineB6292501"
+              "Ref": "tests3stepfunctionconstructtests3stepfunctionconstructWtests3stepfunctionconstructWeventrulestepfunctionconstructStateMachine1203E9BD"
             }
           }
         ],

--- a/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/s3-step-function.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-step-function/test/s3-step-function.test.ts
@@ -116,12 +116,12 @@ test('override eventRuleProps', () => {
     Targets: [
       {
         Arn: {
-          Ref: "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructStateMachine6874E63D"
+          Ref: "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructStateMachineAAE00FFE"
         },
         Id: "Target0",
         RoleArn: {
           "Fn::GetAtt": [
-            "tests3stepfunctiontests3stepfunctionwrappedtests3stepfunctionwrappedeventrulestepfunctionconstructEventsRuleRole0706EB34",
+            "tests3stepfunctiontests3stepfunctionWtests3stepfunctionWeventrulestepfunctionconstructEventsRuleRole1B233B12",
             "Arn"
           ]
         }


### PR DESCRIPTION
*Issue #369 , if available:*

*Description of changes:*
-Replaced `-wrapped` with `W` in order to prevent the error of more than 64 characters in an ID name
-Updated all tests to support new id names

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

fixes #369