### PR TITLE
fix(api-usage-plan): update cfn templates with api usage plan

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.expected.json
@@ -1263,7 +1263,7 @@
         ]
       }
     },
-    "testapigatewayiotRestApiUsagePlanUsagePlanKeyResource427DC49B": {
+    "testapigatewayiotRestApiUsagePlanUsagePlanKeyResourceoverrideParamstestapigatewayiotRestApiApiKey9DF117C022AD8BF0": {
       "Type": "AWS::ApiGateway::UsagePlanKey",
       "Properties": {
         "KeyId": {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.override_auth_api_keys.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.override_auth_api_keys.expected.json
@@ -1261,7 +1261,7 @@
         ]
       }
     },
-    "testapigatewayiotRestApiUsagePlanUsagePlanKeyResource427DC49B": {
+    "testapigatewayiotRestApiUsagePlanUsagePlanKeyResourceoverrideauthapikeystestapigatewayiotRestApiApiKey393D3E36B43FA58D": {
       "Type": "AWS::ApiGateway::UsagePlanKey",
       "Properties": {
         "KeyId": {

--- a/source/tools/cdk-integ-tools/bin/cdk-integ-assert.ts
+++ b/source/tools/cdk-integ-tools/bin/cdk-integ-assert.ts
@@ -24,7 +24,8 @@ async function main() {
     // Enable Default KMS policy to match with CDK v2 expected KMS policy
     let actual = await test.cdkSynthFast(deepmerge(DEFAULT_SYNTH_OPTIONS, {
       context: {
-        '@aws-cdk/aws-kms:defaultKeyPolicies': true
+        '@aws-cdk/aws-kms:defaultKeyPolicies': true,
+        '@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId' : true
       }
     }));
 

--- a/source/tools/cdk-integ-tools/bin/cdk-integ.ts
+++ b/source/tools/cdk-integ-tools/bin/cdk-integ.ts
@@ -54,7 +54,8 @@ async function main() {
       // Enable Default KMS policy to match with CDK v2 expected KMS policy
       const actual = await test.cdkSynthFast(deepmerge(DEFAULT_SYNTH_OPTIONS, {
         context: {
-          '@aws-cdk/aws-kms:defaultKeyPolicies': true
+          '@aws-cdk/aws-kms:defaultKeyPolicies': true,
+          '@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId' : true
         }
       }));
 


### PR DESCRIPTION
*Issue #, if available:* [396](https://github.com/awslabs/aws-solutions-constructs/issues/396)

*Description of changes:*

Update Cfn templates to match the expected results for CDK v2 and V1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.