### PR TITLE
fix(Incorrect Java Artifact ID): Change lambdas3  lambdaelasticachememcached

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
@@ -37,7 +37,7 @@
         "package": "software.amazon.awsconstructs.services.lambdaelasticachememcached",
         "maven": {
           "groupId": "software.amazon.awsconstructs",
-          "artifactId": "lambdas3"
+          "artifactId": "lambdaelasticachememcached"
         }
       },
       "dotnet": {


### PR DESCRIPTION
*Description of changes:*
aws-lambda-elasticache published with wrong artifact ID - this will cause problems for that construct and for aws-lambda-s3 in releases 1.153.0, 1.153.1 and 2.6.0. After loading this will release 1.154.0 and 2.7.0 ASAP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.