### PR TITLE
fix(core) id conflict with multiple buildLambdaFunction() calls

### DIFF
--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
@@ -47,7 +47,7 @@ export function buildLambdaFunction(scope: Construct, props: BuildLambdaFunction
   // Conditional lambda function creation
   if (!props.existingLambdaObj) {
     if (props.lambdaFunctionProps) {
-      return deployLambdaFunction(scope, props.lambdaFunctionProps, undefined, props.vpc);
+      return deployLambdaFunction(scope, props.lambdaFunctionProps, props.lambdaFunctionProps.functionName, props.vpc);
     } else {
       throw Error('Either existingLambdaObj or lambdaFunctionProps is required');
     }

--- a/source/patterns/@aws-solutions-constructs/core/test/lambda-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/lambda-helper.test.ts
@@ -448,3 +448,40 @@ test("Test retrieving lambda vpc security group ids", () => {
   expect(securityGroups).toContain(securityGroup1.securityGroupId);
   expect(securityGroups).toContain(securityGroup2.securityGroupId);
 });
+
+test('test buildLambdaFunction with lambdaFunctionProps default id', () => {
+  const stack = new Stack();
+
+  defaults.buildLambdaFunction(stack, {
+    lambdaFunctionProps: {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+    }
+  });
+
+  expect(stack).toHaveResourceLike('AWS::Lambda::Function', {
+    Role: {
+      'Fn::GetAtt': ['LambdaFunctionServiceRole0C4CDE0B', 'Arn'],
+    },
+  });
+});
+
+test('test buildLambdaFunction with lambdaFunctionProps custom id', () => {
+  const stack = new Stack();
+
+  defaults.buildLambdaFunction(stack, {
+    lambdaFunctionProps: {
+      functionName: 'MyTestFunction',
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+    }
+  });
+
+  expect(stack).toHaveResourceLike('AWS::Lambda::Function', {
+    Role: {
+      'Fn::GetAtt': ['MyTestFunctionServiceRole37517223', 'Arn'],
+    },
+  });
+});


### PR DESCRIPTION
*Description of changes:*

Currently multiple calls to `buildLambdaFunction()`  with `lambdaFunctionProps` in the same stack throws the following error:

>There is already a Construct with name 'LambdaFunctionServiceRole' in Stack [Default]

Error is caused by a call to `deployLambdaFunction()` with `undefined` as function id. So `deployLambdaFunction` creates a lambda with the same default id for every call.

This PR fixes the issue by passing `lambdaFunctionProps.functionName` as lambda id to `deployLambdaFunction()` and adds 2 new tests to `lambda-helper.test.ts`:

- 'test buildLambdaFunction with lambdaFunctionProps default id' that assures that current behaviour is preserved (when lambdaFunctionProps.functionName is not set a default id will be used)
- 'test buildLambdaFunction with lambdaFunctionProps custom id' that assures that lambdaFunctionProps.functionName is used when present


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.