### PR TITLE
chore(release): 1.128.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.128.0](https://github.com/awslabs/aws-solutions-constructs/compare/v1.127.0...v1.128.0) (2021-11-28)
+
 ## [1.127.0](https://github.com/awslabs/aws-solutions-constructs/compare/v2.0.0-rc.2...v1.127.0) (2021-11-28)
 
 * Upgraded all patterns to CDK v1.127.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [1.128.0](https://github.com/awslabs/aws-solutions-constructs/compare/v1.127.0...v1.128.0) (2021-11-28)
 
+* Upgraded all patterns to CDK v1.128.0
+
 ## [1.127.0](https://github.com/awslabs/aws-solutions-constructs/compare/v2.0.0-rc.2...v1.127.0) (2021-11-28)
 
 * Upgraded all patterns to CDK v1.127.0

--- a/source/lerna.json
+++ b/source/lerna.json
@@ -6,5 +6,5 @@
     "./patterns/@aws-solutions-constructs/*"
   ],
   "rejectCycles": "true",
-  "version": "1.127.0"
+  "version": "1.128.0"
 }


### PR DESCRIPTION
See [CHANGELOG](https://github.com/awslabs/aws-solutions-constructs/blob/bump/1.128.0/CHANGELOG.md)