### PR TITLE
fix(use-cases): Fix postinstall script in restaurant-demo

### DIFF
--- a/source/use_cases/aws-restaurant-management-demo/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/package.json
@@ -16,7 +16,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "postinstall": "cd lib/lambda/service-staff/create-order && && npm install && cd ../../../..",
+    "postinstall": "cd lib/lambda/service-staff/create-order && npm install && cd ../../../..",
     "build": "tsc",
     "lint": "eslint -c ../eslintrc.yml --ext=.js,.ts . && tslint --project .",
     "lint-fix": "eslint -c ../eslintrc.yml --ext=.js,.ts --fix .",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removed double && &&, which was causing the postinstall to error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.