### PR TITLE
Use internal container (ACAT response)

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.expected.json
@@ -901,7 +901,21 @@
         "ContainerDefinitions": [
           {
             "Essential": true,
-            "Image": "nginx",
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId"
+                  },
+                  ".dkr.ecr.us-east-1.",
+                  {
+                    "Ref": "AWS::URLSuffix"
+                  },
+                  "/nginx:latest"
+                ]
+              ]
+            },
             "MemoryReservation": 512,
             "Name": "test-container",
             "PortMappings": [
@@ -913,6 +927,12 @@
           }
         ],
         "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "testtaskdefExecutionRole7C3B732C",
+            "Arn"
+          ]
+        },
         "Family": "allexistingprivatehttptesttaskdefFB96B83E",
         "Memory": "512",
         "NetworkMode": "awsvpc",
@@ -925,6 +945,68 @@
             "Arn"
           ]
         }
+      }
+    },
+    "testtaskdefExecutionRole7C3B732C": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "testtaskdefExecutionRoleDefaultPolicy423803C8": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":ecr:us-east-1:",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":repository/nginx"
+                  ]
+                ]
+              }
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "testtaskdefExecutionRoleDefaultPolicy423803C8",
+        "Roles": [
+          {
+            "Ref": "testtaskdefExecutionRole7C3B732C"
+          }
+        ]
       }
     },
     "testsg872EB48A": {

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
@@ -17,6 +17,7 @@ import { AlbToFargate, AlbToFargateProps } from "../lib";
 import * as elb from '@aws-cdk/aws-elasticloadbalancingv2';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as ecs from '@aws-cdk/aws-ecs';
+import * as ecr from '@aws-cdk/aws-ecr';
 import { CfnSecurityGroup } from "@aws-cdk/aws-ec2";
 
 // Setup
@@ -26,8 +27,15 @@ const stack = new Stack(app, defaults.generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for private HTTPS API with existing VPC, LoadBalancer and Service';
 
-const image = ecs.ContainerImage.fromRegistry('nginx');
-
+const repository = ecr.Repository.fromRepositoryName(
+  stack,
+  `place-holder`,
+  `nginx`
+);
+const image = ecs.ContainerImage.fromEcrRepository(
+  repository,
+  "latest"
+);
 const testExistingVpc = defaults.getTestVpc(stack);
 
 const [testService, testContainer] = defaults.CreateFargateService(stack,

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.expected.json
@@ -1171,7 +1171,21 @@
         "ContainerDefinitions": [
           {
             "Essential": true,
-            "Image": "nginx",
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId"
+                  },
+                  ".dkr.ecr.us-east-1.",
+                  {
+                    "Ref": "AWS::URLSuffix"
+                  },
+                  "/nginx:latest"
+                ]
+              ]
+            },
             "MemoryReservation": 512,
             "Name": "test-construct-container",
             "PortMappings": [
@@ -1183,6 +1197,12 @@
           }
         ],
         "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "testconstructtaskdefExecutionRole794591FA",
+            "Arn"
+          ]
+        },
         "Family": "allnewpublichttptestconstructtaskdefDF932EBD",
         "Memory": "512",
         "NetworkMode": "awsvpc",
@@ -1195,6 +1215,68 @@
             "Arn"
           ]
         }
+      }
+    },
+    "testconstructtaskdefExecutionRole794591FA": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "testconstructtaskdefExecutionRoleDefaultPolicy5F290E6C": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":ecr:us-east-1:",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":repository/nginx"
+                  ]
+                ]
+              }
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "testconstructtaskdefExecutionRoleDefaultPolicy5F290E6C",
+        "Roles": [
+          {
+            "Ref": "testconstructtaskdefExecutionRole794591FA"
+          }
+        ]
       }
     },
     "testconstructsgA602AA29": {

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.ts
@@ -16,6 +16,7 @@ import { Aws, App, Stack } from "@aws-cdk/core";
 import { AlbToFargate, AlbToFargateProps } from "../lib";
 import { generateIntegStackName } from '@aws-solutions-constructs/core';
 import * as ecs from '@aws-cdk/aws-ecs';
+import * as ecr from '@aws-cdk/aws-ecr';
 import * as defaults from '@aws-solutions-constructs/core';
 import { CfnSecurityGroup } from "@aws-cdk/aws-ec2";
 
@@ -26,7 +27,8 @@ const stack = new Stack(app, generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for public HTTP API with new VPC, LoadBalancer and Service';
 
-const image = ecs.ContainerImage.fromRegistry('nginx');
+const testRepo = ecr.Repository.fromRepositoryName(stack, 'test-repo', 'nginx');
+const image = ecs.ContainerImage.fromEcrRepository(testRepo);
 
 const testProps: AlbToFargateProps = {
   publicApi: true,

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.expected.json
@@ -1198,7 +1198,21 @@
         "ContainerDefinitions": [
           {
             "Essential": true,
-            "Image": "nginx",
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId"
+                  },
+                  ".dkr.ecr.us-east-1.",
+                  {
+                    "Ref": "AWS::URLSuffix"
+                  },
+                  "/nginx:latest"
+                ]
+              ]
+            },
             "MemoryReservation": 512,
             "Name": "test-construct-container",
             "PortMappings": [
@@ -1210,6 +1224,12 @@
           }
         ],
         "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "testconstructtaskdefExecutionRole794591FA",
+            "Arn"
+          ]
+        },
         "Family": "allnewtwotargetstestconstructtaskdef8EF55A85",
         "Memory": "512",
         "NetworkMode": "awsvpc",
@@ -1222,6 +1242,68 @@
             "Arn"
           ]
         }
+      }
+    },
+    "testconstructtaskdefExecutionRole794591FA": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "testconstructtaskdefExecutionRoleDefaultPolicy5F290E6C": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":ecr:us-east-1:",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":repository/nginx"
+                  ]
+                ]
+              }
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "testconstructtaskdefExecutionRoleDefaultPolicy5F290E6C",
+        "Roles": [
+          {
+            "Ref": "testconstructtaskdefExecutionRole794591FA"
+          }
+        ]
       }
     },
     "testconstructsgA602AA29": {

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.ts
@@ -16,6 +16,7 @@ import { Aws, App, Stack } from "@aws-cdk/core";
 import { AlbToFargate, AlbToFargateProps } from "../lib";
 import * as elb from '@aws-cdk/aws-elasticloadbalancingv2';
 import * as ecs from '@aws-cdk/aws-ecs';
+import * as ecr from '@aws-cdk/aws-ecr';
 import * as defaults from '@aws-solutions-constructs/core';
 import { CfnSecurityGroup } from "@aws-cdk/aws-ec2";
 
@@ -26,7 +27,8 @@ const stack = new Stack(app, defaults.generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for public HTTP API with new VPC, LoadBalancer and Service and 2 targets';
 
-const image = ecs.ContainerImage.fromRegistry('nginx');
+const testRepo = ecr.Repository.fromRepositoryName(stack, 'test-repo', 'nginx');
+const image = ecs.ContainerImage.fromEcrRepository(testRepo);
 
 const testProps: AlbToFargateProps = {
   publicApi: true,


### PR DESCRIPTION
*Issue #, if available:*
ACAT Finding

*Description of changes:*
Stop using external container in integration test placeholder - switch to internal container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.