### PR TITLE
fix(cdk-integ-tools): Ignore the diff for S3AutoDeleteObjects lambda function from cdk-integ-assert

### DIFF
--- a/source/tools/cdk-integ-tools/lib/canonicalize-assets.ts
+++ b/source/tools/cdk-integ-tools/lib/canonicalize-assets.ts
@@ -45,27 +45,7 @@ import { LIST_OF_IGNORED_LAMBDA_PREFIXES } from "./integ-helpers";
     ]);
   }
 
-  hideIgnoredResources(Object.entries(template?.Resources || {}));
-
-  function checkIgnoreList(functionName: string): boolean {
-    for (const funcPrefix of LIST_OF_IGNORED_LAMBDA_PREFIXES) {
-      if (functionName.startsWith(funcPrefix)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  function hideIgnoredResources(resources: [string, any][]) {
-    for (const [resourceName, resourceValue] of resources) {
-      if (checkIgnoreList(resourceName)) {
-        stringSubstitutions.push([
-          resourceValue.Properties.Code.S3Key,
-          'SomeHash.zip'
-        ])
-      }
-    }
-  }
+  hideIgnoredResources(Object.entries(template?.Resources || {}), stringSubstitutions);
 
   // Substitute them out
   return substitute(template);
@@ -95,5 +75,25 @@ import { LIST_OF_IGNORED_LAMBDA_PREFIXES } from "./integ-helpers";
       x = x.replace(re, replacement);
     }
     return x;
+  }
+}
+
+function checkIgnoreList(functionName: string): boolean {
+  for (const funcPrefix of LIST_OF_IGNORED_LAMBDA_PREFIXES) {
+    if (functionName.startsWith(funcPrefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hideIgnoredResources(resources: [string, any][], stringSubstitutions: Array<[RegExp, string]>) {
+  for (const [resourceName, resourceValue] of resources) {
+    if (checkIgnoreList(resourceName)) {
+      stringSubstitutions.push([
+        resourceValue.Properties.Code.S3Key,
+        'SomeHash.zip'
+      ])
+    }
   }
 }

--- a/source/tools/cdk-integ-tools/lib/canonicalize-assets.ts
+++ b/source/tools/cdk-integ-tools/lib/canonicalize-assets.ts
@@ -1,3 +1,5 @@
+import { LIST_OF_IGNORE_LAMBDA_PREFIX } from "./integ-helpers";
+
 /**
  * Reduce template to a normal form where asset references have been normalized
  *
@@ -37,6 +39,24 @@
       new RegExp(`${m[1]}`),
       `Asset${ix}Hash`,
     ]);
+  }
+
+  function checkIgnoreList(functionName: string): boolean {
+    for (const funcPrefix of LIST_OF_IGNORE_LAMBDA_PREFIX) {
+      if (functionName.startsWith(funcPrefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  for (const [resourceName, resourceValue] of Object.entries(template?.Resources || {})) {
+    if (checkIgnoreList(resourceName)) {
+      stringSubstitutions.push([
+        (resourceValue as any).Properties.Code.S3Key,
+        'SomeHash.zip'
+      ])
+    }
   }
 
   // Substitute them out

--- a/source/tools/cdk-integ-tools/lib/integ-helpers.ts
+++ b/source/tools/cdk-integ-tools/lib/integ-helpers.ts
@@ -361,7 +361,7 @@ export const DEFAULT_SYNTH_OPTIONS = {
 // The Lambda functions starting with these prefixes will have their S3Key (ZIP filename) canonicalized
 // i.e. the hash value of zip file will be replaced with a constant value
 // so that it does not show up as a diff during the `cdk-integ-assert`
-export const LIST_OF_IGNORE_LAMBDA_PREFIX = [
+export const LIST_OF_IGNORED_LAMBDA_PREFIXES = [
   'CustomS3AutoDeleteObjectsCustomResourceProviderHandler'
 ];
 

--- a/source/tools/cdk-integ-tools/lib/integ-helpers.ts
+++ b/source/tools/cdk-integ-tools/lib/integ-helpers.ts
@@ -358,6 +358,13 @@ export const DEFAULT_SYNTH_OPTIONS = {
   },
 };
 
+// The Lambda functions starting with these prefixes will have their S3Key (ZIP filename) canonicalized
+// i.e. the hash value of zip file will be replaced with a constant value
+// so that it does not show up as a diff during the `cdk-integ-assert`
+export const LIST_OF_IGNORE_LAMBDA_PREFIX = [
+  'CustomS3AutoDeleteObjectsCustomResourceProviderHandler'
+];
+
 /**
  * Our own execute function which doesn't use shells and strings.
  */

--- a/source/tools/cdk-integ-tools/solutions-constructs-modifications.md
+++ b/source/tools/cdk-integ-tools/solutions-constructs-modifications.md
@@ -1,0 +1,23 @@
+## Customizations that need to be reapplied whenever cdk-integ is refreshed from [CDK] (https://github.com/aws/aws-cdk/tree/master/tools/%40aws-cdk/cdk-integ-tools)
+
+**Provide additional cdk synth options for V1 scripts to ensure output templates match for both V1 and V2**
+[bin/cdk-integ.ts](https://github.com/awslabs/aws-solutions-constructs/blob/main/source/tools/cdk-integ-tools/bin/cdk-integ.ts)
+* add line `import * as deepmerge from 'deepmerge';`
+* Modify `await test.cdkSynthFast` to pass in additional synth options e.g. `'@aws-cdk/aws-kms:defaultKeyPolicies': true,`
+
+[bin/cdk-integ-assert.ts](https://github.com/awslabs/aws-solutions-constructs/blob/main/source/tools/cdk-integ-tools/bin/cdk-integ-assert.ts)
+* add line `import * as deepmerge from 'deepmerge';`
+* Modify `await test.cdkSynthFast` to pass in additional synth options e.g. `'@aws-cdk/aws-kms:defaultKeyPolicies': true,`
+
+**Do not enable FUTURE_FLAGS and TARGET_PARTITIONS in DEFAULT_SYNTH_OPTIONS**
+[lib/integ-helpers.ts] (https://github.com/awslabs/aws-solutions-constructs/blob/main/source/tools/cdk-integ-tools/lib/integ-helpers.ts)
+* Remove references for `...FUTURE_FLAGS` and `TARGET_PARTITIONS`, it breaks the `cdk-integ-assert-v2`
+
+**Check for Lambda Functions to Ignore**
+[lib/canonicalize-assets.ts] (https://github.com/awslabs/aws-solutions-constructs/blob/main/source/tools/cdk-integ-tools/lib/canonicalize-assets.ts)
+* add line `import { LIST_OF_IGNORED_LAMBDA_PREFIXES } from "./integ-helpers";`
+* add `hideIgnoredResources()`
+* add `checkIgnoreList()`
+
+[lib/integ-helpers.ts] (https://github.com/awslabs/aws-solutions-constructs/blob/main/source/tools/cdk-integ-tools/lib/integ-helpers.ts)
+* Add section with `LIST_OF_IGNORED_LAMBDA_PREFIXES`


### PR DESCRIPTION
*Issue #, if available: [627](https://github.com/awslabs/aws-solutions-constructs/issues/627)*

*Description of changes: Ignore the diff for S3AutoDeleteObjects lambda function from cdk-integ-assert* 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.