### PR TITLE
fix(Remove debug statement): Remove extra debug statement in kinesisfirehose-s3

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
@@ -170,7 +170,6 @@ export class KinesisFirehoseToS3 extends Construct {
       awsManagedKey
     );
 
-    printWarning(`kinesisFirehoseProps: ${JSON.stringify(props.kinesisFirehoseProps, null, 2)}`);
     // if the client didn't explicity say it was a Kinesis client, then turn on encryption
     if (!props.kinesisFirehoseProps ||
       !props.kinesisFirehoseProps.deliveryStreamType ||

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
@@ -16,7 +16,7 @@ import { Construct } from "@aws-cdk/core";
 import * as s3 from "@aws-cdk/aws-s3";
 import * as defaults from "@aws-solutions-constructs/core";
 import * as iam from "@aws-cdk/aws-iam";
-import { overrideProps, printWarning, consolidateProps } from "@aws-solutions-constructs/core";
+import { overrideProps, consolidateProps } from "@aws-solutions-constructs/core";
 import * as logs from "@aws-cdk/aws-logs";
 import * as cdk from "@aws-cdk/core";
 import * as kms from "@aws-cdk/aws-kms";


### PR DESCRIPTION
The JSON.stringify() call in this statement caused problems

*Issue #, if available:*
Issue648

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.