### PR TITLE
chore(release): 2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.28.0](https://github.com/awslabs/aws-solutions-constructs/compare/v2.27.0...v2.28.0) (2022-11-02)
+
 ## [2.27.0](https://github.com/awslabs/aws-solutions-constructs/compare/v2.26.0...v2.27.0) (2022-11-02)
 
 Built on CDK 2.50.0

--- a/source/lerna.json
+++ b/source/lerna.json
@@ -6,5 +6,5 @@
     "./patterns/@aws-solutions-constructs/*"
   ],
   "rejectCycles": "true",
-  "version": "2.27.0"
+  "version": "2.28.0"
 }


### PR DESCRIPTION
See [CHANGELOG](https://github.com/awslabs/aws-solutions-constructs/blob/bump/2.28.0/CHANGELOG.md)