### PR TITLE
fix(standardize encryption props) Standardize how encryption properties are used for SNS/SQS constructs.

### DIFF
--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -309,9 +309,9 @@ Existing Inconsistencies would not be published, thatâ€™s for our internal use â
 | --- | --- | --- |--- |
 | existingTopicObj?	| [`sns.Topic`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.Topic.html)|An optional, existing SNS topic to be used instead of the default topic. Providing both this and `topicProps` will cause an error|
 | topicProps?	| [`sns.TopicProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.TopicProps.html)|Optional user provided properties to override the default properties for the SNS topic.
-| enableEncryptionWithCustomerManagedKey?	| `boolean`|Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in the encryptionKey property for this construct.| Sending messages from an AWS service to an encrypted Topic [requires a Customer Master key](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#compatibility-with-aws-services). Those constructs require these properties.  |
-| encryptionKey?		| [`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS queue, and SNS Topic.|
-| encryptionKeyProps?		| [`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.KeyProps.html)|An optional, user provided properties to override the default properties for the KMS encryption key	|
+| enableEncryptionWithCustomerManagedKey?	| `boolean`|If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key.|This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.| Sending messages from an AWS service to an encrypted Topic [requires a Customer Master key](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#compatibility-with-aws-services). Those constructs require these properties.  |
+| encryptionKey?		| [`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SNS Topic with.|
+| encryptionKeyProps?		| [`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.KeyProps.html)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS Topic with.	|
 
 **Required Construct Properties**
 
@@ -331,7 +331,10 @@ Existing Inconsistencies would not be published, thatâ€™s for our internal use â
 | deadLetterQueueProps?	| [`sqs.QueueProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html)|Optional user provided props to override the default props for the SQS queue.|
 | maxReceiveCount	| `int`	| The number of times a message can be unsuccessfully dequeued before being moved to the dead letter queue. Defaults to `15`. |
 | enableQueuePurging	| `boolean`	| Whether to grant additional permissions to the Lambda function enabling it to purge the SQS queue. Defaults to `false`. | This is only on 2 constructs, docs talk about a Lambda function role.|
-| encryptionKey?	| [`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|Optional imported encryption key to encrypt the SQS queue.	| Sending messages from an AWS service to an encrypted queue [requires a Customer Master key](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#compatibility-with-aws-services). Those constructs require these properties. |
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. |This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|Sending messages from an AWS service to an encrypted queue [requires a Customer Master key](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#compatibility-with-aws-services). Those constructs require these properties. |
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
+
 
 **Required Construct Properties**
 

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/README.md
@@ -69,6 +69,9 @@ new ApiGatewayToSqs(this, "ApiGatewayToSqsPattern", new ApiGatewayToSqsProps.Bui
 |allowDeleteOperation?|`boolean`|Whether to deploy an API Gateway Method for Delete operations on the queue (i.e. sqs:DeleteMessage).|
 |deleteRequestTemplate?|`string`|Override the default API Gateway Request template for Delete method, if allowDeleteOperation set to true.|
 |logGroupProps?|[`logs.LogGroupProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_logs.LogGroupProps.html)|User provided props to override the default props for for the CloudWatchLogs LogGroup.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
@@ -13,6 +13,7 @@
 
 // Imports
 import * as api from 'aws-cdk-lib/aws-apigateway';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as defaults from '@aws-solutions-constructs/core';
@@ -103,6 +104,25 @@ export interface ApiGatewayToSqsProps {
    * @default - Default props are used
    */
   readonly logGroupProps?: logs.LogGroupProps
+  /**
+   * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
+   *
+   * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
+   */
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  /**
+   * An optional, imported encryption key to encrypt the SQS Queue with.
+   *
+   * @default - None
+   */
+  readonly encryptionKey?: kms.Key
+  /**
+   * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.
+   *
+   * @default - None
+   */
+  readonly encryptionKeyProps?: kms.KeyProps
 }
 
 /**
@@ -140,7 +160,10 @@ export class ApiGatewayToSqs extends Construct {
     [this.sqsQueue] = defaults.buildQueue(this, 'queue', {
       existingQueueObj: props.existingQueueObj,
       queueProps: props.queueProps,
-      deadLetterQueue: this.deadLetterQueue
+      deadLetterQueue: this.deadLetterQueue,
+      enableEncryptionWithCustomerManagedKey: props.enableEncryptionWithCustomerManagedKey,
+      encryptionKey: props.encryptionKey,
+      encryptionKeyProps: props.encryptionKeyProps
     });
 
     // Setup the API Gateway

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
@@ -31,98 +31,98 @@ export interface ApiGatewayToSqsProps {
    *
    * @default - Default properties are used.
    */
-  readonly apiGatewayProps?: api.RestApiProps | any
+  readonly apiGatewayProps?: api.RestApiProps | any;
   /**
    * Existing instance of SQS queue object, providing both this  and queueProps will cause an error
    *
    * @default - None
    */
-  readonly existingQueueObj?: sqs.Queue,
+  readonly existingQueueObj?: sqs.Queue;
   /**
    * User provided props to override the default props for the SQS queue.
    *
    * @default - Default props are used
    */
-  readonly queueProps?: sqs.QueueProps,
+  readonly queueProps?: sqs.QueueProps;
   /**
    * Whether to deploy a secondary queue to be used as a dead letter queue.
    *
    * @default - required field.
    */
-  readonly deployDeadLetterQueue?: boolean,
+  readonly deployDeadLetterQueue?: boolean;
   /**
    * Optional user provided properties for the dead letter queue
    *
    * @default - Default props are used
    */
-  readonly deadLetterQueueProps?: sqs.QueueProps,
+  readonly deadLetterQueueProps?: sqs.QueueProps;
   /**
    * The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue.
    *
    * @default - required only if deployDeadLetterQueue = true.
    */
-  readonly maxReceiveCount?: number,
+  readonly maxReceiveCount?: number;
   /**
    * Whether to deploy an API Gateway Method for Create operations on the queue (i.e. sqs:SendMessage).
    *
    * @default - false
    */
-  readonly allowCreateOperation?: boolean,
+  readonly allowCreateOperation?: boolean;
   /**
    * API Gateway Request template for Create method, if allowCreateOperation set to true
    *
    * @default - None
    */
-  readonly createRequestTemplate?: string,
+  readonly createRequestTemplate?: string;
   /**
    * Whether to deploy an API Gateway Method for Read operations on the queue (i.e. sqs:ReceiveMessage).
    *
    * @default - "Action=SendMessage&MessageBody=$util.urlEncode(\"$input.body\")"
    */
-  readonly allowReadOperation?: boolean,
+  readonly allowReadOperation?: boolean;
   /**
    * API Gateway Request template for Get method, if allowReadOperation set to true
    *
    * @default - "Action=ReceiveMessage"
    */
-  readonly readRequestTemplate?: string,
+  readonly readRequestTemplate?: string;
   /**
    * Whether to deploy an API Gateway Method for Delete operations on the queue (i.e. sqs:DeleteMessage).
    *
    * @default - false
    */
-  readonly allowDeleteOperation?: boolean
+  readonly allowDeleteOperation?: boolean;
   /**
    * API Gateway Request template for Delete method, if allowDeleteOperation set to true
    *
    * @default - "Action=DeleteMessage&ReceiptHandle=$util.urlEncode($input.params('receiptHandle'))"
    */
-  readonly deleteRequestTemplate?: string,
+  readonly deleteRequestTemplate?: string;
   /**
    * User provided props to override the default props for the CloudWatchLogs LogGroup.
    *
    * @default - Default props are used
    */
-  readonly logGroupProps?: logs.LogGroupProps
+  readonly logGroupProps?: logs.LogGroupProps;
   /**
    * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
    * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
    *
    * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
   /**
    * An optional, imported encryption key to encrypt the SQS Queue with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key
+  readonly encryptionKey?: kms.Key;
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.
    *
    * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps
+  readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 /**

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/README.md
@@ -117,9 +117,9 @@ constructStack.getEncryptionKey().addToResourcePolicy(policyStatement);
 |topicProps?|[`sns.TopicProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.TopicProps.html)|User provided props to override the default props for the SNS Topic. |
 |existingEventBusInterface?|[`events.IEventBus`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.IEventBus.html)| Optional user-provided custom EventBus for construct to use. Providing both this and `eventBusProps` results an error.|
 |eventBusProps?|[`events.EventBusProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.EventBusProps.html)|Optional user-provided properties to override the default properties when creating a custom EventBus. Setting this value to `{}` will create a custom EventBus using all default properties. If neither this nor `existingEventBusInterface` is provided the construct will use the `default` EventBus. Providing both this and `existingEventBusInterface` results an error.|
-|enableEncryptionWithCustomerManagedKey?|`boolean`|Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in the encryptionKey property for this construct.|
-|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SNS Topic.|
-|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.KeyProps.html)|An optional, user provided properties to override the default properties for the KMS encryption key.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SNS Topic with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS Topic with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/lib/index.ts
@@ -57,19 +57,19 @@ export interface EventbridgeToSnsProps {
      *
      * @default - True if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
-    readonly enableEncryptionWithCustomerManagedKey?: boolean
+    readonly enableEncryptionWithCustomerManagedKey?: boolean;
     /**
      * An optional, imported encryption key to encrypt the SNS topic with.
      *
      * @default - None.
      */
-    readonly encryptionKey?: kms.Key
+    readonly encryptionKey?: kms.Key;
     /**
      * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SNS topic with.
      *
      * @default - None
      */
-    readonly encryptionKeyProps?: kms.KeyProps
+    readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 export class EventbridgeToSns extends Construct {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/lib/index.ts
@@ -52,24 +52,24 @@ export interface EventbridgeToSnsProps {
      */
     readonly existingTopicObj?: sns.Topic;
     /**
-     * Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in
-     * the encryptionKey property for this construct.
+     * If no key is provided, this flag determines whether the topic is encrypted with a new CMK or an AWS managed key.
+     * This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.
      *
-     * @default - true (encryption enabled, managed by this CDK app).
+     * @default - True if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
-    readonly enableEncryptionWithCustomerManagedKey?: boolean;
+    readonly enableEncryptionWithCustomerManagedKey?: boolean
     /**
-     * An optional, imported encryption key to encrypt the SQS queue, and SNS Topic.
+     * An optional, imported encryption key to encrypt the SNS topic with.
      *
-     * @default - not specified.
+     * @default - None.
      */
-    readonly encryptionKey?: kms.Key;
+    readonly encryptionKey?: kms.Key
     /**
-     * Optional user-provided props to override the default props for the encryption key.
+     * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SNS topic with.
      *
-     * @default - Default props are used.
+     * @default - None
      */
-    readonly encryptionKeyProps?: kms.KeyProps;
+    readonly encryptionKeyProps?: kms.KeyProps
 }
 
 export class EventbridgeToSns extends Construct {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
@@ -263,3 +263,100 @@ test('check custom event bus resource with props when deploy:true', () => {
     Name: 'testcustomeventbus'
   });
 });
+
+test('Topic is encrypted when key is provided on topicProps.masterKey prop', () => {
+  const stack = new cdk.Stack();
+  const key = defaults.buildEncryptionKey(stack, {
+    description: 'my-key'
+  });
+
+  const props: EventbridgeToSnsProps = {
+    eventRuleProps: {
+      schedule: events.Schedule.rate(cdk.Duration.minutes(5))
+    },
+    topicProps: {
+      masterKey: key
+    }
+  };
+
+  new EventbridgeToSns(stack, 'test-events-rule-sqs', props);
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "EncryptionKey1B843E66",
+        "Arn"
+      ]
+    }
+  });
+
+  expect(stack).toHaveResource('AWS::KMS::Key', {
+    Description: "my-key",
+    EnableKeyRotation: true
+  });
+});
+
+test('Topic is encrypted when keyProps are provided', () => {
+  const stack = new cdk.Stack();
+
+  const props: EventbridgeToSnsProps = {
+    eventRuleProps: {
+      schedule: events.Schedule.rate(cdk.Duration.minutes(5))
+    },
+    encryptionKeyProps: {
+      description: 'my-key'
+    }
+  };
+
+  new EventbridgeToSns(stack, 'test-events-rule-sqs', props);
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "testeventsrulesqsEncryptionKey19AB0C02",
+        "Arn"
+      ]
+    }
+  });
+
+  expect(stack).toHaveResource('AWS::KMS::Key', {
+    Description: "my-key",
+    EnableKeyRotation: true
+  });
+});
+
+test('Topic is encrypted with AWS-managed KMS key when enableEncryptionWithCustomerManagedKey property is false', () => {
+  const stack = new cdk.Stack();
+
+  const props: EventbridgeToSnsProps = {
+    eventRuleProps: {
+      schedule: events.Schedule.rate(cdk.Duration.minutes(5))
+    },
+    enableEncryptionWithCustomerManagedKey: false
+  };
+
+  new EventbridgeToSns(stack, 'test-events-rule-sqs', props);
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      "Fn::Join": [
+        "",
+        [
+          "arn:",
+          {
+            Ref: "AWS::Partition"
+          },
+          ":kms:",
+          {
+            Ref: "AWS::Region"
+          },
+          ":",
+          {
+            Ref: "AWS::AccountId"
+          },
+          ":alias/aws/sns"
+        ]
+      ]
+    }
+  });
+});

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/README.md
@@ -121,9 +121,9 @@ constructStack.getEncryptionKey().addToResourcePolicy(policyStatement);
 |deployDeadLetterQueue?|`boolean`|Whether to create a secondary queue to be used as a dead letter queue. Defaults to `true`.|
 |deadLetterQueueProps?|[`sqs.QueueProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html)|Optional user-provided props to override the default props for the dead letter queue. Only used if the `deployDeadLetterQueue` property is set to true.|
 |maxReceiveCount?|`number`|The number of times a message can be unsuccessfully dequeued before being moved to the dead letter queue. Defaults to `15`.|
-|enableEncryptionWithCustomerManagedKey?|`boolean`|Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in the encryptionKey property for this construct.|
-|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS queue.|
-|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.KeyProps.html)|An optional, user provided properties to override the default properties for the KMS encryption key.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/lib/index.ts
@@ -79,24 +79,24 @@ export interface EventbridgeToSqsProps {
    */
   readonly maxReceiveCount?: number;
   /**
-   * Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in
-   * the encryptionKey property for this construct.
+   * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
    *
-   * @default - true (encryption enabled, managed by this CDK app).
+   * @default - True if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean;
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
   /**
-   * An optional, imported encryption key to encrypt the SQS queue, and SNS Topic.
+   * An optional, imported encryption key to encrypt the SQS queue with.
    *
-   * @default - not specified.
+   * @default - None
    */
-  readonly encryptionKey?: kms.Key;
+  readonly encryptionKey?: kms.Key
   /**
-   * Optional user-provided props to override the default props for the encryption key.
+   * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SQS queue with.
    *
-   * @default - Default props are used.
+   * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps;
+  readonly encryptionKeyProps?: kms.KeyProps
 }
 
 export class EventbridgeToSqs extends Construct {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/lib/index.ts
@@ -84,19 +84,19 @@ export interface EventbridgeToSqsProps {
    *
    * @default - True if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
   /**
    * An optional, imported encryption key to encrypt the SQS queue with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key
+  readonly encryptionKey?: kms.Key;
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SQS queue with.
    *
    * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps
+  readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 export class EventbridgeToSqs extends Construct {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/README.md
@@ -87,6 +87,9 @@ new FargateToSns(this, "test_construct", new FargateToSnsProps.Builder()
 |topicProps?|[sns.TopicProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.TopicProps.html)|Optional user provided properties to override the default properties for the SNS topic.|
 |topicArnEnvironmentVariableName?|string|Optional Name for the container environment variable set to the ARN of the topic. Default: SNS_TOPIC_ARN |
 |topicNameEnvironmentVariableName?|string|Optional Name for the container environment variable set to the name of the topic. Default: SNS_TOPIC_NAME |
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SNS Topic with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS Topic with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/lib/index.ts
@@ -12,6 +12,7 @@
  */
 
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as sns from "aws-cdk-lib/aws-sns";
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from "constructs";
@@ -125,6 +126,25 @@ export interface FargateToSnsProps {
    * @default - None
    */
   readonly existingContainerDefinitionObject?: ecs.ContainerDefinition;
+  /**
+   * If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.
+   *
+   * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
+   */
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  /**
+   * An optional, imported encryption key to encrypt the SNS Topic with.
+   *
+   * @default - None
+   */
+  readonly encryptionKey?: kms.Key
+  /**
+   * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SNS Topic with.
+   *
+   * @default - None
+   */
+  readonly encryptionKeyProps?: kms.KeyProps
 }
 
 export class FargateToSns extends Construct {
@@ -169,6 +189,9 @@ export class FargateToSns extends Construct {
     [this.snsTopic] = defaults.buildTopic(this, {
       existingTopicObj: props.existingTopicObject,
       topicProps: props.topicProps,
+      enableEncryptionWithCustomerManagedKey: props.enableEncryptionWithCustomerManagedKey,
+      encryptionKey: props.encryptionKey,
+      encryptionKeyProps: props.encryptionKeyProps
     });
 
     this.snsTopic.grantPublish(this.service.taskDefinition.taskRole);

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/lib/index.ts
@@ -132,19 +132,19 @@ export interface FargateToSnsProps {
    *
    * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
   /**
    * An optional, imported encryption key to encrypt the SNS Topic with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key
+  readonly encryptionKey?: kms.Key;
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SNS Topic with.
    *
    * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps
+  readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 export class FargateToSns extends Construct {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/test/fargate-sns.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/test/fargate-sns.test.ts
@@ -15,6 +15,7 @@ import '@aws-cdk/assert/jest';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToSns } from "../lib";
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 
@@ -363,4 +364,130 @@ test('Existing service/existing topic, private API, existing VPC', () => {
   expect(stack).toCountResources('AWS::EC2::VPC', 1);
   expect(stack).toCountResources('AWS::SNS::Topic', 1);
   expect(stack).toCountResources('AWS::ECS::Service', 1);
+});
+
+test('Topic is encrypted with imported CMK when set on encryptionKey prop', () => {
+  const stack = new cdk.Stack(undefined, undefined, {
+    env: { account: "123456789012", region: 'us-east-1' },
+  });
+
+  const cmk = new kms.Key(stack, 'cmk');
+  new FargateToSns(stack, 'test-construct', {
+    publicApi: true,
+    ecrRepositoryArn: defaults.fakeEcrRepoArn,
+    encryptionKey: cmk
+  });
+
+  expect(stack).toHaveResource("AWS::SNS::Topic", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "cmk01DE03DA",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('Topic is encrypted with imported CMK when set on topicProps.masterKey prop', () => {
+  const stack = new cdk.Stack(undefined, undefined, {
+    env: { account: "123456789012", region: 'us-east-1' },
+  });
+
+  const cmk = new kms.Key(stack, 'cmk');
+  new FargateToSns(stack, 'test-construct', {
+    publicApi: true,
+    ecrRepositoryArn: defaults.fakeEcrRepoArn,
+    topicProps: {
+      masterKey: cmk
+    }
+  });
+
+  expect(stack).toHaveResource("AWS::SNS::Topic", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "cmk01DE03DA",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('Topic is encrypted with provided encrytionKeyProps', () => {
+  const stack = new cdk.Stack(undefined, undefined, {
+    env: { account: "123456789012", region: 'us-east-1' },
+  });
+
+  new FargateToSns(stack, 'test-construct', {
+    publicApi: true,
+    ecrRepositoryArn: defaults.fakeEcrRepoArn,
+    encryptionKeyProps: {
+      alias: 'new-key-alias-from-props'
+    }
+  });
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      'Fn::GetAtt': [
+        'testconstructEncryptionKey6153B053',
+        'Arn'
+      ]
+    },
+  });
+
+  expect(stack).toHaveResource('AWS::KMS::Alias', {
+    AliasName: 'alias/new-key-alias-from-props',
+    TargetKeyId: {
+      'Fn::GetAtt': [
+        'testconstructEncryptionKey6153B053',
+        'Arn'
+      ]
+    }
+  });
+});
+
+test('Topic is encrypted by default with AWS-managed KMS key when no other encryption properties are set', () => {
+  const stack = new cdk.Stack(undefined, undefined, {
+    env: { account: "123456789012", region: 'us-east-1' },
+  });
+
+  new FargateToSns(stack, 'test-construct', {
+    publicApi: true,
+    ecrRepositoryArn: defaults.fakeEcrRepoArn,
+  });
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      'Fn::Join': [
+        "",
+        [
+          "arn:",
+          {
+            Ref: "AWS::Partition"
+          },
+          ":kms:us-east-1:123456789012:alias/aws/sns"
+        ]
+      ]
+    },
+  });
+});
+
+test('Topic is encrypted with customer managed KMS Key when enable encryption flag is true', () => {
+  const stack = new cdk.Stack(undefined, undefined, {
+    env: { account: "123456789012", region: 'us-east-1' },
+  });
+
+  new FargateToSns(stack, 'test-construct', {
+    publicApi: true,
+    ecrRepositoryArn: defaults.fakeEcrRepoArn,
+    enableEncryptionWithCustomerManagedKey: true
+  });
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      'Fn::GetAtt': [
+        'testconstructEncryptionKey6153B053',
+        'Arn'
+      ]
+    },
+  });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/README.md
@@ -91,6 +91,9 @@ new FargateToSqs(this, "test_construct", new FargateToSqsProps.Builder()
 |queueUrlEnvironmentVariableName?|string|Optional Name for the container environment variable set to the URL of the queue. Default: SQS_QUEUE_URL |
 |queueArnEnvironmentVariableName?|string|Optional Name for the container environment variable set to the arn of the queue. Default: SQS_QUEUE_ARN |
 |queuePermissions?|`string[]`|Optional queue permissions to grant to the Fargate service. One or more of the following may be specified: `Read`,`Write`. Default is `Write`|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 
 
 ## Pattern Properties

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/lib/index.ts
@@ -156,19 +156,19 @@ export interface FargateToSqsProps {
    *
    * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
   /**
    * An optional, imported encryption key to encrypt the SQS Queue with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key
+  readonly encryptionKey?: kms.Key;
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
    *
    * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps
+  readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 export class FargateToSqs extends Construct {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/lib/index.ts
@@ -12,6 +12,7 @@
  */
 
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as sqs from "aws-cdk-lib/aws-sqs";
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from "constructs";
@@ -149,6 +150,25 @@ export interface FargateToSqsProps {
    * @default - Write
    */
   readonly queuePermissions?: string[];
+  /**
+   * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
+   *
+   * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
+   */
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  /**
+   * An optional, imported encryption key to encrypt the SQS Queue with.
+   *
+   * @default - None
+   */
+  readonly encryptionKey?: kms.Key
+  /**
+   * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
+   *
+   * @default - None
+   */
+  readonly encryptionKeyProps?: kms.KeyProps
 }
 
 export class FargateToSqs extends Construct {
@@ -207,6 +227,9 @@ export class FargateToSqs extends Construct {
       queueProps: props.queueProps,
       deadLetterQueue: this.deadLetterQueue,
       existingQueueObj: props.existingQueueObj,
+      enableEncryptionWithCustomerManagedKey: props.enableEncryptionWithCustomerManagedKey,
+      encryptionKey: props.encryptionKey,
+      encryptionKeyProps: props.encryptionKeyProps
     });
 
     // Enable message send and receive permissions for Fargate service by default

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/README.md
@@ -100,9 +100,9 @@ new IotToSqs(this, "test_iot_sqs", new IotToSqsProps.Builder()
 |deadLetterQueueProps?|[`sqs.QueueProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html)|Optional user provided properties for the dead letter queue.|
 |deployDeadLetterQueue?|`boolean`|Whether to deploy a secondary queue to be used as a dead letter queue. Default `true`.|
 |maxReceiveCount?|`number`|The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue. Required field if `deployDeadLetterQueue`=`true`.|
-|enableEncryptionWithCustomerManagedKey?|`boolean`|Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in the `encryptionKey` property for this construct.|
-|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS queue.|
-|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.KeyProps.html)|Optional user-provided props to override the default props for the encryption key.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 
 
 ## Pattern Properties

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/lib/index.ts
@@ -69,21 +69,21 @@ export interface IotToSqsProps {
    *
    * @default - True if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
 
   /**
    * An optional, imported encryption key to encrypt the SQS Queue with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key,
+  readonly encryptionKey?: kms.Key;
 
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
    *
    * @default - None
    */
-   readonly encryptionKeyProps?: kms.KeyProps
+   readonly encryptionKeyProps?: kms.KeyProps;
  }
 
 export class IotToSqs extends Construct {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/lib/index.ts
@@ -64,27 +64,27 @@ export interface IotToSqsProps {
   readonly maxReceiveCount?: number;
 
   /**
-   * Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in
-   * the encryptionKey property for this construct.
+   * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
    *
-   * @default - true (encryption enabled, managed by this CDK app).
+   * @default - True if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean;
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
 
   /**
-   * An optional, imported encryption key to encrypt the SQS queue, and SNS Topic.
+   * An optional, imported encryption key to encrypt the SQS Queue with.
    *
-   * @default - not specified.
+   * @default - None
    */
-  readonly encryptionKey?: kms.Key;
+  readonly encryptionKey?: kms.Key,
 
   /**
-   * Optional user-provided props to override the default props for the encryption key.
+   * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
    *
-   * @default - Default props are used.
+   * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps;
-}
+   readonly encryptionKeyProps?: kms.KeyProps
+ }
 
 export class IotToSqs extends Construct {
   public readonly sqsQueue: sqs.Queue;

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/test/iot-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/test/iot-sqs.test.ts
@@ -354,6 +354,76 @@ test('Pattern deployment with existing KMS key', () => {
   });
 });
 
+// ---------------------------------------------------------------
+// Testing with existing KMS key on queueProps.encryptionMasterKey
+// ---------------------------------------------------------------
+test('Pattern deployment with existing KMS key', () => {
+  // Initial Setup
+  const stack = new Stack();
+
+  const kmsKey = new kms.Key(stack, 'existing-key', {
+    enableKeyRotation: false,
+    alias: 'existing-key-alias'
+  });
+
+  const props: IotToSqsProps = {
+    queueProps: {
+      encryptionMasterKey: kmsKey
+    },
+    iotTopicRuleProps: {
+      topicRulePayload: {
+        ruleDisabled: false,
+        description: "Processing messages from IoT devices or factory machines",
+        sql: "SELECT * FROM 'test/topic/#'",
+        actions: []
+      }
+    }
+  };
+  new IotToSqs(stack, 'test-iot-sqs', props);
+
+  // Creates a default sqs queue
+  expect(stack).toHaveResource("AWS::SQS::Queue", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "existingkey205DFC01",
+        "Arn"
+      ]
+    }
+  });
+
+  // Creates a dead letter queue
+  expect(stack).toHaveResource("AWS::SQS::Queue", {
+    KmsMasterKeyId: "alias/aws/sqs"
+  });
+
+  // Creates an IoT Topic Rule
+  expect(stack).toHaveResource("AWS::IoT::TopicRule", {
+    TopicRulePayload: {
+      Actions: [
+        {
+          Sqs: {
+            QueueUrl: { Ref: "testiotsqsqueue630B4C1F" },
+            RoleArn: {
+              "Fn::GetAtt": [
+                "testiotsqsiotactionsrole93B1D327",
+                "Arn"
+              ]
+            }
+          }
+        }
+      ],
+      Description: "Processing messages from IoT devices or factory machines",
+      RuleDisabled: false,
+      Sql: "SELECT * FROM 'test/topic/#'"
+    }
+  });
+
+  // Uses the provided key
+  expect(stack).toHaveResource("AWS::KMS::Key", {
+    EnableKeyRotation: false
+  });
+});
+
 // --------------------------------------------------------------
 // Testing with passing KMS key props
 // --------------------------------------------------------------

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/README.md
@@ -90,6 +90,9 @@ new LambdaToSns(this, "test-lambda-sns-stack", new LambdaToSnsProps.Builder()
 |deployVpc?|`boolean`|Whether to create a new VPC based on `vpcProps` into which to deploy this pattern. Setting this to true will deploy the minimal, most private VPC to run the pattern:<ul><li> One isolated subnet in each Availability Zone used by the CDK program</li><li>`enableDnsHostnames` and `enableDnsSupport` will both be set to true</li></ul>If this property is `true` then `existingVpc` cannot be specified. Defaults to `false`.|
 |topicArnEnvironmentVariableName?|`string`|Optional Name for the Lambda function environment variable set to the arn of the topic. Default: SNS_TOPIC_ARN |
 |topicNameEnvironmentVariableName?|`string`|Optional Name for the Lambda function environment variable set to the name of the topic. Default: SNS_TOPIC_NAME |
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SNS Topic with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS Topic with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/lib/index.ts
@@ -80,19 +80,19 @@ export interface LambdaToSnsProps {
    *
    * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
   /**
    * An optional, imported encryption key to encrypt the SNS Topic with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key
+  readonly encryptionKey?: kms.Key;
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS Topic with.
    *
    * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps
+  readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 /**
@@ -116,10 +116,6 @@ export class LambdaToSns extends Construct {
       defaults.CheckProps(props);
 
       if (props.deployVpc || props.existingVpc) {
-        if (props.deployVpc && props.existingVpc) {
-          throw new Error("More than 1 VPC specified in the properties");
-        }
-
         this.vpc = defaults.buildVpc(scope, {
           defaultVpcProps: defaults.DefaultIsolatedVpcProps(),
           existingVpc: props.existingVpc,

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/lib/index.ts
@@ -13,6 +13,7 @@
 
 // Imports
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as defaults from '@aws-solutions-constructs/core';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
@@ -73,6 +74,25 @@ export interface LambdaToSnsProps {
    * @default - SNS_TOPIC_NAME
    */
   readonly topicNameEnvironmentVariableName?: string;
+  /**
+   * If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.
+   *
+   * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
+   */
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  /**
+   * An optional, imported encryption key to encrypt the SNS Topic with.
+   *
+   * @default - None
+   */
+  readonly encryptionKey?: kms.Key
+  /**
+   * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS Topic with.
+   *
+   * @default - None
+   */
+  readonly encryptionKeyProps?: kms.KeyProps
 }
 
 /**
@@ -123,7 +143,10 @@ export class LambdaToSns extends Construct {
       // Setup the SNS topic
       [this.snsTopic] = defaults.buildTopic(this, {
         existingTopicObj: props.existingTopicObj,
-        topicProps: props.topicProps
+        topicProps: props.topicProps,
+        enableEncryptionWithCustomerManagedKey: props.enableEncryptionWithCustomerManagedKey,
+        encryptionKey: props.encryptionKey,
+        encryptionKeyProps: props.encryptionKeyProps
       });
 
       // Configure environment variables

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/test/lambda-sns.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/test/lambda-sns.test.ts
@@ -554,3 +554,16 @@ test('Topic is encrypted with customer managed KMS Key when enable encryption fl
     },
   });
 });
+
+test('Error is thrown when conflicting VPC information is provided', () => {
+  const stack = new Stack();
+
+  const app = () => {
+    new LambdaToSns(stack, 'test-construct', {
+      existingVpc: new ec2.Vpc(stack, "test-vpc", {}),
+      deployVpc: true
+    });
+  };
+
+  expect(app).toThrowError('Error - Either provide an existingVpc or some combination of deployVpc and vpcProps, but not both.');
+});

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/README.md
@@ -93,6 +93,9 @@ new LambdaToSqs(this, "test-lambda-sqs-stack", new LambdaToSqsProps.Builder()
 |vpcProps?|[`ec2.VpcProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.VpcProps.html)|Optional user-provided properties to override the default properties for the new VPC. `enableDnsHostnames`, `enableDnsSupport`, `natGateways` and `subnetConfiguration` are set by the pattern, so any values for those properties supplied here will be overrriden. If `deployVpc` is not `true` then this property will be ignored.|
 |deployVpc?|`boolean`|Whether to create a new VPC based on `vpcProps` into which to deploy this pattern. Setting this to true will deploy the minimal, most private VPC to run the pattern:<ul><li> One isolated subnet in each Availability Zone used by the CDK program</li><li>`enableDnsHostnames` and `enableDnsSupport` will both be set to true</li></ul>If this property is `true` then `existingVpc` cannot be specified. Defaults to `false`.|
 |queueEnvironmentVariableName?|`string`|Optional Name for the Lambda function environment variable set to the URL of the queue. Default: SQS_QUEUE_URL |
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/lib/index.ts
@@ -13,6 +13,7 @@
 
 // Imports
 import * as defaults from "@aws-solutions-constructs/core";
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as sqs from "aws-cdk-lib/aws-sqs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
@@ -90,6 +91,25 @@ export interface LambdaToSqsProps {
    * @default - SQS_QUEUE_URL
    */
   readonly queueEnvironmentVariableName?: string;
+  /**
+   * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
+   *
+   * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
+   */
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  /**
+   * An optional, imported encryption key to encrypt the SQS Queue with.
+   *
+   * @default - None
+   */
+  readonly encryptionKey?: kms.Key
+  /**
+   * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
+   *
+   * @default - None
+   */
+  readonly encryptionKeyProps?: kms.KeyProps
 }
 
 /**
@@ -150,7 +170,10 @@ export class LambdaToSqs extends Construct {
       [this.sqsQueue] = defaults.buildQueue(this, 'queue', {
         existingQueueObj: props.existingQueueObj,
         queueProps: props.queueProps,
-        deadLetterQueue: this.deadLetterQueue
+        deadLetterQueue: this.deadLetterQueue,
+        enableEncryptionWithCustomerManagedKey: props.enableEncryptionWithCustomerManagedKey,
+        encryptionKey: props.encryptionKey,
+        encryptionKeyProps: props.encryptionKeyProps
       });
 
       // Configure environment variables

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/lib/index.ts
@@ -97,19 +97,19 @@ export interface LambdaToSqsProps {
    *
    * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
   /**
    * An optional, imported encryption key to encrypt the SQS Queue with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key
+  readonly encryptionKey?: kms.Key;
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
    *
    * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps
+  readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 /**
@@ -134,10 +134,6 @@ export class LambdaToSqs extends Construct {
       defaults.CheckProps(props);
 
       if (props.deployVpc || props.existingVpc) {
-        if (props.deployVpc && props.existingVpc) {
-          throw new Error("More than 1 VPC specified in the properties");
-        }
-
         this.vpc = defaults.buildVpc(scope, {
           defaultVpcProps: defaults.DefaultIsolatedVpcProps(),
           existingVpc: props.existingVpc,

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/README.md
@@ -71,9 +71,9 @@ new S3ToSqs(this, "S3ToSQSPattern", new S3ToSqsProps.Builder()
 |deadLetterQueueProps?|[`sqs.QueueProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html)|Optional user provided props to override the default props for the dead letter SQS queue.|
 |deployDeadLetterQueue?|`boolean`|Whether to create a secondary queue to be used as a dead letter queue. Defaults to true.|
 |maxReceiveCount?|`number`|The number of times a message can be unsuccessfully dequeued before being moved to the dead letter queue. Defaults to 15.|
-|enableEncryptionWithCustomerManagedKey?|`boolean`|Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in the encryptionKey property for this construct.|
-|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|Optional imported encryption key to encrypt the SQS queue.|
-|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.KeyProps.html)|Optional user provided properties to override the default properties for the KMS encryption key.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 |loggingBucketProps?|[`s3.BucketProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.BucketProps.html)|Optional user provided props to override the default props for the S3 Logging Bucket.|
 |logS3AccessLogs?| boolean|Whether to turn on Access Logging for the S3 bucket. Creates an S3 bucket with associated storage costs for the logs. Enabling Access Logging is a best practice. default - true|
 

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/lib/index.ts
@@ -80,22 +80,22 @@ export interface S3ToSqsProps {
      */
     readonly maxReceiveCount?: number
     /**
-     * Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in
-     * the encryptionKey property for this construct.
+     * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+     * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
      *
-     * @default - true (encryption enabled, managed by this CDK app).
+     * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
     readonly enableEncryptionWithCustomerManagedKey?: boolean
     /**
-     * Optional imported encryption key to encrypt the SQS queue.
+     * An optional, imported encryption key to encrypt the SQS Queue with.
      *
-     * @default - not specified.
+     * @default - None
      */
-    readonly encryptionKey?: kms.Key,
+    readonly encryptionKey?: kms.Key
     /**
-     * Optional user provided props to override the default props for the encryption key.
+     * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
      *
-     * @default - Default props are used.
+     * @default - None
      */
     readonly encryptionKeyProps?: kms.KeyProps
     /**
@@ -171,7 +171,8 @@ export class S3ToSqs extends Construct {
         queueProps: props.queueProps,
         deadLetterQueue: this.deadLetterQueue,
         enableEncryptionWithCustomerManagedKey: enableEncryptionParam,
-        encryptionKey: props.encryptionKey
+        encryptionKey: props.encryptionKey,
+        encryptionKeyProps: props.encryptionKeyProps
       });
 
       // Setup the S3 bucket event types

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/lib/index.ts
@@ -30,13 +30,13 @@ export interface S3ToSqsProps {
      *
      * @default - None
      */
-    readonly existingBucketObj?: s3.Bucket,
+    readonly existingBucketObj?: s3.Bucket;
     /**
      * Optional user provided props to override the default props for the S3 Bucket.
      *
      * @default - Default props are used
      */
-    readonly bucketProps?: s3.BucketProps,
+    readonly bucketProps?: s3.BucketProps;
     /**
      * The S3 event types that will trigger the notification.
      *
@@ -48,62 +48,62 @@ export interface S3ToSqsProps {
      *
      * @default - If not specified no filter rules will be applied.
      */
-    readonly s3EventFilters?: s3.NotificationKeyFilter[]
+    readonly s3EventFilters?: s3.NotificationKeyFilter[];
     /**
      * Existing instance of SQS queue object, Providing both this and queueProps will cause an error.
      *
      * @default - Default props are used
      */
-    readonly existingQueueObj?: sqs.Queue,
+    readonly existingQueueObj?: sqs.Queue;
     /**
      * Optional user provided properties
      *
      * @default - Default props are used
      */
-    readonly queueProps?: sqs.QueueProps,
+    readonly queueProps?: sqs.QueueProps;
     /**
      * Optional user provided properties for the dead letter queue
      *
      * @default - Default props are used
      */
-    readonly deadLetterQueueProps?: sqs.QueueProps,
+    readonly deadLetterQueueProps?: sqs.QueueProps;
     /**
      * Whether to deploy a secondary queue to be used as a dead letter queue.
      *
      * @default - true.
      */
-    readonly deployDeadLetterQueue?: boolean,
+    readonly deployDeadLetterQueue?: boolean;
     /**
      * The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue.
      *
      * @default - required field if deployDeadLetterQueue=true.
      */
-    readonly maxReceiveCount?: number
+    readonly maxReceiveCount?: number;
     /**
      * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
      * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
      *
      * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
-    readonly enableEncryptionWithCustomerManagedKey?: boolean
+    readonly enableEncryptionWithCustomerManagedKey?: boolean;
     /**
      * An optional, imported encryption key to encrypt the SQS Queue with.
      *
      * @default - None
      */
-    readonly encryptionKey?: kms.Key
+    readonly encryptionKey?: kms.Key;
     /**
      * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
      *
      * @default - None
      */
-    readonly encryptionKeyProps?: kms.KeyProps
+    readonly encryptionKeyProps?: kms.KeyProps;
     /**
      * Optional user provided props to override the default props for the S3 Logging Bucket.
      *
      * @default - Default props are used
      */
-    readonly loggingBucketProps?: s3.BucketProps
+    readonly loggingBucketProps?: s3.BucketProps;
     /**
      * Whether to turn on Access Logs for the S3 bucket with the associated storage costs.
      * Enabling Access Logging is a best practice.

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/integ.creatingNewQueue.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/integ.creatingNewQueue.expected.json
@@ -28,6 +28,40 @@
                 }
               },
               "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*"
+              ],
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "tests3sqsS3BucketFF76CDA6",
+                      "Arn"
+                    ]
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "s3.amazonaws.com"
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:GenerateDataKey*",
+                "kms:Decrypt"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "s3.amazonaws.com"
+              },
+              "Resource": "*"
             }
           ],
           "Version": "2012-10-17"
@@ -260,82 +294,12 @@
         ]
       }
     },
-    "tests3sqsEncryptionKeyFD4D5946": {
-      "Type": "AWS::KMS::Key",
-      "Properties": {
-        "KeyPolicy": {
-          "Statement": [
-            {
-              "Action": "kms:*",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition"
-                      },
-                      ":iam::",
-                      {
-                        "Ref": "AWS::AccountId"
-                      },
-                      ":root"
-                    ]
-                  ]
-                }
-              },
-              "Resource": "*"
-            },
-            {
-              "Action": [
-                "kms:Decrypt",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*"
-              ],
-              "Condition": {
-                "ArnLike": {
-                  "aws:SourceArn": {
-                    "Fn::GetAtt": [
-                      "tests3sqsS3BucketFF76CDA6",
-                      "Arn"
-                    ]
-                  }
-                }
-              },
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "s3.amazonaws.com"
-              },
-              "Resource": "*"
-            },
-            {
-              "Action": [
-                "kms:GenerateDataKey*",
-                "kms:Decrypt"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "s3.amazonaws.com"
-              },
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "EnableKeyRotation": true
-      },
-      "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain"
-    },
     "tests3sqsqueue810CCE19": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
         "KmsMasterKeyId": {
           "Fn::GetAtt": [
-            "tests3sqsEncryptionKeyFD4D5946",
+            "ImportedEncryptionKeyBE10B2FC",
             "Arn"
           ]
         },

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/README.md
@@ -83,6 +83,9 @@ new SnsToLambda(this, "test-lambda-sqs-stack", new SnsToLambdaProps.Builder()
 |lambdaFunctionProps?|[`lambda.FunctionProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.FunctionProps.html)|User provided props to override the default props for the Lambda function.|
 |existingTopicObj?|[`sns.Topic`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Function.html)|Existing instance of SNS Topic object, providing both this and `topicProps` will cause an error.|
 |topicProps?|[`sns.TopicProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.TopicProps.html)|Optional user provided properties to override the default properties for the SNS topic.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SNS Topic with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS Topic with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/lib/index.ts
@@ -28,44 +28,44 @@ export interface SnsToLambdaProps {
    *
    * @default - None
    */
-  readonly existingLambdaObj?: lambda.Function,
+  readonly existingLambdaObj?: lambda.Function;
   /**
    * User provided props to override the default props for the Lambda function.
    *
    * @default - Default properties are used.
    */
-  readonly lambdaFunctionProps?: lambda.FunctionProps,
+  readonly lambdaFunctionProps?: lambda.FunctionProps;
   /**
    * Existing instance of SNS Topic object, providing both this and topicProps will cause an error..
    *
    * @default - Default props are used
    */
-  readonly existingTopicObj?: sns.Topic,
+  readonly existingTopicObj?: sns.Topic;
   /**
    * Optional user provided properties to override the default properties for the SNS topic.
    *
    * @default - Default properties are used.
    */
-  readonly topicProps?: sns.TopicProps
+  readonly topicProps?: sns.TopicProps;
   /**
    * If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key.
    * This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.
    *
    * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
    */
-  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  readonly enableEncryptionWithCustomerManagedKey?: boolean;
   /**
    * An optional, imported encryption key to encrypt the SNS Topic with.
    *
    * @default - None
    */
-  readonly encryptionKey?: kms.Key
+  readonly encryptionKey?: kms.Key;
   /**
    * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SNS Topic with.
    *
    * @default - None
    */
-  readonly encryptionKeyProps?: kms.KeyProps
+  readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 /**

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/lib/index.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as defaults from '@aws-solutions-constructs/core';
@@ -46,6 +47,25 @@ export interface SnsToLambdaProps {
    * @default - Default properties are used.
    */
   readonly topicProps?: sns.TopicProps
+  /**
+   * If no key is provided, this flag determines whether the SNS Topic is encrypted with a new CMK or an AWS managed key.
+   * This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.
+   *
+   * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
+   */
+  readonly enableEncryptionWithCustomerManagedKey?: boolean
+  /**
+   * An optional, imported encryption key to encrypt the SNS Topic with.
+   *
+   * @default - None
+   */
+  readonly encryptionKey?: kms.Key
+  /**
+   * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SNS Topic with.
+   *
+   * @default - None
+   */
+  readonly encryptionKeyProps?: kms.KeyProps
 }
 
 /**
@@ -76,7 +96,10 @@ export class SnsToLambda extends Construct {
     // Setup the SNS topic
     [this.snsTopic] = defaults.buildTopic(this, {
       existingTopicObj: props.existingTopicObj,
-      topicProps: props.topicProps
+      topicProps: props.topicProps,
+      enableEncryptionWithCustomerManagedKey: props.enableEncryptionWithCustomerManagedKey,
+      encryptionKey: props.encryptionKey,
+      encryptionKeyProps: props.encryptionKeyProps
     });
 
     this.lambdaFunction.addEventSource(new SnsEventSource(this.snsTopic));

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/sns-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/sns-lambda.test.ts
@@ -13,6 +13,7 @@
 
 import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
 import { SnsToLambda, SnsToLambdaProps } from "../lib";
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as cdk from "aws-cdk-lib";
@@ -81,4 +82,151 @@ test('provide existingTopicObj', () => {
   expectCDK(stack).to(haveResource("AWS::SNS::Topic", {
     TopicName: "custom-topic"
   }));
+});
+
+test('Topic is encrypted with imported CMK when set on encryptionKey prop', () => {
+  const stack = new cdk.Stack();
+  const cmk = new kms.Key(stack, 'cmk');
+  const props: SnsToLambdaProps = {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler'
+    },
+    encryptionKey: cmk
+  };
+
+  new SnsToLambda(stack, 'test-sns-lambda', props);
+
+  expect(stack).toHaveResource("AWS::SNS::Topic", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "cmk01DE03DA",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('Topic is encrypted with imported CMK when set on topicProps.masterKey prop', () => {
+  const stack = new cdk.Stack();
+  const cmk = new kms.Key(stack, 'cmk');
+  const props: SnsToLambdaProps = {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler'
+    },
+    topicProps: {
+      masterKey: cmk
+    }
+  };
+
+  new SnsToLambda(stack, 'test-sns-lambda', props);
+
+  expect(stack).toHaveResource("AWS::SNS::Topic", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "cmk01DE03DA",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('Topic is encrypted with provided encrytionKeyProps', () => {
+  const stack = new cdk.Stack();
+
+  const props: SnsToLambdaProps = {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler'
+    },
+    encryptionKeyProps: {
+      alias: 'new-key-alias-from-props'
+    }
+  };
+
+  new SnsToLambda(stack, 'test-sns-lambda', props);
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      'Fn::GetAtt': [
+        'testsnslambdaEncryptionKeyDDDF040B',
+        'Arn'
+      ]
+    },
+  });
+
+  expect(stack).toHaveResource('AWS::KMS::Alias', {
+    AliasName: 'alias/new-key-alias-from-props',
+    TargetKeyId: {
+      'Fn::GetAtt': [
+        'testsnslambdaEncryptionKeyDDDF040B',
+        'Arn'
+      ]
+    }
+  });
+});
+
+test('Topic is encrypted by default with AWS-managed KMS key when no other encryption properties are set', () => {
+  const stack = new cdk.Stack();
+
+  const props: SnsToLambdaProps = {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler'
+    },
+  };
+
+  new SnsToLambda(stack, 'test-sns-lambda', props);
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      "Fn::Join": [
+        "",
+        [
+          "arn:",
+          {
+            Ref: "AWS::Partition"
+          },
+          ":kms:",
+          {
+            Ref: "AWS::Region"
+          },
+          ":",
+          {
+            Ref: "AWS::AccountId"
+          },
+          ":alias/aws/sns"
+        ]
+      ]
+    }
+  });
+});
+
+test('Topic is encrypted with customer managed KMS Key when enable encryption flag is true', () => {
+  const stack = new cdk.Stack();
+
+  const props: SnsToLambdaProps = {
+    lambdaFunctionProps: {
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler'
+    },
+    enableEncryptionWithCustomerManagedKey: true
+  };
+
+  new SnsToLambda(stack, 'test-sns-lambda', props);
+
+  expect(stack).toHaveResource('AWS::SNS::Topic', {
+    KmsMasterKeyId: {
+      'Fn::GetAtt': [
+        'testsnslambdaEncryptionKeyDDDF040B',
+        'Arn'
+      ]
+    },
+  });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/README.md
@@ -104,9 +104,9 @@ constructStack.getEncryptionKey().addToResourcePolicy(policyStatement);
 |deployDeadLetterQueue?|`boolean`|Whether to create a secondary queue to be used as a dead letter queue. Defaults to true.|
 |deadLetterQueueProps?|[`sqs.QueueProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html)|Optional user-provided props to override the default props for the dead letter SQS queue.|
 |maxReceiveCount?|`number`|The number of times a message can be unsuccessfully dequeued before being moved to the dead letter queue. Defaults to 15.|
-|enableEncryptionWithCustomerManagedKey?|`boolean`|Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in the encryptionKey property for this construct.|
-|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS queue, and SNS Topic.|
-|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.KeyProps.html)|An optional, user provided properties to override the default properties for the KMS encryption key.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: topicProps.masterKey, queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue and SNS Topic with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 |sqsSubscriptionProps?|[`subscriptions.SqsSubscriptionProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns_subscriptions.SqsSubscriptionProps.html)|Optional user-provided props to override the default props for sqsSubscriptionProps.|
 
 ## Pattern Properties

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/lib/index.ts
@@ -31,43 +31,43 @@ export interface SnsToSqsProps {
      *
      * @default - Default props are used
      */
-    readonly existingTopicObj?: sns.Topic,
+    readonly existingTopicObj?: sns.Topic;
     /**
      * Optional user provided properties to override the default properties for the SNS topic.
      *
      * @default - Default properties are used.
      */
-    readonly topicProps?: sns.TopicProps,
+    readonly topicProps?: sns.TopicProps;
     /**
      * Existing instance of SQS queue object, Providing both this and queueProps will cause an error.
      *
      * @default - Default props are used
      */
-    readonly existingQueueObj?: sqs.Queue,
+    readonly existingQueueObj?: sqs.Queue;
     /**
      * Optional user provided properties
      *
      * @default - Default props are used
      */
-    readonly queueProps?: sqs.QueueProps,
+    readonly queueProps?: sqs.QueueProps;
     /**
      * Optional user provided properties for the dead letter queue
      *
      * @default - Default props are used
      */
-    readonly deadLetterQueueProps?: sqs.QueueProps,
+    readonly deadLetterQueueProps?: sqs.QueueProps;
     /**
      * Whether to deploy a secondary queue to be used as a dead letter queue.
      *
      * @default - true.
      */
-    readonly deployDeadLetterQueue?: boolean,
+    readonly deployDeadLetterQueue?: boolean;
     /**
      * The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue.
      *
      * @default - required field if deployDeadLetterQueue=true.
      */
-    readonly maxReceiveCount?: number
+    readonly maxReceiveCount?: number;
     /**
      * If no keys are provided, this flag determines whether both the topic and queue are encrypted with a new CMK or an AWS managed key.
      * This flag is ignored if any of the following are defined:
@@ -75,25 +75,25 @@ export interface SnsToSqsProps {
      *
      * @default - True if topicProps.masterKey, queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
-    readonly enableEncryptionWithCustomerManagedKey?: boolean
+    readonly enableEncryptionWithCustomerManagedKey?: boolean;
     /**
      * An optional, imported encryption key to encrypt the SQS Queue and SNS Topic with.
      *
      * @default - None
      */
-    readonly encryptionKey?: kms.Key
+    readonly encryptionKey?: kms.Key;
     /**
      * Optional user-provided props to override the default props for the encryption key.
      *
      * @default - None
      */
-    readonly encryptionKeyProps?: kms.KeyProps
+    readonly encryptionKeyProps?: kms.KeyProps;
     /**
      * Optional user-provided props to override the default props for sqsSubscriptionProps.
      *
      * @default - Default props are used.
      */
-    readonly sqsSubscriptionProps?: subscriptions.SqsSubscriptionProps
+    readonly sqsSubscriptionProps?: subscriptions.SqsSubscriptionProps;
 }
 
 /**

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/lib/index.ts
@@ -69,22 +69,23 @@ export interface SnsToSqsProps {
      */
     readonly maxReceiveCount?: number
     /**
-     * Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in
-     * the encryptionKey property for this construct.
+     * If no keys are provided, this flag determines whether both the topic and queue are encrypted with a new CMK or an AWS managed key.
+     * This flag is ignored if any of the following are defined:
+     * topicProps.masterKey, queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
      *
-     * @default - true (encryption enabled, managed by this CDK app).
+     * @default - True if topicProps.masterKey, queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
     readonly enableEncryptionWithCustomerManagedKey?: boolean
     /**
-     * An optional, imported encryption key to encrypt the SQS queue, and SNS Topic.
+     * An optional, imported encryption key to encrypt the SQS Queue and SNS Topic with.
      *
-     * @default - not specified.
+     * @default - None
      */
     readonly encryptionKey?: kms.Key
     /**
      * Optional user-provided props to override the default props for the encryption key.
      *
-     * @default - Default props are used.
+     * @default - None
      */
     readonly encryptionKeyProps?: kms.KeyProps
     /**
@@ -92,7 +93,7 @@ export interface SnsToSqsProps {
      *
      * @default - Default props are used.
      */
-     readonly sqsSubscriptionProps?: subscriptions.SqsSubscriptionProps
+    readonly sqsSubscriptionProps?: subscriptions.SqsSubscriptionProps
 }
 
 /**

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/integ.sns-existing-kms-key.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/integ.sns-existing-kms-key.expected.json
@@ -1,0 +1,438 @@
+{
+  "Description": "Integration Test for aws-sns-sqs with customer managed KMS key",
+  "Resources": {
+    "ImportedSNSEncryptionKeyF83F9D6C": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "EnableKeyRotation": true
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "ImportedSQSEncryptionKey29533C9A": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "sns.amazonaws.com"
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "sns.amazonaws.com"
+              },
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "EnableKeyRotation": true
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "testsnssqsdeadLetterQueue8DACC0A1": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "KmsMasterKeyId": "alias/aws/sqs"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testsnssqsdeadLetterQueuePolicyAB8A9883": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:ReceiveMessage",
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:RemovePermission",
+                "sqs:AddPermission",
+                "sqs:SetQueueAttributes"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testsnssqsdeadLetterQueue8DACC0A1",
+                  "Arn"
+                ]
+              },
+              "Sid": "QueueOwnerOnlyAccess"
+            },
+            {
+              "Action": "SQS:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testsnssqsdeadLetterQueue8DACC0A1",
+                  "Arn"
+                ]
+              },
+              "Sid": "HttpsOnly"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "testsnssqsdeadLetterQueue8DACC0A1"
+          }
+        ]
+      }
+    },
+    "testsnssqsSnsTopic2CD0065B": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "KmsMasterKeyId": {
+          "Fn::GetAtt": [
+            "ImportedSNSEncryptionKeyF83F9D6C",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "testsnssqsSnsTopicPolicy604079F2": {
+      "Type": "AWS::SNS::TopicPolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "SNS:Publish",
+                "SNS:RemovePermission",
+                "SNS:SetTopicAttributes",
+                "SNS:DeleteTopic",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:GetTopicAttributes",
+                "SNS:Receive",
+                "SNS:AddPermission",
+                "SNS:Subscribe"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "AWS:SourceOwner": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": {
+                "Ref": "testsnssqsSnsTopic2CD0065B"
+              },
+              "Sid": "TopicOwnerOnlyAccess"
+            },
+            {
+              "Action": [
+                "SNS:Publish",
+                "SNS:RemovePermission",
+                "SNS:SetTopicAttributes",
+                "SNS:DeleteTopic",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:GetTopicAttributes",
+                "SNS:Receive",
+                "SNS:AddPermission",
+                "SNS:Subscribe"
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Ref": "testsnssqsSnsTopic2CD0065B"
+              },
+              "Sid": "HttpsOnly"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Topics": [
+          {
+            "Ref": "testsnssqsSnsTopic2CD0065B"
+          }
+        ]
+      }
+    },
+    "testsnssqsqueueB02504BF": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "KmsMasterKeyId": {
+          "Fn::GetAtt": [
+            "ImportedSQSEncryptionKey29533C9A",
+            "Arn"
+          ]
+        },
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "testsnssqsdeadLetterQueue8DACC0A1",
+              "Arn"
+            ]
+          },
+          "maxReceiveCount": 15
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testsnssqsqueuePolicyE64464B6": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:ReceiveMessage",
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:RemovePermission",
+                "sqs:AddPermission",
+                "sqs:SetQueueAttributes"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testsnssqsqueueB02504BF",
+                  "Arn"
+                ]
+              },
+              "Sid": "QueueOwnerOnlyAccess"
+            },
+            {
+              "Action": "SQS:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testsnssqsqueueB02504BF",
+                  "Arn"
+                ]
+              },
+              "Sid": "HttpsOnly"
+            },
+            {
+              "Action": "sqs:SendMessage",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "testsnssqsSnsTopic2CD0065B"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "sns.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testsnssqsqueueB02504BF",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "testsnssqsqueueB02504BF"
+          }
+        ]
+      }
+    },
+    "testsnssqsqueuesnsexistingkmskeytestsnssqsSnsTopic7F8632A2DD832F81": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "testsnssqsSnsTopic2CD0065B"
+        },
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "testsnssqsqueueB02504BF",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "testsnssqsqueuePolicyE64464B6"
+      ]
+    }
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+    }
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                  ],
+                  {
+                    "Ref": "BootstrapVersion"
+                  }
+                ]
+              }
+            ]
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+        }
+      ]
+    }
+  }
+}

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/integ.sns-existing-kms-key.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/integ.sns-existing-kms-key.ts
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+// Imports
+import { App, Stack } from "aws-cdk-lib";
+import { SnsToSqs, SnsToSqsProps } from "../lib";
+import { KeyProps } from 'aws-cdk-lib/aws-kms';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import { generateIntegStackName } from '@aws-solutions-constructs/core';
+
+// Setup
+const app = new App();
+const stack = new Stack(app, generateIntegStackName(__filename));
+stack.templateOptions.description = 'Integration Test for aws-sns-sqs with customer managed KMS key';
+
+// Definitions
+
+// Create a customer managed KMS CMK to encrypt the SNS Topic
+const snsEncryptionKeyProps: KeyProps = {
+  enableKeyRotation: true
+};
+const snsEncryptionKey = new kms.Key(stack, 'ImportedSNSEncryptionKey', snsEncryptionKeyProps);
+
+// Create customer managed KMS CMK to encrypt the SQS Queue
+const sqsEncryptionKeyProps: KeyProps = {
+  enableKeyRotation: true
+};
+const sqsEncryptionKey = new kms.Key(stack, 'ImportedSQSEncryptionKey', sqsEncryptionKeyProps);
+
+// Create the SNS to SQS construct
+const props: SnsToSqsProps = {
+  topicProps: {
+    masterKey: snsEncryptionKey
+  },
+  queueProps: {
+    encryptionMasterKey: sqsEncryptionKey
+  },
+  enableEncryptionWithCustomerManagedKey: false
+};
+
+new SnsToSqs(stack, 'test-sns-sqs', props);
+
+// Synth
+app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/README.md
@@ -89,6 +89,9 @@ new SqsToLambda(this, "SnsToSqsPattern", new SqsToLambdaProps.Builder()
 |deployDeadLetterQueue?|`boolean`|Whether to create a secondary queue to be used as a dead letter queue. Defaults to true.|
 |maxReceiveCount?|`number`|The number of times a message can be unsuccessfully dequeued before being moved to the dead letter queue. Defaults to 15.|
 |sqsEventSourceProps?| [`SqsEventSourceProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_event_sources.SqsEventSourceProps.html)|Optional user provided properties for the queue event source.|
+|enableEncryptionWithCustomerManagedKey?|`boolean`|If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key. This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.|
+|encryptionKey?|[`kms.Key`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html)|An optional, imported encryption key to encrypt the SQS Queue with.|
+|encryptionKeyProps?|[`kms.KeyProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html#construct-props)|Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS queue with.|
 
 ## Pattern Properties
 

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/lib/index.ts
@@ -12,6 +12,7 @@
  */
 
 // Imports
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as defaults from '@aws-solutions-constructs/core';
@@ -71,6 +72,25 @@ export interface SqsToLambdaProps {
      * @default - Default props are used
      */
     readonly sqsEventSourceProps?: SqsEventSourceProps
+    /**
+     * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+     * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
+     *
+     * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
+     */
+    readonly enableEncryptionWithCustomerManagedKey?: boolean
+    /**
+     * An optional, imported encryption key to encrypt the SQS queue with.
+     *
+     * @default - None
+     */
+    readonly encryptionKey?: kms.Key
+    /**
+     * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SQS queue with.
+     *
+     * @default - None
+     */
+    readonly encryptionKeyProps?: kms.KeyProps
 }
 
 /**
@@ -111,7 +131,10 @@ export class SqsToLambda extends Construct {
       [this.sqsQueue] = defaults.buildQueue(this, 'queue', {
         existingQueueObj: props.existingQueueObj,
         queueProps: props.queueProps,
-        deadLetterQueue: this.deadLetterQueue
+        deadLetterQueue: this.deadLetterQueue,
+        enableEncryptionWithCustomerManagedKey: props.enableEncryptionWithCustomerManagedKey,
+        encryptionKey: props.encryptionKey,
+        encryptionKeyProps: props.encryptionKeyProps
       });
 
       // Setup the event source mapping

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/lib/index.ts
@@ -29,68 +29,68 @@ export interface SqsToLambdaProps {
      *
      * @default - None
      */
-    readonly existingLambdaObj?: lambda.Function,
+    readonly existingLambdaObj?: lambda.Function;
     /**
      * User provided props to override the default props for the Lambda function.
      *
      * @default - Default properties are used.
      */
-    readonly lambdaFunctionProps?: lambda.FunctionProps,
+    readonly lambdaFunctionProps?: lambda.FunctionProps;
     /**
      * Existing instance of SQS queue object, Providing both this and queueProps will cause an error.
      *
      * @default - Default props are used
      */
-    readonly existingQueueObj?: sqs.Queue,
+    readonly existingQueueObj?: sqs.Queue;
     /**
      * Optional user provided properties
      *
      * @default - Default props are used
      */
-    readonly queueProps?: sqs.QueueProps,
+    readonly queueProps?: sqs.QueueProps;
     /**
      * Optional user provided properties for the dead letter queue.
      *
      * @default - Default props are used
      */
-    readonly deadLetterQueueProps?: sqs.QueueProps,
+    readonly deadLetterQueueProps?: sqs.QueueProps;
     /**
      * Whether to deploy a secondary queue to be used as a dead letter queue.
      *
      * @default - true.
      */
-    readonly deployDeadLetterQueue?: boolean,
+    readonly deployDeadLetterQueue?: boolean;
     /**
      * The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue.
      *
      * @default - required field if deployDeadLetterQueue=true.
      */
-    readonly maxReceiveCount?: number,
+    readonly maxReceiveCount?: number;
     /**
      * Optional user provided properties for the queue event source.
      *
      * @default - Default props are used
      */
-    readonly sqsEventSourceProps?: SqsEventSourceProps
+    readonly sqsEventSourceProps?: SqsEventSourceProps;
     /**
      * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
      * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
      *
      * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
-    readonly enableEncryptionWithCustomerManagedKey?: boolean
+    readonly enableEncryptionWithCustomerManagedKey?: boolean;
     /**
      * An optional, imported encryption key to encrypt the SQS queue with.
      *
      * @default - None
      */
-    readonly encryptionKey?: kms.Key
+    readonly encryptionKey?: kms.Key;
     /**
      * Optional user provided properties to override the default properties for the KMS encryption key used to  encrypt the SQS queue with.
      *
      * @default - None
      */
-    readonly encryptionKeyProps?: kms.KeyProps
+    readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 /**

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/test/test.sqs-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/test/test.sqs-lambda.test.ts
@@ -16,6 +16,7 @@ import { Stack } from "aws-cdk-lib";
 import { SqsToLambda, SqsToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import '@aws-cdk/assert/jest';
+import * as kms from 'aws-cdk-lib/aws-kms';
 
 // --------------------------------------------------------------
 // Pattern deployment w/ new Lambda function and
@@ -133,5 +134,140 @@ test('Pattern deployment w/ batch size', () => {
 
   expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
     BatchSize: 5
+  });
+});
+
+test('Queue is encrypted with imported CMK when set on encryptionKey prop', () => {
+  const stack = new Stack();
+
+  const cmk = new kms.Key(stack, 'cmk');
+  new SqsToLambda(stack, 'test-construct', {
+    lambdaFunctionProps: {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      environment: {
+        LAMBDA_NAME: 'deployed-function'
+      }
+    },
+    encryptionKey: cmk
+  });
+
+  expect(stack).toHaveResource("AWS::SQS::Queue", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "cmk01DE03DA",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('Queue is encrypted with imported CMK when set on queueProps.encryptionMasterKey prop', () => {
+  const stack = new Stack();
+
+  const cmk = new kms.Key(stack, 'cmk');
+  new SqsToLambda(stack, 'test-construct', {
+    lambdaFunctionProps: {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      environment: {
+        LAMBDA_NAME: 'deployed-function'
+      }
+    },
+    queueProps: {
+      encryptionMasterKey: cmk
+    }
+  });
+
+  expect(stack).toHaveResource("AWS::SQS::Queue", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "cmk01DE03DA",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('Queue is encrypted with provided encrytionKeyProps', () => {
+  const stack = new Stack();
+
+  new SqsToLambda(stack, 'test-construct', {
+    lambdaFunctionProps: {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      environment: {
+        LAMBDA_NAME: 'deployed-function'
+      }
+    },
+    encryptionKeyProps: {
+      alias: 'new-key-alias-from-props'
+    }
+  });
+
+  expect(stack).toHaveResource('AWS::SQS::Queue', {
+    KmsMasterKeyId: {
+      'Fn::GetAtt': [
+        'testconstructEncryptionKey6153B053',
+        'Arn'
+      ]
+    },
+  });
+
+  expect(stack).toHaveResource('AWS::KMS::Alias', {
+    AliasName: 'alias/new-key-alias-from-props',
+    TargetKeyId: {
+      'Fn::GetAtt': [
+        'testconstructEncryptionKey6153B053',
+        'Arn'
+      ]
+    }
+  });
+});
+
+test('Queue is encrypted by default with SQS-managed KMS key when no other encryption properties are set', () => {
+  const stack = new Stack();
+
+  new SqsToLambda(stack, 'test-construct', {
+    lambdaFunctionProps: {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      environment: {
+        LAMBDA_NAME: 'deployed-function'
+      }
+    },
+  });
+
+  expect(stack).toHaveResource('AWS::SQS::Queue', {
+    KmsMasterKeyId: "alias/aws/sqs"
+  });
+});
+
+test('Queue is encrypted with customer managed KMS Key when enable encryption flag is true', () => {
+  const stack = new Stack();
+
+  new SqsToLambda(stack, 'test-construct', {
+    lambdaFunctionProps: {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      environment: {
+        LAMBDA_NAME: 'deployed-function'
+      }
+    },
+    enableEncryptionWithCustomerManagedKey: true
+  });
+
+  expect(stack).toHaveResource('AWS::SQS::Queue', {
+    KmsMasterKeyId: {
+      'Fn::GetAtt': [
+        'testconstructEncryptionKey6153B053',
+        'Arn'
+      ]
+    },
   });
 });

--- a/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
@@ -115,6 +115,16 @@ export function CheckProps(propsObject: VerifiedProps | any) {
     errorFound = true;
   }
 
+  if (propsObject.queueProps?.encryptionMasterKey && propsObject.encryptionKey) {
+    errorMessages += 'Error - Either provide queueProps.encryptionMasterKey or encryptionKey, but not both.\n';
+    errorFound = true;
+  }
+
+  if (propsObject.queueProps?.encryptionMasterKey && propsObject.encryptionKeyProps) {
+    errorMessages += 'Error - Either provide queueProps.encryptionMasterKey or encryptionKeyProps, but not both.\n';
+    errorFound = true;
+  }
+
   if ((propsObject?.deployDeadLetterQueue === false) && propsObject.deadLetterQueueProps) {
     errorMessages += 'Error - If deployDeadLetterQueue is false then deadLetterQueueProps cannot be specified.\n';
     errorFound = true;
@@ -145,8 +155,18 @@ export function CheckProps(propsObject: VerifiedProps | any) {
     errorFound = true;
   }
 
-  if ((propsObject.topicProps) && propsObject.existingTopicObj) {
+  if (propsObject.topicProps && propsObject.existingTopicObj) {
     errorMessages += 'Error - Either provide topicProps or existingTopicObj, but not both.\n';
+    errorFound = true;
+  }
+
+  if (propsObject.topicProps?.masterKey && propsObject.encryptionKey) {
+    errorMessages += 'Error - Either provide topicProps.masterKey or encryptionKey, but not both.\n';
+    errorFound = true;
+  }
+
+  if (propsObject.topicProps?.masterKey && propsObject.encryptionKeyProps) {
+    errorMessages += 'Error - Either provide topicProps.masterKey or encryptionKeyProps, but not both.\n';
     errorFound = true;
   }
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
@@ -16,7 +16,7 @@ import * as sns from 'aws-cdk-lib/aws-sns';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { DefaultSnsTopicProps } from './sns-defaults';
 import { buildEncryptionKey } from './kms-helper';
-import { consolidateProps } from './utils';
+import { consolidateProps, printWarning } from './utils';
 import { PolicyStatement, AnyPrincipal, Effect, AccountPrincipal } from 'aws-cdk-lib/aws-iam';
 import { Stack } from 'aws-cdk-lib';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
@@ -36,22 +36,22 @@ export interface BuildTopicProps {
      */
     readonly topicProps?: sns.TopicProps
     /**
-     * Use a Customer Managed KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in
-     * the encryptionKey property for this construct.
+     * If no key is provided, this flag determines whether the topic is encrypted with a new CMK or an AWS managed key.
+     * This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.
      *
-     * @default - false (encryption enabled with AWS Managed KMS Key).
+     * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
     readonly enableEncryptionWithCustomerManagedKey?: boolean
     /**
      * An optional, imported encryption key to encrypt the SNS topic with.
      *
-     * @default - not specified.
+     * @default - None
      */
-    readonly encryptionKey?: kms.Key,
+    readonly encryptionKey?: kms.Key
     /**
-     * Optional user-provided props to override the default props for the encryption key.
+     * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS topic with.
      *
-     * @default - Ignored if encryptionKey is provided
+     * @default - None
      */
     readonly encryptionKeyProps?: kms.KeyProps
 }
@@ -122,20 +122,21 @@ export function buildTopic(scope: Construct, props: BuildTopicProps): [sns.Topic
     // Setup the topic properties
     const snsTopicProps = consolidateProps(DefaultSnsTopicProps, props.topicProps);
 
-    // Set encryption properties
-    if (props.enableEncryptionWithCustomerManagedKey === undefined || props.enableEncryptionWithCustomerManagedKey === false) {
-      // Retrieve SNS managed key to encrypt the SNS Topic
-      const awsManagedKey = kms.Alias.fromAliasName(scope, 'aws-managed-key', 'alias/aws/sns');
-      snsTopicProps.masterKey = awsManagedKey;
-    } else {
-      // Use the imported Customer Managed KMS key
-      if (props.encryptionKey) {
-        snsTopicProps.masterKey = props.encryptionKey;
-      } else {
-        // Create a new Customer Managed KMS key
-        snsTopicProps.masterKey = buildEncryptionKey(scope, props.encryptionKeyProps);
-      }
+    if ((props.topicProps?.masterKey || props.encryptionKey || props.encryptionKeyProps) && props.enableEncryptionWithCustomerManagedKey === true) {
+      printWarning("Ignoring enableEncryptionWithCustomerManagedKey because one of topicProps.masterKey, encryptionKey, or encryptionKeyProps was already specified");
     }
+
+    // Set encryption properties
+    if (props.topicProps?.masterKey) {
+      snsTopicProps.masterKey = props.topicProps?.masterKey;
+    } else if (props.encryptionKey) {
+      snsTopicProps.masterKey = props.encryptionKey;
+    } else if (props.encryptionKeyProps || props.enableEncryptionWithCustomerManagedKey === true) {
+      snsTopicProps.masterKey = buildEncryptionKey(scope, props.encryptionKeyProps);
+    } else {
+      snsTopicProps.masterKey = kms.Alias.fromAliasName(scope, 'aws-managed-key', 'alias/aws/sns');
+    }
+
     // Create the SNS Topic
     const topic: sns.Topic = new sns.Topic(scope, 'SnsTopic', snsTopicProps);
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
@@ -28,32 +28,32 @@ export interface BuildTopicProps {
      *
      * @default - None.
      */
-    readonly existingTopicObj?: sns.Topic,
+    readonly existingTopicObj?: sns.Topic;
     /**
      * Optional user provided props to override the default props for the SNS topic.
      *
      * @default - Default props are used.
      */
-    readonly topicProps?: sns.TopicProps
+    readonly topicProps?: sns.TopicProps;
     /**
      * If no key is provided, this flag determines whether the topic is encrypted with a new CMK or an AWS managed key.
      * This flag is ignored if any of the following are defined: topicProps.masterKey, encryptionKey or encryptionKeyProps.
      *
      * @default - False if topicProps.masterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
-    readonly enableEncryptionWithCustomerManagedKey?: boolean
+    readonly enableEncryptionWithCustomerManagedKey?: boolean;
     /**
      * An optional, imported encryption key to encrypt the SNS topic with.
      *
      * @default - None
      */
-    readonly encryptionKey?: kms.Key
+    readonly encryptionKey?: kms.Key;
     /**
      * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SNS topic with.
      *
      * @default - None
      */
-    readonly encryptionKeyProps?: kms.KeyProps
+    readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 function applySecureTopicPolicy(topic: sns.Topic): void {

--- a/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
@@ -28,38 +28,38 @@ export interface BuildQueueProps {
      *
      * @default - None.
      */
-    readonly existingQueueObj?: sqs.Queue,
+    readonly existingQueueObj?: sqs.Queue;
     /**
      * Optional user provided props to override the default props for the primary queue.
      *
      * @default - Default props are used.
      */
-    readonly queueProps?: sqs.QueueProps
+    readonly queueProps?: sqs.QueueProps;
     /**
      * Optional dead letter queue to pass bad requests to after the max receive count is reached.
      *
      * @default - Default props are used.
      */
-    readonly deadLetterQueue?: sqs.DeadLetterQueue
+    readonly deadLetterQueue?: sqs.DeadLetterQueue;
     /**
      * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
      * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
      *
      * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
-    readonly enableEncryptionWithCustomerManagedKey?: boolean
+    readonly enableEncryptionWithCustomerManagedKey?: boolean;
     /**
      * An optional, imported encryption key to encrypt the SQS Queue with.
      *
      * @default - None
      */
-    readonly encryptionKey?: kms.Key
+    readonly encryptionKey?: kms.Key;
     /**
      * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
      *
      * @default - None
      */
-     readonly encryptionKeyProps?: kms.KeyProps
+     readonly encryptionKeyProps?: kms.KeyProps;
 }
 
 export function buildQueue(scope: Construct, id: string, props: BuildQueueProps): [sqs.Queue, kms.IKey?] {

--- a/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
@@ -15,7 +15,7 @@
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as defaults from './sqs-defaults';
 import * as kms from 'aws-cdk-lib/aws-kms';
-import { overrideProps } from './utils';
+import { overrideProps, printWarning } from './utils';
 import { AccountPrincipal, Effect, PolicyStatement, AnyPrincipal } from 'aws-cdk-lib/aws-iam';
 import { Stack } from 'aws-cdk-lib';
 import {buildEncryptionKey} from "./kms-helper";
@@ -42,27 +42,34 @@ export interface BuildQueueProps {
      */
     readonly deadLetterQueue?: sqs.DeadLetterQueue
     /**
-     * Use a KMS Key, either managed by this CDK app, or imported. If importing an encryption key, it must be specified in
-     * the encryptionKey property for this construct.
+     * If no key is provided, this flag determines whether the queue is encrypted with a new CMK or an AWS managed key.
+     * This flag is ignored if any of the following are defined: queueProps.encryptionMasterKey, encryptionKey or encryptionKeyProps.
      *
-     * @default - false (encryption enabled with AWS Managed KMS Key).
+     * @default - False if queueProps.encryptionMasterKey, encryptionKey, and encryptionKeyProps are all undefined.
      */
     readonly enableEncryptionWithCustomerManagedKey?: boolean
     /**
-     * An optional, imported encryption key to encrypt the SQS queue with.
+     * An optional, imported encryption key to encrypt the SQS Queue with.
      *
-     * @default - not specified.
+     * @default - None
      */
-    readonly encryptionKey?: kms.Key,
+    readonly encryptionKey?: kms.Key
     /**
-     * Optional user-provided props to override the default props for the encryption key.
+     * Optional user provided properties to override the default properties for the KMS encryption key used to encrypt the SQS Queue with.
      *
-     * @default - Ignored if encryptionKey is provided
+     * @default - None
      */
-    readonly encryptionKeyProps?: kms.KeyProps
+     readonly encryptionKeyProps?: kms.KeyProps
 }
 
 export function buildQueue(scope: Construct, id: string, props: BuildQueueProps): [sqs.Queue, kms.IKey?] {
+
+  if ((props.queueProps?.encryptionMasterKey || props.encryptionKey || props.encryptionKeyProps)
+  && props.enableEncryptionWithCustomerManagedKey === true) {
+    printWarning(`Ignoring enableEncryptionWithCustomerManagedKey because one of
+     queueProps.encryptionMasterKey, encryptionKey, or encryptionKeyProps was already specified`);
+  }
+
   // If an existingQueueObj is not specified
   if (!props.existingQueueObj) {
     // Setup the queue
@@ -81,15 +88,16 @@ export function buildQueue(scope: Construct, id: string, props: BuildQueueProps)
       queueProps.deadLetterQueue = props.deadLetterQueue;
     }
 
-    // Set encryption properties
-    if (props.enableEncryptionWithCustomerManagedKey) {
-      // Use the imported Customer Managed KMS key
-      if (props.encryptionKey) {
-        queueProps.encryptionMasterKey = props.encryptionKey;
-      } else {
-        queueProps.encryptionMasterKey = buildEncryptionKey(scope, props.encryptionKeyProps);
-      }
+    // Set encryption properties.
+    // Note that defaults.DefaultQueueProps sets encryption to Server-side KMS encryption with a KMS key managed by SQS.
+    if (props.queueProps?.encryptionMasterKey) {
+      queueProps.encryptionMasterKey = props.queueProps?.encryptionMasterKey;
+    } else if (props.encryptionKey) {
+      queueProps.encryptionMasterKey = props.encryptionKey;
+    } else if (props.encryptionKeyProps || props.enableEncryptionWithCustomerManagedKey === true) {
+      queueProps.encryptionMasterKey = buildEncryptionKey(scope, props.encryptionKeyProps);
     }
+
     const queue = new sqs.Queue(scope, id, queueProps);
 
     applySecureQueuePolicy(queue);
@@ -173,7 +181,7 @@ function applySecureQueuePolicy(queue: sqs.Queue): void {
     })
   );
 
-  // Apply Topic policy to enforce encryption of data in transit
+  // Apply queue policy to enforce encryption of data in transit
   queue.addToResourcePolicy(
     new PolicyStatement({
       sid: 'HttpsOnly',

--- a/source/patterns/@aws-solutions-constructs/core/test/input-validation.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/input-validation.test.ts
@@ -16,6 +16,7 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as glue from 'aws-cdk-lib/aws-glue';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as mediastore from 'aws-cdk-lib/aws-mediastore';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -90,6 +91,43 @@ test("Test fail SQS Queue check", () => {
 
   // Assertion
   expect(app).toThrowError('Error - Either provide queueProps or existingQueueObj, but not both.\n');
+});
+
+test('Test fail SQS queue check when queueProps.encryptionMasterKey and encryptionKey are both specified', () => {
+  const stack = new Stack();
+
+  const props: defaults.VerifiedProps = {
+    queueProps: {
+      encryptionMasterKey: new kms.Key(stack, 'key')
+    },
+    encryptionKey: new kms.Key(stack, 'otherkey')
+  };
+
+  const app = () => {
+    defaults.CheckProps(props);
+  };
+
+  expect(app).toThrowError('Error - Either provide queueProps.encryptionMasterKey or encryptionKey, but not both.\n');
+});
+
+test('Test fail SQS queue check when queueProps.encryptionMasterKey and encryptionKeyProps are both specified', () => {
+  const stack = new Stack();
+
+  const props: defaults.VerifiedProps = {
+    encryptionKeyProps: {
+      description: 'key description'
+    },
+    queueProps: {
+      encryptionMasterKey: new kms.Key(stack, 'key')
+    }
+  };
+
+  const app = () => {
+    defaults.CheckProps(props);
+  };
+
+  // Assertion
+  expect(app).toThrowError('Error - Either provide queueProps.encryptionMasterKey or encryptionKeyProps, but not both.\n');
 });
 
 test('Test fail Dead Letter Queue check', () => {
@@ -273,6 +311,60 @@ test('Test fail SNS topic check with bad topic attribute name', () => {
 
   // Assertion
   expect(app).toThrowError('Error - Either provide topicProps or existingTopicObj, but not both.\n');
+});
+
+test('Test fail SNS topic check when both encryptionKey and encryptionKeyProps are specified', () => {
+  const stack = new Stack();
+
+  const props: defaults.VerifiedProps = {
+    encryptionKey: new kms.Key(stack, 'key'),
+    encryptionKeyProps: {
+      description: 'a description'
+    }
+  };
+
+  const app = () => {
+    defaults.CheckProps(props);
+  };
+
+  expect(app).toThrowError('Error - Either provide encryptionKey or encryptionKeyProps, but not both.\n');
+});
+
+test('Test fail SNS topic check when both topicProps.masterKey and encryptionKeyProps are specified', () => {
+  const stack = new Stack();
+
+  const props: defaults.VerifiedProps = {
+    topicProps: {
+      masterKey: new kms.Key(stack, 'key')
+    },
+    encryptionKeyProps: {
+      description: 'a description'
+    }
+  };
+
+  const app = () => {
+    defaults.CheckProps(props);
+  };
+
+  expect(app).toThrowError('Error - Either provide topicProps.masterKey or encryptionKeyProps, but not both.\n');
+});
+
+test('Test fail SNS topic check when both encryptionKey and topicProps.masterKey are specified', () => {
+  const stack = new Stack();
+
+  const props: defaults.VerifiedProps = {
+    encryptionKey: new kms.Key(stack, 'key'),
+    topicProps: {
+      masterKey: new kms.Key(stack, 'otherkey')
+    }
+  };
+
+  const app = () => {
+    defaults.CheckProps(props);
+  };
+
+  // Assertion
+  expect(app).toThrowError('Error - Either provide topicProps.masterKey or encryptionKey, but not both.\n');
 });
 
 test('Test fail Glue job check', () => {

--- a/source/patterns/@aws-solutions-constructs/core/test/sns-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/sns-helper.test.ts
@@ -101,6 +101,80 @@ test('Test deployment w/ imported encryption key', () => {
   });
 });
 
+test('enableEncryptionWithCustomerManagedKey flag is ignored when encryptionKey is set', () => {
+  const stack = new Stack();
+  defaults.buildTopic(stack, {
+    enableEncryptionWithCustomerManagedKey: false,
+    encryptionKey: defaults.buildEncryptionKey(stack)
+  });
+
+  expect(stack).toHaveResource("AWS::SNS::Topic", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "EncryptionKey1B843E66",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('enableEncryptionWithCustomerManagedKey flag is ignored when topicProps.masterKey is set', () => {
+  const stack = new Stack();
+  defaults.buildTopic(stack, {
+    enableEncryptionWithCustomerManagedKey: false,
+    topicProps: {
+      masterKey: defaults.buildEncryptionKey(stack)
+    }
+  });
+
+  expect(stack).toHaveResource("AWS::SNS::Topic", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "EncryptionKey1B843E66",
+        "Arn"
+      ]
+    }
+  });
+});
+
+test('enableEncryptionWithCustomerManagedKey flag is ignored when encryptionKeyProps is set', () => {
+  const stack = new Stack();
+  const description = "custom description";
+  defaults.buildTopic(stack, {
+    enableEncryptionWithCustomerManagedKey: false,
+    encryptionKeyProps: {
+      description
+    },
+  });
+
+  expect(stack).toHaveResource("AWS::SNS::Topic", {
+    KmsMasterKeyId: {
+      "Fn::GetAtt": [
+        "EncryptionKey1B843E66",
+        "Arn"
+      ]
+    }
+  });
+
+  expect(stack).toHaveResource("AWS::KMS::Key", {
+    Description: description
+  });
+});
+
+test('encryptionProps are set correctly on the SNS Topic', () => {
+  const stack = new Stack();
+  const description = "custom description";
+  defaults.buildTopic(stack, {
+    encryptionKeyProps: {
+      description
+    }
+  });
+
+  expect(stack).toHaveResource("AWS::KMS::Key", {
+    Description: description
+  });
+});
+
 test('Check SNS Topic policy', () => {
   const stack = new Stack();
   defaults.buildTopic(stack, {});

--- a/source/patterns/@aws-solutions-constructs/core/test/sqs-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/sqs-helper.test.ts
@@ -92,9 +92,9 @@ test('Test DLQ when existing Queue Provided', () => {
     existingQueueObj: existingQueue,
   };
 
-  const returnedQueueu = defaults.buildDeadLetterQueue(stack, buildDlqProps);
+  const returnedQueue = defaults.buildDeadLetterQueue(stack, buildDlqProps);
 
-  expect(returnedQueueu).toBeUndefined();
+  expect(returnedQueue).toBeUndefined();
   expect(stack).toCountResources("AWS::SQS::Queue", 1);
 });
 


### PR DESCRIPTION
This PR standardizes how encryption properties are used across all constructs that utilize SQS Queues or SNS Topics. The core `sns-helper` and `sqs-helper` classes have been updated to be aware of encryption properties of the underlying `queueProps` and `topicProps` properties respectively. This PR passes all existing tests, and includes new tests to cover the various ways encryption can be set. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.