### PR TITLE
fix(cdk-v2-align-version): it fails to build cdk-integ-tools for constructs v2.0.0-rc.2

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
@@ -66,8 +66,7 @@
   "devDependencies": {
     "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^26.0.22",
-    "@types/node": "^10.3.0",
-    "aws-cdk": "0.0.0"
+    "@types/node": "^10.3.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/source/tools/cdk-integ-tools/package.json
+++ b/source/tools/cdk-integ-tools/package.json
@@ -35,7 +35,6 @@
     "@aws-cdk/cloudformation-diff": "0.0.0",
     "@aws-cdk/cx-api": "0.0.0",
     "@aws-cdk/assert": "0.0.0",
-    "aws-cdk": "0.0.0",
     "fs-extra": "^9.0.1",
     "yargs": "^16.1.1",
     "deepmerge": "^4.0.0"


### PR DESCRIPTION
*Issue #, if available:* [423](https://github.com/awslabs/aws-solutions-constructs/issues/423)

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.