### PR TITLE
Add missing coverage reports in alphabetical order

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,73 +22,71 @@ sonar.exclusions=\
 #    source/test/coverage-reports/jest/*/lcov.info
 # so we have to provide an explicit list of reportPaths
 sonar.javascript.lcov.reportPaths= \
+    source/patterns/@aws-solutions-constructs/aws-alb-fargate/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-alb-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-apigateway-iot/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-dynamodb-stream-lambda-elasticsearch-kibana/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisfirehose-s3/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-events-rule-kinesisstreams/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-events-rule-lambda/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-events-rule-sns/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-events-rule-sqs/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-events-rule-step-function/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-s3/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-sns/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-sqs/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-iot-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-iot-lambda/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-iot-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-iot-sqs/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-s3/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-sns/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-lambda-sqs/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-lambda-sqs/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-lambda-step-function/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-route53-alb/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-route53-apigateway/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-s3-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-s3-sqs/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-s3-step-function/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-sns-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-sns-sqs/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-sqs-lambda/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-alb-fargate/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-iot-s3/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-route53-apigateway/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-fargate-sns/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-fargate-s3/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-fargate-sqs/coverage/lcov.info, \
-    source/patterns/@aws-solutions-constructs/aws-alb-lambda/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/core/coverage/lcov.info
 
 # Encoding of the source files


### PR DESCRIPTION
This PR updates `sonar-project.properties` file with alphabetically ordered list of coverage report directories from all existing patterns.

Alphabetical order would allow us to do automated checks on this in the future if desired.