### PR TITLE
feat(aws-apigateway-dynamodb): add optional resourceName parameter

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/README.md
@@ -65,6 +65,7 @@ new ApiGatewayToDynamoDB(this, "test-api-gateway-dynamodb-default", new ApiGatew
 |dynamoTableProps?|[`dynamodb.TableProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.TableProps.html)|Optional user provided props to override the default props for DynamoDB Table.|
 |existingTableObj?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.Table.html)|Existing instance of DynamoDB table object, providing both this and `dynamoTableProps` will cause an error.|
 |apiGatewayProps?|[`api.RestApiProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApiProps.html)|Optional user-provided props to override the default props for the API Gateway.|
+|resourceName?|`string`|Optional name of the resource on the API Gateway. Defaults to the table's partitionKeyName|
 |allowCreateOperation?|`boolean`|Whether to deploy an API Gateway Method for POST HTTP operations on the DynamoDB table (i.e. dynamodb:PutItem).|
 |createRequestTemplate?|`string`|API Gateway Request Template for the create method for the default `application/json` content-type. This property is required if the `allowCreateOperation` property is set to true.|
 |additionalCreateRequestTemplates?|`{ [contentType: string]: string; }`|Optional Create Request Templates for content-types other than `application/json`. Use the `createRequestTemplate` property to set the request template for the `application/json` content-type. This property can only be specified if the `allowCreateOperation` property is set to true.|

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
@@ -400,6 +400,17 @@ test('Construct accepts additional delete request templates', () => {
   });
 });
 
+test('Construct can customize the api resourceName', () => {
+  const stack = new Stack();
+  new ApiGatewayToDynamoDB(stack, 'api-gateway-dynamodb', {
+    resourceName: 'my-resource-name',
+  });
+
+  expect(stack).toHaveResource("AWS::ApiGateway::Resource", {
+    PathPart: "{my-resource-name}",
+  });
+});
+
 test('Construct uses default integration responses', () => {
   const stack = new Stack();
   new ApiGatewayToDynamoDB(stack, 'api-gateway-dynamodb', {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.additional-request-templates-custom-resource-name.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.additional-request-templates-custom-resource-name.expected.json
@@ -1,0 +1,426 @@
+{
+  "Description": "Integration Test for aws-apigateway-dynamodb",
+  "Resources": {
+    "existingtableE51CCC93": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "KeySchema": [
+          {
+            "AttributeName": "PK",
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "SK",
+            "KeyType": "RANGE"
+          }
+        ],
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "PK",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "SK",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "PointInTimeRecoverySpecification": {
+          "PointInTimeRecoveryEnabled": true
+        },
+        "SSESpecification": {
+          "SSEEnabled": true
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameApiAccessLogGroup89C7FD92": {
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W86",
+              "reason": "Retention period for CloudWatchLogs LogGroups are set to 'Never Expire' to preserve customer data indefinitely"
+            },
+            {
+              "id": "W84",
+              "reason": "By default CloudWatchLogs LogGroups data is encrypted using the CloudWatch server-side encryption keys (AWS Managed Keys)"
+            }
+          ]
+        }
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "EDGE"
+          ]
+        },
+        "Name": "RestApi"
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiDeployment7F5497B67361a1e02c5799cae81447bf3ad5ef46": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE"
+        },
+        "Description": "Automatically created by the RestApi construct"
+      },
+      "DependsOn": [
+        "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiidGETB657BB05",
+        "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiid4EBF99AB"
+      ],
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W45",
+              "reason": "ApiGateway has AccessLogging enabled in AWS::ApiGateway::Stage resource, but cfn_nag checkes for it in AWS::ApiGateway::Deployment resource"
+            }
+          ]
+        }
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiDeploymentStageprodDD2DED0B": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE"
+        },
+        "AccessLogSetting": {
+          "DestinationArn": {
+            "Fn::GetAtt": [
+              "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameApiAccessLogGroup89C7FD92",
+              "Arn"
+            ]
+          },
+          "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
+        },
+        "DeploymentId": {
+          "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiDeployment7F5497B67361a1e02c5799cae81447bf3ad5ef46"
+        },
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*"
+          }
+        ],
+        "StageName": "prod",
+        "TracingEnabled": true
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiid4EBF99AB": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "{id}",
+        "RestApiId": {
+          "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE"
+        }
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiidGETB657BB05": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "GET",
+        "ResourceId": {
+          "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiid4EBF99AB"
+        },
+        "RestApiId": {
+          "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE"
+        },
+        "AuthorizationType": "AWS_IAM",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameapigatewayrole3D282506",
+              "Arn"
+            ]
+          },
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": [
+            {
+              "StatusCode": "200"
+            },
+            {
+              "ResponseTemplates": {
+                "text/html": "Error"
+              },
+              "SelectionPattern": "500",
+              "StatusCode": "500"
+            }
+          ],
+          "PassthroughBehavior": "NEVER",
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/json'"
+          },
+          "RequestTemplates": {
+            "application/json": {
+              "Fn::Join": [
+                "",
+                [
+                  "{           \"TableName\": \"",
+                  {
+                    "Ref": "existingtableE51CCC93"
+                  },
+                  "\",           \"KeyConditionExpression\": \"PK = :v1\",           \"ExpressionAttributeValues\": {             \":v1\": {               \"S\": \"$input.params('id')\"             }           }         }"
+                ]
+              ]
+            },
+            "text/plain": {
+              "Fn::Join": [
+                "",
+                [
+                  "{       \"TableName\": \"",
+                  {
+                    "Ref": "existingtableE51CCC93"
+                  },
+                  "\",       \"KeyConditionExpression\": \"PK = :v2 AND SK = :v1\",       \"ExpressionAttributeValues\": {         \":v1\": {           \"S\": \"$input.params('id')\"         },         \":v2\": {           \"S\": \"MY_VALUE\"         }       }     }"
+                ]
+              ]
+            }
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":dynamodb:action/Query"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Content-Type": true
+            },
+            "StatusCode": "200"
+          },
+          {
+            "ResponseParameters": {
+              "method.response.header.Content-Type": true
+            },
+            "StatusCode": "500"
+          }
+        ]
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiUsagePlan4D14DF10": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE"
+            },
+            "Stage": {
+              "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiDeploymentStageprodDD2DED0B"
+            },
+            "Throttle": {}
+          }
+        ]
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameLambdaRestApiCloudWatchRoleA4832ADD": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:DescribeLogGroups",
+                    "logs:DescribeLogStreams",
+                    "logs:PutLogEvents",
+                    "logs:GetLogEvents",
+                    "logs:FilterLogEvents"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":logs:",
+                        {
+                          "Ref": "AWS::Region"
+                        },
+                        ":",
+                        {
+                          "Ref": "AWS::AccountId"
+                        },
+                        ":*"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "LambdaRestApiCloudWatchRolePolicy"
+          }
+        ]
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameLambdaRestApiAccountFA4A4D09": {
+      "Type": "AWS::ApiGateway::Account",
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameLambdaRestApiCloudWatchRoleA4832ADD",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE"
+      ]
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameapigatewayrole3D282506": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameapigatewayroleDefaultPolicyAC080A34": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "dynamodb:Query",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "existingtableE51CCC93",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameapigatewayroleDefaultPolicyAC080A34",
+        "Roles": [
+          {
+            "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameapigatewayrole3D282506"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiEndpoint4892309E": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiC4813ABE"
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix"
+            },
+            "/",
+            {
+              "Ref": "testapigatewaydynamodbadditionalrequesttemplatescustomresourcenameRestApiDeploymentStageprodDD2DED0B"
+            },
+            "/"
+          ]
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+    }
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                  ],
+                  {
+                    "Ref": "BootstrapVersion"
+                  }
+                ]
+              }
+            ]
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+        }
+      ]
+    }
+  }
+}

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.additional-request-templates-custom-resource-name.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/integ.additional-request-templates-custom-resource-name.ts
@@ -1,0 +1,63 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+// Imports
+import { App, Stack } from "aws-cdk-lib";
+import { ApiGatewayToDynamoDB } from "../lib";
+import { generateIntegStackName } from '@aws-solutions-constructs/core';
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+
+// Setup
+const app = new App();
+const stack = new Stack(app, generateIntegStackName(__filename));
+stack.templateOptions.description = 'Integration Test for aws-apigateway-dynamodb';
+
+const partitionKeyName = 'PK';
+const sortKeyName = 'SK';
+const resourceName = 'id';
+
+const existingTableObj = new dynamodb.Table(stack, 'existing-table', {
+  partitionKey: {
+    name: partitionKeyName,
+    type: dynamodb.AttributeType.STRING,
+  },
+  sortKey: {
+    name: sortKeyName,
+    type: dynamodb.AttributeType.STRING
+  },
+  pointInTimeRecovery: true,
+  encryption: dynamodb.TableEncryption.AWS_MANAGED,
+  billingMode: dynamodb.BillingMode.PAY_PER_REQUEST
+});
+
+new ApiGatewayToDynamoDB(stack, 'test-api-gateway-dynamodb-additional-request-templates-custom-resource-name', {
+  existingTableObj,
+  resourceName,
+  additionalReadRequestTemplates: {
+    'text/plain': `{ \
+      "TableName": "${existingTableObj.tableName}", \
+      "KeyConditionExpression": "${partitionKeyName} = :v2 AND ${sortKeyName} = :v1", \
+      "ExpressionAttributeValues": { \
+        ":v1": { \
+          "S": "$input.params('${resourceName}')" \
+        }, \
+        ":v2": { \
+          "S": "MY_VALUE" \
+        } \
+      } \
+    }`,
+  }
+});
+
+// Synth
+app.synth();


### PR DESCRIPTION
Fixes #848

*Description of changes:*
- Add a resourceName on the `ApiGatewayToDynamoDB` construct

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.