### PR TITLE
fix(aws-apigateway-iot and aws-cloudfront-apigateway-lambda): fixed deprecated warnings (TESTING BUILD)

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
@@ -11,260 +11,260 @@
  *  and limitations under the License.
  */
 
- import { CloudFrontToApiGatewayToLambda, CloudFrontToApiGatewayToLambdaProps } from "../lib";
- import * as cdk from "@aws-cdk/core";
- import * as lambda from '@aws-cdk/aws-lambda';
- import * as api from '@aws-cdk/aws-apigateway';
- import * as s3 from "@aws-cdk/aws-s3";
- import '@aws-cdk/assert/jest';
+import { CloudFrontToApiGatewayToLambda, CloudFrontToApiGatewayToLambdaProps } from "../lib";
+import * as cdk from "@aws-cdk/core";
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as api from '@aws-cdk/aws-apigateway';
+import * as s3 from "@aws-cdk/aws-s3";
+import '@aws-cdk/assert/jest';
 
- function deployNewFunc(stack: cdk.Stack) {
-   const lambdaFunctionProps: lambda.FunctionProps = {
-     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-     runtime: lambda.Runtime.NODEJS_10_X,
-     handler: 'index.handler'
-   };
+function deployNewFunc(stack: cdk.Stack) {
+  const lambdaFunctionProps: lambda.FunctionProps = {
+    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+    runtime: lambda.Runtime.NODEJS_10_X,
+    handler: 'index.handler'
+  };
 
-   return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-     lambdaFunctionProps
-   });
- }
+  return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+    lambdaFunctionProps
+  });
+}
 
- function useExistingFunc(stack: cdk.Stack) {
-   const lambdaFunctionProps: lambda.FunctionProps = {
-     runtime: lambda.Runtime.NODEJS_10_X,
-     handler: 'index.handler',
-     code: lambda.Code.fromAsset(`${__dirname}/lambda`)
-   };
+function useExistingFunc(stack: cdk.Stack) {
+  const lambdaFunctionProps: lambda.FunctionProps = {
+    runtime: lambda.Runtime.NODEJS_10_X,
+    handler: 'index.handler',
+    code: lambda.Code.fromAsset(`${__dirname}/lambda`)
+  };
 
-   return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-     existingLambdaObj: new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps)
-   });
- }
+  return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+    existingLambdaObj: new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps)
+  });
+}
 
- test('check properties', () => {
-   const stack = new cdk.Stack();
+test('check properties', () => {
+  const stack = new cdk.Stack();
 
-   const construct: CloudFrontToApiGatewayToLambda = deployNewFunc(stack);
+  const construct: CloudFrontToApiGatewayToLambda = deployNewFunc(stack);
 
-   expect(construct.cloudFrontWebDistribution !== null);
-   expect(construct.apiGateway !== null);
-   expect(construct.lambdaFunction !== null);
-   expect(construct.cloudFrontFunction !== null);
-   expect(construct.cloudFrontLoggingBucket !== null);
-   expect(construct.apiGatewayCloudWatchRole !== null);
-   expect(construct.apiGatewayLogGroup !== null);
- });
+  expect(construct.cloudFrontWebDistribution !== null);
+  expect(construct.apiGateway !== null);
+  expect(construct.lambdaFunction !== null);
+  expect(construct.cloudFrontFunction !== null);
+  expect(construct.cloudFrontLoggingBucket !== null);
+  expect(construct.apiGatewayCloudWatchRole !== null);
+  expect(construct.apiGatewayLogGroup !== null);
+});
 
- test('check lambda function properties for deploy: true', () => {
-   const stack = new cdk.Stack();
+test('check lambda function properties for deploy: true', () => {
+  const stack = new cdk.Stack();
 
-   deployNewFunc(stack);
+  deployNewFunc(stack);
 
-   expect(stack).toHaveResource('AWS::Lambda::Function', {
-     Handler: "index.handler",
-     Role: {
-       "Fn::GetAtt": [
-         "testcloudfrontapigatewaylambdaLambdaFunctionServiceRoleCB74590F",
-         "Arn"
-       ]
-     },
-     Runtime: "nodejs10.x",
-     Environment: {
-       Variables: {
-         AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-       }
-     }
-   });
- });
+  expect(stack).toHaveResource('AWS::Lambda::Function', {
+    Handler: "index.handler",
+    Role: {
+      "Fn::GetAtt": [
+        "testcloudfrontapigatewaylambdaLambdaFunctionServiceRoleCB74590F",
+        "Arn"
+      ]
+    },
+    Runtime: "nodejs10.x",
+    Environment: {
+      Variables: {
+        AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
+      }
+    }
+  });
+});
 
- test('check lambda function role for deploy: false', () => {
-   const stack = new cdk.Stack();
+test('check lambda function role for deploy: false', () => {
+  const stack = new cdk.Stack();
 
-   useExistingFunc(stack);
+  useExistingFunc(stack);
 
-   expect(stack).toHaveResource('AWS::IAM::Role', {
-     AssumeRolePolicyDocument: {
-       Statement: [
-         {
-           Action: "sts:AssumeRole",
-           Effect: "Allow",
-           Principal: {
-             Service: "lambda.amazonaws.com"
-           }
-         }
-       ],
-       Version: "2012-10-17"
-     },
-     ManagedPolicyArns: [
-       {
-         "Fn::Join": [
-           "",
-           [
-             "arn:",
-             {
-               Ref: "AWS::Partition"
-             },
-             ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-           ]
-         ]
-       }
-     ]
-   });
- });
+  expect(stack).toHaveResource('AWS::IAM::Role', {
+    AssumeRolePolicyDocument: {
+      Statement: [
+        {
+          Action: "sts:AssumeRole",
+          Effect: "Allow",
+          Principal: {
+            Service: "lambda.amazonaws.com"
+          }
+        }
+      ],
+      Version: "2012-10-17"
+    },
+    ManagedPolicyArns: [
+      {
+        "Fn::Join": [
+          "",
+          [
+            "arn:",
+            {
+              Ref: "AWS::Partition"
+            },
+            ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          ]
+        ]
+      }
+    ]
+  });
+});
 
- test('check exception for Missing existingObj from props', () => {
-   const stack = new cdk.Stack();
+test('check exception for Missing existingObj from props', () => {
+  const stack = new cdk.Stack();
 
-   const props: CloudFrontToApiGatewayToLambdaProps = {
-   };
+  const props: CloudFrontToApiGatewayToLambdaProps = {
+  };
 
-   try {
-     new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
-   } catch (e) {
-     expect(e).toBeInstanceOf(Error);
-   }
- });
+  try {
+    new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
+  } catch (e) {
+    expect(e).toBeInstanceOf(Error);
+  }
+});
 
- test('check no prop', () => {
-   const stack = new cdk.Stack();
+test('check no prop', () => {
+  const stack = new cdk.Stack();
 
-   const props: CloudFrontToApiGatewayToLambdaProps = {
-   };
+  const props: CloudFrontToApiGatewayToLambdaProps = {
+  };
 
-   try {
-     new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
-   } catch (e) {
-     expect(e).toBeInstanceOf(Error);
-   }
- });
+  try {
+    new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
+  } catch (e) {
+    expect(e).toBeInstanceOf(Error);
+  }
+});
 
- test('override api gateway properties with existingLambdaObj', () => {
-   const stack = new cdk.Stack();
+test('override api gateway properties with existingLambdaObj', () => {
+  const stack = new cdk.Stack();
 
-   const lambdaFunctionProps: lambda.FunctionProps = {
-     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-     runtime: lambda.Runtime.NODEJS_10_X,
-     handler: 'index.handler'
-   };
+  const lambdaFunctionProps: lambda.FunctionProps = {
+    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+    runtime: lambda.Runtime.NODEJS_10_X,
+    handler: 'index.handler'
+  };
 
-   const fn: lambda.Function = new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps);
+  const fn: lambda.Function = new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps);
 
-   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-     existingLambdaObj: fn,
-     apiGatewayProps: {
-       description: "Override description"
-     }
-   });
+  new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+    existingLambdaObj: fn,
+    apiGatewayProps: {
+      description: "Override description"
+    }
+  });
 
-   expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
-     {
-       Description: "Override description",
-       EndpointConfiguration: {
-         Types: [
-           "REGIONAL"
-         ]
-       },
-       Name: "LambdaRestApi"
-     });
- });
+  expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+    {
+      Description: "Override description",
+      EndpointConfiguration: {
+        Types: [
+          "REGIONAL"
+        ]
+      },
+      Name: "LambdaRestApi"
+    });
+});
 
- test('override api gateway properties without existingLambdaObj', () => {
-   const stack = new cdk.Stack();
+test('override api gateway properties without existingLambdaObj', () => {
+  const stack = new cdk.Stack();
 
-   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-     lambdaFunctionProps: {
-       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-       runtime: lambda.Runtime.NODEJS_10_X,
-       handler: 'index.handler'
-     },
-     apiGatewayProps: {
-       endpointConfiguration: {
-         types: [api.EndpointType.PRIVATE],
-       },
-       description: "Override description"
-     }
-   });
+  new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_10_X,
+      handler: 'index.handler'
+    },
+    apiGatewayProps: {
+      endpointConfiguration: {
+        types: [api.EndpointType.PRIVATE],
+      },
+      description: "Override description"
+    }
+  });
 
-   expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
-     {
-       Description: "Override description",
-       EndpointConfiguration: {
-         Types: [
-           "PRIVATE"
-         ]
-       },
-       Name: "LambdaRestApi"
-     });
- });
+  expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+    {
+      Description: "Override description",
+      EndpointConfiguration: {
+        Types: [
+          "PRIVATE"
+        ]
+      },
+      Name: "LambdaRestApi"
+    });
+});
 
- // --------------------------------------------------------------
- // Cloudfront logging bucket with destroy removal policy and auto delete objects
- // --------------------------------------------------------------
- test('Cloudfront logging bucket with destroy removal policy and auto delete objects', () => {
-   const stack = new cdk.Stack();
+// --------------------------------------------------------------
+// Cloudfront logging bucket with destroy removal policy and auto delete objects
+// --------------------------------------------------------------
+test('Cloudfront logging bucket with destroy removal policy and auto delete objects', () => {
+  const stack = new cdk.Stack();
 
-   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-     lambdaFunctionProps: {
-       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-       runtime: lambda.Runtime.NODEJS_10_X,
-       handler: 'index.handler'
-     },
-     apiGatewayProps: {
-       endpointConfiguration: {
-         types: [api.EndpointType.PRIVATE],
-       }
-     },
-     cloudFrontLoggingBucketProps: {
-       removalPolicy: cdk.RemovalPolicy.DESTROY,
-       autoDeleteObjects: true
-     }
-   });
+  new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_10_X,
+      handler: 'index.handler'
+    },
+    apiGatewayProps: {
+      endpointConfiguration: {
+        types: [api.EndpointType.PRIVATE],
+      }
+    },
+    cloudFrontLoggingBucketProps: {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true
+    }
+  });
 
-   expect(stack).toHaveResource("AWS::S3::Bucket", {
-     AccessControl: "LogDeliveryWrite"
-   });
+  expect(stack).toHaveResource("AWS::S3::Bucket", {
+    AccessControl: "LogDeliveryWrite"
+  });
 
-   expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
-     ServiceToken: {
-       "Fn::GetAtt": [
-         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-         "Arn"
-       ]
-     },
-     BucketName: {
-       Ref: "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421"
-     }
-   });
- });
+  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+    ServiceToken: {
+      "Fn::GetAtt": [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+        "Arn"
+      ]
+    },
+    BucketName: {
+      Ref: "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421"
+    }
+  });
+});
 
- // --------------------------------------------------------------
- // Cloudfront logging bucket error providing existing log bucket and logBucketProps
- // --------------------------------------------------------------
- test('Cloudfront logging bucket error when providing existing log bucket and logBucketProps', () => {
-   const stack = new cdk.Stack();
-   const logBucket = new s3.Bucket(stack, 'cloudfront-log-bucket', {});
+// --------------------------------------------------------------
+// Cloudfront logging bucket error providing existing log bucket and logBucketProps
+// --------------------------------------------------------------
+test('Cloudfront logging bucket error when providing existing log bucket and logBucketProps', () => {
+  const stack = new cdk.Stack();
+  const logBucket = new s3.Bucket(stack, 'cloudfront-log-bucket', {});
 
-   const app = () => { new CloudFrontToApiGatewayToLambda(stack, 'cloudfront-s3', {
-     lambdaFunctionProps: {
-       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-       runtime: lambda.Runtime.NODEJS_10_X,
-       handler: 'index.handler'
-     },
-     apiGatewayProps: {
-       endpointConfiguration: {
-         types: [api.EndpointType.PRIVATE],
-       }
-     },
-     cloudFrontLoggingBucketProps: {
-       removalPolicy: cdk.RemovalPolicy.DESTROY,
-       autoDeleteObjects: true
-     },
-     cloudFrontDistributionProps: {
-       logBucket
-     },
-   });
-   };
+  const app = () => { new CloudFrontToApiGatewayToLambda(stack, 'cloudfront-s3', {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_10_X,
+      handler: 'index.handler'
+    },
+    apiGatewayProps: {
+      endpointConfiguration: {
+        types: [api.EndpointType.PRIVATE],
+      }
+    },
+    cloudFrontLoggingBucketProps: {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true
+    },
+    cloudFrontDistributionProps: {
+      logBucket
+    },
+  });
+  };
 
-   expect(app).toThrowError();
- });
+  expect(app).toThrowError();
+});

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
@@ -11,264 +11,260 @@
  *  and limitations under the License.
  */
 
-import { CloudFrontToApiGatewayToLambda, CloudFrontToApiGatewayToLambdaProps } from "../lib";
-import * as cdk from "@aws-cdk/core";
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as api from '@aws-cdk/aws-apigateway';
-import * as s3 from "@aws-cdk/aws-s3";
-import '@aws-cdk/assert/jest';
+ import { CloudFrontToApiGatewayToLambda, CloudFrontToApiGatewayToLambdaProps } from "../lib";
+ import * as cdk from "@aws-cdk/core";
+ import * as lambda from '@aws-cdk/aws-lambda';
+ import * as api from '@aws-cdk/aws-apigateway';
+ import * as s3 from "@aws-cdk/aws-s3";
+ import '@aws-cdk/assert/jest';
 
-function deployNewFunc(stack: cdk.Stack) {
-  const lambdaFunctionProps: lambda.FunctionProps = {
-    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-    runtime: lambda.Runtime.NODEJS_10_X,
-    handler: 'index.handler'
-  };
+ function deployNewFunc(stack: cdk.Stack) {
+   const lambdaFunctionProps: lambda.FunctionProps = {
+     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+     runtime: lambda.Runtime.NODEJS_10_X,
+     handler: 'index.handler'
+   };
 
-  return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-    lambdaFunctionProps
-  });
-}
+   return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     lambdaFunctionProps
+   });
+ }
 
-function useExistingFunc(stack: cdk.Stack) {
-  const lambdaFunctionProps: lambda.FunctionProps = {
-    runtime: lambda.Runtime.NODEJS_10_X,
-    handler: 'index.handler',
-    code: lambda.Code.fromAsset(`${__dirname}/lambda`)
-  };
+ function useExistingFunc(stack: cdk.Stack) {
+   const lambdaFunctionProps: lambda.FunctionProps = {
+     runtime: lambda.Runtime.NODEJS_10_X,
+     handler: 'index.handler',
+     code: lambda.Code.fromAsset(`${__dirname}/lambda`)
+   };
 
-  return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-    existingLambdaObj: new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps)
-  });
-}
+   return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     existingLambdaObj: new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps)
+   });
+ }
 
-test('check properties', () => {
-  const stack = new cdk.Stack();
+ test('check properties', () => {
+   const stack = new cdk.Stack();
 
-  const construct: CloudFrontToApiGatewayToLambda = deployNewFunc(stack);
+   const construct: CloudFrontToApiGatewayToLambda = deployNewFunc(stack);
 
-  expect(construct.cloudFrontWebDistribution !== null);
-  expect(construct.apiGateway !== null);
-  expect(construct.lambdaFunction !== null);
-  expect(construct.cloudFrontFunction !== null);
-  expect(construct.cloudFrontLoggingBucket !== null);
-  expect(construct.apiGatewayCloudWatchRole !== null);
-  expect(construct.apiGatewayLogGroup !== null);
-});
+   expect(construct.cloudFrontWebDistribution !== null);
+   expect(construct.apiGateway !== null);
+   expect(construct.lambdaFunction !== null);
+   expect(construct.cloudFrontFunction !== null);
+   expect(construct.cloudFrontLoggingBucket !== null);
+   expect(construct.apiGatewayCloudWatchRole !== null);
+   expect(construct.apiGatewayLogGroup !== null);
+ });
 
-test('check lambda function properties for deploy: true', () => {
-  const stack = new cdk.Stack();
+ test('check lambda function properties for deploy: true', () => {
+   const stack = new cdk.Stack();
 
-  deployNewFunc(stack);
+   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
-    Handler: "index.handler",
-    Role: {
-      "Fn::GetAtt": [
-        "testcloudfrontapigatewaylambdaLambdaFunctionServiceRoleCB74590F",
-        "Arn"
-      ]
-    },
-    Runtime: "nodejs10.x",
-    Environment: {
-      Variables: {
-        AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-      }
-    }
-  });
-});
+   expect(stack).toHaveResource('AWS::Lambda::Function', {
+     Handler: "index.handler",
+     Role: {
+       "Fn::GetAtt": [
+         "testcloudfrontapigatewaylambdaLambdaFunctionServiceRoleCB74590F",
+         "Arn"
+       ]
+     },
+     Runtime: "nodejs10.x",
+     Environment: {
+       Variables: {
+         AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
+       }
+     }
+   });
+ });
 
-test('check lambda function role for deploy: false', () => {
-  const stack = new cdk.Stack();
+ test('check lambda function role for deploy: false', () => {
+   const stack = new cdk.Stack();
 
-  useExistingFunc(stack);
+   useExistingFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
-    AssumeRolePolicyDocument: {
-      Statement: [
-        {
-          Action: "sts:AssumeRole",
-          Effect: "Allow",
-          Principal: {
-            Service: "lambda.amazonaws.com"
-          }
-        }
-      ],
-      Version: "2012-10-17"
-    },
-    ManagedPolicyArns: [
-      {
-        "Fn::Join": [
-          "",
-          [
-            "arn:",
-            {
-              Ref: "AWS::Partition"
-            },
-            ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-          ]
-        ]
-      }
-    ]
-  });
-});
+   expect(stack).toHaveResource('AWS::IAM::Role', {
+     AssumeRolePolicyDocument: {
+       Statement: [
+         {
+           Action: "sts:AssumeRole",
+           Effect: "Allow",
+           Principal: {
+             Service: "lambda.amazonaws.com"
+           }
+         }
+       ],
+       Version: "2012-10-17"
+     },
+     ManagedPolicyArns: [
+       {
+         "Fn::Join": [
+           "",
+           [
+             "arn:",
+             {
+               Ref: "AWS::Partition"
+             },
+             ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+           ]
+         ]
+       }
+     ]
+   });
+ });
 
-test('check exception for Missing existingObj from props', () => {
-  const stack = new cdk.Stack();
+ test('check exception for Missing existingObj from props', () => {
+   const stack = new cdk.Stack();
 
-  const props: CloudFrontToApiGatewayToLambdaProps = {
-  };
+   const props: CloudFrontToApiGatewayToLambdaProps = {
+   };
 
-  try {
-    new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
-  } catch (e) {
-    expect(e).toBeInstanceOf(Error);
-  }
-});
+   try {
+     new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
+   } catch (e) {
+     expect(e).toBeInstanceOf(Error);
+   }
+ });
 
-test('check no prop', () => {
-  const stack = new cdk.Stack();
+ test('check no prop', () => {
+   const stack = new cdk.Stack();
 
-  const props: CloudFrontToApiGatewayToLambdaProps = {
-  };
+   const props: CloudFrontToApiGatewayToLambdaProps = {
+   };
 
-  try {
-    new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
-  } catch (e) {
-    expect(e).toBeInstanceOf(Error);
-  }
-});
+   try {
+     new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
+   } catch (e) {
+     expect(e).toBeInstanceOf(Error);
+   }
+ });
 
-test('override api gateway properties with existingLambdaObj', () => {
-  const stack = new cdk.Stack();
+ test('override api gateway properties with existingLambdaObj', () => {
+   const stack = new cdk.Stack();
 
-  const lambdaFunctionProps: lambda.FunctionProps = {
-    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-    runtime: lambda.Runtime.NODEJS_10_X,
-    handler: 'index.handler'
-  };
+   const lambdaFunctionProps: lambda.FunctionProps = {
+     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+     runtime: lambda.Runtime.NODEJS_10_X,
+     handler: 'index.handler'
+   };
 
-  const fn: lambda.Function = new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps);
+   const fn: lambda.Function = new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps);
 
-  new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-    existingLambdaObj: fn,
-    apiGatewayProps: {
-      options: {
-        description: "Override description"
-      }
-    }
-  });
+   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     existingLambdaObj: fn,
+     apiGatewayProps: {
+       description: "Override description"
+     }
+   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
-    {
-      Description: "Override description",
-      EndpointConfiguration: {
-        Types: [
-          "REGIONAL"
-        ]
-      },
-      Name: "LambdaRestApi"
-    });
-});
+   expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+     {
+       Description: "Override description",
+       EndpointConfiguration: {
+         Types: [
+           "REGIONAL"
+         ]
+       },
+       Name: "LambdaRestApi"
+     });
+ });
 
-test('override api gateway properties without existingLambdaObj', () => {
-  const stack = new cdk.Stack();
+ test('override api gateway properties without existingLambdaObj', () => {
+   const stack = new cdk.Stack();
 
-  new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-    lambdaFunctionProps: {
-      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-      runtime: lambda.Runtime.NODEJS_10_X,
-      handler: 'index.handler'
-    },
-    apiGatewayProps: {
-      endpointConfiguration: {
-        types: [api.EndpointType.PRIVATE],
-      },
-      options: {
-        description: "Override description"
-      }
-    }
-  });
+   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     lambdaFunctionProps: {
+       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+       runtime: lambda.Runtime.NODEJS_10_X,
+       handler: 'index.handler'
+     },
+     apiGatewayProps: {
+       endpointConfiguration: {
+         types: [api.EndpointType.PRIVATE],
+       },
+       description: "Override description"
+     }
+   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
-    {
-      Description: "Override description",
-      EndpointConfiguration: {
-        Types: [
-          "PRIVATE"
-        ]
-      },
-      Name: "LambdaRestApi"
-    });
-});
+   expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+     {
+       Description: "Override description",
+       EndpointConfiguration: {
+         Types: [
+           "PRIVATE"
+         ]
+       },
+       Name: "LambdaRestApi"
+     });
+ });
 
-// --------------------------------------------------------------
-// Cloudfront logging bucket with destroy removal policy and auto delete objects
-// --------------------------------------------------------------
-test('Cloudfront logging bucket with destroy removal policy and auto delete objects', () => {
-  const stack = new cdk.Stack();
+ // --------------------------------------------------------------
+ // Cloudfront logging bucket with destroy removal policy and auto delete objects
+ // --------------------------------------------------------------
+ test('Cloudfront logging bucket with destroy removal policy and auto delete objects', () => {
+   const stack = new cdk.Stack();
 
-  new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
-    lambdaFunctionProps: {
-      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-      runtime: lambda.Runtime.NODEJS_10_X,
-      handler: 'index.handler'
-    },
-    apiGatewayProps: {
-      endpointConfiguration: {
-        types: [api.EndpointType.PRIVATE],
-      }
-    },
-    cloudFrontLoggingBucketProps: {
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: true
-    }
-  });
+   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     lambdaFunctionProps: {
+       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+       runtime: lambda.Runtime.NODEJS_10_X,
+       handler: 'index.handler'
+     },
+     apiGatewayProps: {
+       endpointConfiguration: {
+         types: [api.EndpointType.PRIVATE],
+       }
+     },
+     cloudFrontLoggingBucketProps: {
+       removalPolicy: cdk.RemovalPolicy.DESTROY,
+       autoDeleteObjects: true
+     }
+   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
-    AccessControl: "LogDeliveryWrite"
-  });
+   expect(stack).toHaveResource("AWS::S3::Bucket", {
+     AccessControl: "LogDeliveryWrite"
+   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
-    ServiceToken: {
-      "Fn::GetAtt": [
-        "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-        "Arn"
-      ]
-    },
-    BucketName: {
-      Ref: "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421"
-    }
-  });
-});
+   expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+     ServiceToken: {
+       "Fn::GetAtt": [
+         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+         "Arn"
+       ]
+     },
+     BucketName: {
+       Ref: "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421"
+     }
+   });
+ });
 
-// --------------------------------------------------------------
-// Cloudfront logging bucket error providing existing log bucket and logBucketProps
-// --------------------------------------------------------------
-test('Cloudfront logging bucket error when providing existing log bucket and logBucketProps', () => {
-  const stack = new cdk.Stack();
-  const logBucket = new s3.Bucket(stack, 'cloudfront-log-bucket', {});
+ // --------------------------------------------------------------
+ // Cloudfront logging bucket error providing existing log bucket and logBucketProps
+ // --------------------------------------------------------------
+ test('Cloudfront logging bucket error when providing existing log bucket and logBucketProps', () => {
+   const stack = new cdk.Stack();
+   const logBucket = new s3.Bucket(stack, 'cloudfront-log-bucket', {});
 
-  const app = () => { new CloudFrontToApiGatewayToLambda(stack, 'cloudfront-s3', {
-    lambdaFunctionProps: {
-      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-      runtime: lambda.Runtime.NODEJS_10_X,
-      handler: 'index.handler'
-    },
-    apiGatewayProps: {
-      endpointConfiguration: {
-        types: [api.EndpointType.PRIVATE],
-      }
-    },
-    cloudFrontLoggingBucketProps: {
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: true
-    },
-    cloudFrontDistributionProps: {
-      logBucket
-    },
-  });
-  };
+   const app = () => { new CloudFrontToApiGatewayToLambda(stack, 'cloudfront-s3', {
+     lambdaFunctionProps: {
+       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+       runtime: lambda.Runtime.NODEJS_10_X,
+       handler: 'index.handler'
+     },
+     apiGatewayProps: {
+       endpointConfiguration: {
+         types: [api.EndpointType.PRIVATE],
+       }
+     },
+     cloudFrontLoggingBucketProps: {
+       removalPolicy: cdk.RemovalPolicy.DESTROY,
+       autoDeleteObjects: true
+     },
+     cloudFrontDistributionProps: {
+       logBucket
+     },
+   });
+   };
 
-  expect(app).toThrowError();
-});
+   expect(app).toThrowError();
+ });

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -11,363 +11,260 @@
  *  and limitations under the License.
  */
 
-import { ResourcePart } from '@aws-cdk/assert';
-import '@aws-cdk/assert/jest';
-import * as s3 from '@aws-cdk/aws-s3';
-import * as cdk from "@aws-cdk/core";
-import { RemovalPolicy } from '@aws-cdk/core';
-import { CloudFrontToS3, CloudFrontToS3Props } from "../lib";
-import * as acm from '@aws-cdk/aws-certificatemanager';
+ import { CloudFrontToApiGatewayToLambda, CloudFrontToApiGatewayToLambdaProps } from "../lib";
+ import * as cdk from "@aws-cdk/core";
+ import * as lambda from '@aws-cdk/aws-lambda';
+ import * as api from '@aws-cdk/aws-apigateway';
+ import * as s3 from "@aws-cdk/aws-s3";
+ import '@aws-cdk/assert/jest';
 
-function deploy(stack: cdk.Stack, props?: CloudFrontToS3Props) {
-  return new CloudFrontToS3(stack, 'test-cloudfront-s3', {
-    bucketProps: {
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    },
-    ...props
-  });
-}
+ function deployNewFunc(stack: cdk.Stack) {
+   const lambdaFunctionProps: lambda.FunctionProps = {
+     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+     runtime: lambda.Runtime.NODEJS_10_X,
+     handler: 'index.handler'
+   };
 
-test('check s3Bucket default encryption', () => {
-  const stack = new cdk.Stack();
-  deploy(stack);
-  expect(stack).toHaveResource('AWS::S3::Bucket', {
-    BucketEncryption: {
-      ServerSideEncryptionConfiguration: [{
-        ServerSideEncryptionByDefault: {
-          SSEAlgorithm: "AES256"
-        }
-      }]
-    }
-  });
-});
+   return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     lambdaFunctionProps
+   });
+ }
 
-test('check s3Bucket public access block configuration', () => {
-  const stack = new cdk.Stack();
-  deploy(stack);
-  expect(stack).toHaveResource('AWS::S3::Bucket', {
-    PublicAccessBlockConfiguration: {
-      BlockPublicAcls: true,
-      BlockPublicPolicy: true,
-      IgnorePublicAcls: true,
-      RestrictPublicBuckets: true
-    }
-  });
-});
+ function useExistingFunc(stack: cdk.Stack) {
+   const lambdaFunctionProps: lambda.FunctionProps = {
+     runtime: lambda.Runtime.NODEJS_10_X,
+     handler: 'index.handler',
+     code: lambda.Code.fromAsset(`${__dirname}/lambda`)
+   };
 
-test('test s3Bucket override publicAccessBlockConfiguration', () => {
-  const stack = new cdk.Stack();
+   return new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     existingLambdaObj: new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps)
+   });
+ }
 
-  const props: CloudFrontToS3Props = {
-    bucketProps: {
-      blockPublicAccess: {
-        blockPublicAcls: false,
-        blockPublicPolicy: true,
-        ignorePublicAcls: false,
-        restrictPublicBuckets: true
-      }
-    }
-  };
+ test('check properties', () => {
+   const stack = new cdk.Stack();
 
-  new CloudFrontToS3(stack, 'test-cloudfront-s3', props);
+   const construct: CloudFrontToApiGatewayToLambda = deployNewFunc(stack);
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
-    PublicAccessBlockConfiguration: {
-      BlockPublicAcls: false,
-      BlockPublicPolicy: true,
-      IgnorePublicAcls: false,
-      RestrictPublicBuckets: true
-    },
-  });
-});
+   expect(construct.cloudFrontWebDistribution !== null);
+   expect(construct.apiGateway !== null);
+   expect(construct.lambdaFunction !== null);
+   expect(construct.cloudFrontFunction !== null);
+   expect(construct.cloudFrontLoggingBucket !== null);
+   expect(construct.apiGatewayCloudWatchRole !== null);
+   expect(construct.apiGatewayLogGroup !== null);
+ });
 
-test('check existing bucket', () => {
-  const stack = new cdk.Stack();
+ test('check lambda function properties for deploy: true', () => {
+   const stack = new cdk.Stack();
 
-  const existingBucket = new s3.Bucket(stack, 'my-bucket', {
-    bucketName: 'my-bucket'
-  });
+   deployNewFunc(stack);
 
-  const props: CloudFrontToS3Props = {
-    existingBucketObj: existingBucket
-  };
+   expect(stack).toHaveResource('AWS::Lambda::Function', {
+     Handler: "index.handler",
+     Role: {
+       "Fn::GetAtt": [
+         "testcloudfrontapigatewaylambdaLambdaFunctionServiceRoleCB74590F",
+         "Arn"
+       ]
+     },
+     Runtime: "nodejs10.x",
+     Environment: {
+       Variables: {
+         AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
+       }
+     }
+   });
+ });
 
-  new CloudFrontToS3(stack, 'test-cloudfront-s3', props);
+ test('check lambda function role for deploy: false', () => {
+   const stack = new cdk.Stack();
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
-    BucketName: "my-bucket"
-  });
+   useExistingFunc(stack);
 
-  expect(stack).toHaveResource("AWS::S3::BucketPolicy", {
-    Metadata: {
-      cfn_nag: {
-        rules_to_suppress: [
-          {
-            id: "F16",
-            reason: "Public website bucket policy requires a wildcard principal"
-          }
-        ]
-      }
-    }
-  }, ResourcePart.CompleteDefinition);
-});
+   expect(stack).toHaveResource('AWS::IAM::Role', {
+     AssumeRolePolicyDocument: {
+       Statement: [
+         {
+           Action: "sts:AssumeRole",
+           Effect: "Allow",
+           Principal: {
+             Service: "lambda.amazonaws.com"
+           }
+         }
+       ],
+       Version: "2012-10-17"
+     },
+     ManagedPolicyArns: [
+       {
+         "Fn::Join": [
+           "",
+           [
+             "arn:",
+             {
+               Ref: "AWS::Partition"
+             },
+             ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+           ]
+         ]
+       }
+     ]
+   });
+ });
 
-test('check exception for Missing existingObj from props for deploy = false', () => {
-  const stack = new cdk.Stack();
+ test('check exception for Missing existingObj from props', () => {
+   const stack = new cdk.Stack();
 
-  try {
-    new CloudFrontToS3(stack, 'test-cloudfront-s3', {});
-  } catch (e) {
-    expect(e).toBeInstanceOf(Error);
-  }
-});
+   const props: CloudFrontToApiGatewayToLambdaProps = {
+   };
 
-test('check properties', () => {
-  const stack = new cdk.Stack();
+   try {
+     new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
+   } catch (e) {
+     expect(e).toBeInstanceOf(Error);
+   }
+ });
 
-  const construct: CloudFrontToS3 = deploy(stack);
+ test('check no prop', () => {
+   const stack = new cdk.Stack();
 
-  expect(construct.cloudFrontWebDistribution !== null);
-  expect(construct.s3Bucket !== null);
-});
+   const props: CloudFrontToApiGatewayToLambdaProps = {
+   };
 
-// --------------------------------------------------------------
-// Test bad call with existingBucket and bucketProps
-// --------------------------------------------------------------
-test("Test bad call with existingBucket and bucketProps", () => {
-  // Stack
-  const stack = new cdk.Stack();
+   try {
+     new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', props);
+   } catch (e) {
+     expect(e).toBeInstanceOf(Error);
+   }
+ });
 
-  const testBucket = new s3.Bucket(stack, 'test-bucket', {});
+ test('override api gateway properties with existingLambdaObj', () => {
+   const stack = new cdk.Stack();
 
-  const app = () => {
-    // Helper declaration
-    new CloudFrontToS3(stack, "bad-s3-args", {
-      existingBucketObj: testBucket,
-      bucketProps: {
-        removalPolicy: RemovalPolicy.DESTROY
-      },
-    });
-  };
-  // Assertion
-  expect(app).toThrowError();
-});
+   const lambdaFunctionProps: lambda.FunctionProps = {
+     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+     runtime: lambda.Runtime.NODEJS_10_X,
+     handler: 'index.handler'
+   };
 
-test("Test existingBucketObj", () => {
-  // Stack
-  const stack = new cdk.Stack();
-  const construct: CloudFrontToS3 = new CloudFrontToS3(stack, "existingIBucket", {
-    existingBucketObj: s3.Bucket.fromBucketName(stack, 'mybucket', 'mybucket')
-  });
-  // Assertion
-  expect(construct.cloudFrontWebDistribution !== null);
-  expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
-    DistributionConfig: {
-      Origins: [
-        {
-          DomainName: {
-            "Fn::Join": [
-              "",
-              [
-                "mybucket.s3.",
-                {
-                  Ref: "AWS::Region"
-                },
-                ".",
-                {
-                  Ref: "AWS::URLSuffix"
-                }
-              ]
-            ]
-          },
-          Id: "existingIBucketCloudFrontDistributionOrigin1D5849125",
-          S3OriginConfig: {
-            OriginAccessIdentity: {
-              "Fn::Join": [
-                "",
-                [
-                  "origin-access-identity/cloudfront/",
-                  {
-                    Ref: "existingIBucketCloudFrontDistributionOrigin1S3OriginDDDB1606"
-                  }
-                ]
-              ]
-            }
-          }
-        }
-      ]
-    }
-  });
-});
+   const fn: lambda.Function = new lambda.Function(stack, 'MyExistingFunction', lambdaFunctionProps);
 
-test('test cloudfront disable cloudfront logging', () => {
-  const stack = new cdk.Stack();
+   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     existingLambdaObj: fn,
+     apiGatewayProps: {
+       description: "Override description"
+     }
+   });
 
-  const construct = deploy(stack, { cloudFrontDistributionProps: { enableLogging: false } });
+   expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+     {
+       Description: "Override description",
+       EndpointConfiguration: {
+         Types: [
+           "REGIONAL"
+         ]
+       },
+       Name: "LambdaRestApi"
+     });
+ });
 
-  expect(construct.cloudFrontLoggingBucket === undefined);
-});
+ test('override api gateway properties without existingLambdaObj', () => {
+   const stack = new cdk.Stack();
 
-test('test cloudfront with custom domain names', () => {
-  const stack = new cdk.Stack();
+   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     lambdaFunctionProps: {
+       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+       runtime: lambda.Runtime.NODEJS_10_X,
+       handler: 'index.handler'
+     },
+     apiGatewayProps: {
+       endpointConfiguration: {
+         types: [api.EndpointType.PRIVATE],
+       },
+       description: "Override description"
+     }
+   });
 
-  const certificate = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:123456789012:certificate/11112222-3333-1234-1234-123456789012');
+   expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+     {
+       Description: "Override description",
+       EndpointConfiguration: {
+         Types: [
+           "PRIVATE"
+         ]
+       },
+       Name: "LambdaRestApi"
+     });
+ });
 
-  const props: CloudFrontToS3Props = {
-    cloudFrontDistributionProps: {
-      domainNames: ['mydomains'],
-      certificate
-    }
-  };
+ // --------------------------------------------------------------
+ // Cloudfront logging bucket with destroy removal policy and auto delete objects
+ // --------------------------------------------------------------
+ test('Cloudfront logging bucket with destroy removal policy and auto delete objects', () => {
+   const stack = new cdk.Stack();
 
-  new CloudFrontToS3(stack, 'test-cloudfront-s3', props);
+   new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+     lambdaFunctionProps: {
+       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+       runtime: lambda.Runtime.NODEJS_10_X,
+       handler: 'index.handler'
+     },
+     apiGatewayProps: {
+       endpointConfiguration: {
+         types: [api.EndpointType.PRIVATE],
+       }
+     },
+     cloudFrontLoggingBucketProps: {
+       removalPolicy: cdk.RemovalPolicy.DESTROY,
+       autoDeleteObjects: true
+     }
+   });
 
-  expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
-    DistributionConfig: {
-      Aliases: [
-        "mydomains"
-      ]
-    }
-  });
-});
+   expect(stack).toHaveResource("AWS::S3::Bucket", {
+     AccessControl: "LogDeliveryWrite"
+   });
 
-// --------------------------------------------------------------
-// s3 bucket with bucket, loggingBucket, and auto delete objects
-// --------------------------------------------------------------
-test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
-  const stack = new cdk.Stack();
+   expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+     ServiceToken: {
+       "Fn::GetAtt": [
+         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+         "Arn"
+       ]
+     },
+     BucketName: {
+       Ref: "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421"
+     }
+   });
+ });
 
-  new CloudFrontToS3(stack, 'cloudfront-s3', {
-    bucketProps: {
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    },
-    loggingBucketProps: {
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: true
-    }
-  });
+ // --------------------------------------------------------------
+ // Cloudfront logging bucket error providing existing log bucket and logBucketProps
+ // --------------------------------------------------------------
+ test('Cloudfront logging bucket error when providing existing log bucket and logBucketProps', () => {
+   const stack = new cdk.Stack();
+   const logBucket = new s3.Bucket(stack, 'cloudfront-log-bucket', {});
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
-    AccessControl: "LogDeliveryWrite"
-  });
+   const app = () => { new CloudFrontToApiGatewayToLambda(stack, 'cloudfront-s3', {
+     lambdaFunctionProps: {
+       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+       runtime: lambda.Runtime.NODEJS_10_X,
+       handler: 'index.handler'
+     },
+     apiGatewayProps: {
+       endpointConfiguration: {
+         types: [api.EndpointType.PRIVATE],
+       }
+     },
+     cloudFrontLoggingBucketProps: {
+       removalPolicy: cdk.RemovalPolicy.DESTROY,
+       autoDeleteObjects: true
+     },
+     cloudFrontDistributionProps: {
+       logBucket
+     },
+   });
+   };
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
-    ServiceToken: {
-      "Fn::GetAtt": [
-        "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-        "Arn"
-      ]
-    },
-    BucketName: {
-      Ref: "cloudfronts3S3LoggingBucket52EEB708"
-    }
-  });
-});
-
-// --------------------------------------------------------------
-// Cloudfront logging bucket with destroy removal policy and auto delete objects
-// --------------------------------------------------------------
-test('Cloudfront logging bucket with destroy removal policy and auto delete objects', () => {
-  const stack = new cdk.Stack();
-
-  new CloudFrontToS3(stack, 'cloudfront-s3', {
-    cloudFrontLoggingBucketProps: {
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: true
-    }
-  });
-
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
-    AccessControl: "LogDeliveryWrite"
-  });
-
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
-    ServiceToken: {
-      "Fn::GetAtt": [
-        "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-        "Arn"
-      ]
-    },
-    BucketName: {
-      Ref: "cloudfronts3CloudfrontLoggingBucket5B845143"
-    }
-  });
-});
-
-// --------------------------------------------------------------
-// Cloudfront logging bucket error providing existing log bucket and logBucketProps
-// --------------------------------------------------------------
-test('Cloudfront logging bucket error when providing existing log bucket and logBucketProps', () => {
-  const stack = new cdk.Stack();
-  const logBucket = new s3.Bucket(stack, 'cloudfront-log-bucket', {});
-
-  const app = () => {
-    new CloudFrontToS3(stack, 'cloudfront-s3', {
-      cloudFrontDistributionProps: {
-        logBucket
-      },
-      cloudFrontLoggingBucketProps: {
-        removalPolicy: cdk.RemovalPolicy.DESTROY,
-        autoDeleteObjects: true
-      }
-    });
-  };
-
-  expect(app).toThrowError();
-});
-
-// --------------------------------------------------------------
-// s3 bucket with one content bucket and no logging bucket
-// --------------------------------------------------------------
-test('s3 bucket with one content bucket and no logging bucket', () => {
-  const stack = new cdk.Stack();
-
-  const construct = new CloudFrontToS3(stack, 'cloudfront-s3', {
-    bucketProps: {
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    },
-    logS3AccessLogs: false
-  });
-
-  expect(stack).toCountResources("AWS::S3::Bucket", 2);
-  expect(construct.s3LoggingBucket).toEqual(undefined);
-});
-
-// --------------------------------------------------
-// CloudFront origin path
-// --------------------------------------------------
-test('CloudFront origin path present when provided', () => {
-  const stack = new cdk.Stack();
-
-  new CloudFrontToS3(stack, 'cloudfront-s3', {
-    originPath: '/testPath'
-  });
-
-  expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
-    DistributionConfig:
-    {
-      Origins: [
-        {
-          OriginPath: "/testPath",
-        }
-      ]
-    }
-  });
-});
-
-test('CloudFront origin path should not be present if not provided', () => {
-  const stack = new cdk.Stack();
-
-  new CloudFrontToS3(stack, 'cloudfront-s3', {});
-
-  expect(stack).not.toHaveResourceLike("AWS::CloudFront::Distribution", {
-    DistributionConfig:
-    {
-      Origins: [
-        {
-          OriginPath: "/testPath",
-        }
-      ]
-    }
-  });
-});
+   expect(app).toThrowError();
+ });

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
@@ -101,20 +101,22 @@ function configureLambdaRestApi(scope: Construct, defaultApiGatewayProps: api.La
     cwRole = configureCloudwatchRoleForApi(scope, _api);
   }
 
-  let usagePlanProps: api.UsagePlanProps = {
+  // Configure Usage Plan
+  const usagePlanProps: api.UsagePlanProps = {
     apiStages: [{
       api: _api,
       stage: _api.deploymentStage
     }]
   };
-    // If requireApiKey param is set to true, create a api key & associate to Usage Plan
-  if (apiGatewayProps?.defaultMethodOptions?.apiKeyRequired === true) {
-    const extraParams = { apiKey: _api.addApiKey('ApiKey')};
-    usagePlanProps = Object.assign(usagePlanProps, extraParams);
-  }
 
-  // Configure Usage Plan
-  _api.addUsagePlan('UsagePlan', usagePlanProps);
+  const plan = _api.addUsagePlan('UsagePlan', usagePlanProps);
+
+  // If requireApiKey param is set to true, create a api key & associate to Usage Plan
+  if (apiGatewayProps?.defaultMethodOptions?.apiKeyRequired === true) {
+    // Configure Usage Plan with API Key
+    const key = _api.addApiKey('ApiKey');
+    plan.addApiKey(key);
+  }
 
   // Return the API and CW Role
   return [_api, cwRole];
@@ -152,21 +154,22 @@ function configureRestApi(scope: Construct, defaultApiGatewayProps: api.RestApiP
     cwRole = configureCloudwatchRoleForApi(scope, _api);
   }
 
-  let usagePlanProps: api.UsagePlanProps = {
+  // Configure Usage Plan
+  const usagePlanProps: api.UsagePlanProps = {
     apiStages: [{
       api: _api,
       stage: _api.deploymentStage
     }]
   };
 
+  const plan = _api.addUsagePlan('UsagePlan', usagePlanProps);
+
   // If requireApiKey param is set to true, create a api key & associate to Usage Plan
   if (apiGatewayProps?.defaultMethodOptions?.apiKeyRequired === true) {
-    const extraParams = { apiKey: _api.addApiKey('ApiKey')};
-    usagePlanProps = Object.assign(usagePlanProps, extraParams);
+    // Configure Usage Plan with API Key
+    const key = _api.addApiKey('ApiKey');
+    plan.addApiKey(key);
   }
-
-  // Configure Usage Plan
-  _api.addUsagePlan('UsagePlan', usagePlanProps);
 
   // Return the API and CW Role
   return [_api, cwRole];


### PR DESCRIPTION
Issue #551  , if available:

Description of changes:
-Replaces UsagePlanProp.apiKey with method addApiKey()
-options prop in LambdaRestApi has been deprecated since it now extends RestApiProps, removed options prop in test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.