### PR TITLE
fix(doc): Typo in aws-sns-lambda README.md

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/README.md
@@ -45,7 +45,7 @@ _Parameters_
 
 * scope [`Construct`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_core.Construct.html)
 * id `string`
-* props [`S3ToLambdaProps`](#pattern-construct-props)
+* props [`SnsToLambdaProps`](#pattern-construct-props)
 
 ## Pattern Construct Props
 


### PR DESCRIPTION
Fix typo and reference SnsToLambdaProps correctly.

*Issue #, if available:* N/A

*Description of changes:* Minor typo in the docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.