### PR TITLE
chore(core): Add warnings about using core functions from outside of Solutions Constructs

### DIFF
--- a/deployment/v2/align-version.js
+++ b/deployment/v2/align-version.js
@@ -10,7 +10,7 @@ const findVersion = process.argv[2];
 const replaceVersion = process.argv[3];
 
 // these versions need to be sourced from a config file
-const awsCdkLibVersion = '2.67.0';
+const awsCdkLibVersion = '2.68.0';
 const constructsVersion = '10.0.0';
 const MODULE_EXEMPTIONS = new Set([
   '@aws-cdk/cloudformation-diff',

--- a/source/patterns/@aws-solutions-constructs/core/lib/alb-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/alb-defaults.ts
@@ -12,12 +12,15 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultListenerProps(loadBalancer: elb.ApplicationLoadBalancer): elb.ApplicationListenerProps {
   return {
     loadBalancer,

--- a/source/patterns/@aws-solutions-constructs/core/lib/alb-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/alb-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
 
 export function DefaultListenerProps(loadBalancer: elb.ApplicationLoadBalancer): elb.ApplicationListenerProps {

--- a/source/patterns/@aws-solutions-constructs/core/lib/alb-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/alb-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -29,8 +29,12 @@ import { DefaultListenerProps } from "./alb-defaults";
 import { createAlbLoggingBucket } from "./s3-bucket-helper";
 import { DefaultLoggingBucketProps } from "./s3-bucket-defaults";
 
-//  Returns the correct ALB Load Balancer to use in this construct, either an existing
-//  one provided as an argument or create  new one otherwise.
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
+ * Returns the correct ALB Load Balancer to use in this construct, either an existing
+ * one provided as an argument or create  new one otherwise.
+ */
 export function ObtainAlb(
   scope: Construct,
   id: string,
@@ -61,6 +65,9 @@ export function ObtainAlb(
   return loadBalancer;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function AddListener(
   scope: Construct,
   id: string,
@@ -116,9 +123,13 @@ export function AddListener(
   return listener;
 }
 
-// Creates a Target Group for Lambda functions and adds the
-// provided functions as a target to that group. Then adds
-// the new Target Group to the provided Listener.
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
+ * Creates a Target Group for Lambda functions and adds the
+ * provided functions as a target to that group. Then adds
+ * the new Target Group to the provided Listener.
+ */
 export function AddLambdaTarget(
   scope: Construct,
   id: string,
@@ -145,6 +156,9 @@ export function AddLambdaTarget(
   return newTargetGroup;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function AddFargateTarget(
   scope: Construct,
   id: string,
@@ -170,9 +184,13 @@ export function AddFargateTarget(
   return newTargetGroup;
 }
 
-// Looks for the listener associated with Target Groups
-// If there is a single listener, this returns it whether it is HTTP or HTTPS
-// If there are 2 listeners, it finds the HTTPS listener (we assume the HTTP listener redirects to HTTPS)
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
+ * Looks for the listener associated with Target Groups
+ * If there is a single listener, this returns it whether it is HTTP or HTTPS
+ * If there are 2 listeners, it finds the HTTPS listener (we assume the HTTP listener redirects to HTTPS)
+ */
 export function GetActiveListener(listeners: elb.ApplicationListener[]): elb.ApplicationListener {
   let listener: elb.ApplicationListener;
 
@@ -187,6 +205,9 @@ export function GetActiveListener(listeners: elb.ApplicationListener[]): elb.App
   return listener;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CheckAlbProps(props: any) {
   let errorMessages = '';
   let errorFound = false;

--- a/source/patterns/@aws-solutions-constructs/core/lib/alb-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/alb-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Construct } from "constructs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as api from 'aws-cdk-lib/aws-apigateway';
 import { IntegrationResponse } from 'aws-cdk-lib/aws-apigateway';
 import * as lambda from 'aws-cdk-lib/aws-lambda';

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -49,6 +49,8 @@ function DefaultRestApiProps(_endpointType: api.EndpointType[], _logGroup: LogGr
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Provides the default set of properties for Edge/Global Lambda backed RestApi
  * @param scope - the construct to which the RestApi should be attached to.
  * @param _endpointType - endpoint type for Api Gateway e.g. Regional, Global, Private
@@ -65,6 +67,8 @@ export function DefaultGlobalLambdaRestApiProps(_existingLambdaObj: lambda.Funct
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Provides the default set of properties for Regional Lambda backed RestApi
  * @param scope - the construct to which the RestApi should be attached to.
  * @param _endpointType - endpoint type for Api Gateway e.g. Regional, Global, Private
@@ -81,6 +85,8 @@ export function DefaultRegionalLambdaRestApiProps(_existingLambdaObj: lambda.Fun
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Provides the default set of properties for Edge/Global RestApi
  * @param _logGroup - CW Log group for Api Gateway access logging
  */
@@ -89,6 +95,8 @@ export function DefaultGlobalRestApiProps(_logGroup: LogGroup) {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Provides the default set of properties for Regional RestApi
  * @param _logGroup - CW Log group for Api Gateway access logging
  */
@@ -97,6 +105,8 @@ export function DefaultRegionalRestApiProps(_logGroup: LogGroup) {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * @returns The set of default integration responses for status codes 200 and 500.
  */
 export function DefaultIntegrationResponses(): IntegrationResponse[] {

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -185,6 +185,8 @@ export interface GlobalLambdaRestApiResponse {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Builds and returns a global api.RestApi designed to be used with an AWS Lambda function.
  * @param scope - the construct to which the RestApi should be attached to.
  * @param _existingLambdaObj - an existing AWS Lambda function.
@@ -207,6 +209,8 @@ export interface RegionalLambdaRestApiResponse {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Builds and returns a regional api.RestApi designed to be used with an AWS Lambda function.
  * @param scope - the construct to which the RestApi should be attached to.
  * @param existingLambdaObj - an existing AWS Lambda function.
@@ -229,6 +233,8 @@ export interface GlobalRestApiResponse {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Builds and returns a standard api.RestApi.
  * @param scope - the construct to which the RestApi should be attached to.
  * @param apiGatewayProps - (optional) user-specified properties to override the default properties.
@@ -250,6 +256,8 @@ export interface RegionalRestApiResponse {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Builds and returns a Regional api.RestApi.
  * @param scope - the construct to which the RestApi should be attached to.
  * @param apiGatewayProps - (optional) user-specified properties to override the default properties.
@@ -281,6 +289,9 @@ export interface AddProxyMethodToApiResourceInputParams {
   readonly methodOptions?: apigateway.MethodOptions
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function addProxyMethodToApiResource(params: AddProxyMethodToApiResourceInputParams): apigateway.Method {
   // Make sure the user hasn't also specified the application/json content-type in the additionalRequestTemplates optional property
   if (params.additionalRequestTemplates && 'application/json' in params.additionalRequestTemplates) {

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // Imports
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as api from 'aws-cdk-lib/aws-apigateway';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import { FunctionEventType, IOrigin } from 'aws-cdk-lib/aws-cloudfront';

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -25,6 +25,9 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cdk from 'aws-cdk-lib';
 import {BehaviorOptions} from "aws-cdk-lib/aws-cloudfront/lib/distribution";
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultCloudFrontWebDistributionForApiGatewayProps(apiEndPoint: api.RestApi,
   loggingBucket: s3.Bucket | undefined,
   setHttpSecurityHeaders: boolean,
@@ -52,6 +55,9 @@ export function DefaultCloudFrontWebDistributionForApiGatewayProps(apiEndPoint: 
   };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultCloudFrontWebDistributionForS3Props(
   sourceBucket: s3.IBucket,
   loggingBucket: s3.Bucket | undefined,
@@ -85,6 +91,9 @@ export function DefaultCloudFrontWebDistributionForS3Props(
   };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultCloudFrontDisributionForMediaStoreProps(mediastoreContainer: mediastore.CfnContainer,
   loggingBucket: s3.Bucket | undefined,
   originRequestPolicy: cloudfront.OriginRequestPolicy,

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cdk from 'aws-cdk-lib';

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -73,6 +73,9 @@ export interface CloudFrontDistributionForApiGatewayResponse {
   readonly loggingBucket?: s3.Bucket
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CloudFrontDistributionForApiGateway(scope: Construct,
   apiEndPoint: api.RestApi,
   cloudFrontDistributionProps?: cloudfront.DistributionProps | any,
@@ -106,6 +109,9 @@ export interface CloudFrontDistributionForS3Response {
   readonly cloudfrontFunction?: cloudfront.Function,
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CloudFrontDistributionForS3(
   scope: Construct,
   sourceBucket: s3.IBucket,
@@ -153,6 +159,9 @@ export interface CloudFrontDistributionForMediaStoreResponse {
   readonly cloudfrontFunction?: cloudfront.Function
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CloudFrontDistributionForMediaStore(scope: Construct,
   mediaStoreContainer: mediastore.CfnContainer,
   cloudFrontDistributionProps?: cloudfront.DistributionProps | any,
@@ -216,6 +225,9 @@ export function CloudFrontDistributionForMediaStore(scope: Construct,
   return { distribution: cfDistribution, loggingBucket, requestPolicy: originRequestPolicy, cloudfrontFunction };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CloudFrontOriginAccessIdentity(scope: Construct, comment?: string) {
   return new cloudfront.OriginAccessIdentity(scope, 'CloudFrontOriginAccessIdentity', {
     comment: comment ? comment : `access-identity-${cdk.Aws.REGION}-${cdk.Aws.STACK_NAME}`

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as logs from 'aws-cdk-lib/aws-logs';
 
 export function DefaultLogGroupProps(): logs.LogGroupProps {

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-defaults.ts
@@ -12,12 +12,15 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as logs from 'aws-cdk-lib/aws-logs';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultLogGroupProps(): logs.LogGroupProps {
 
   const logGroupProps: logs.LogGroupProps = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { DefaultLogGroupProps } from './cloudwatch-log-group-defaults';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import { addCfnSuppressRules, consolidateProps } from './utils';

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -22,6 +22,9 @@ import { addCfnSuppressRules, consolidateProps } from './utils';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from 'constructs';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildLogGroup(scope: Construct, logGroupId?: string, logGroupProps?: logs.LogGroupProps): logs.LogGroup {
   let _logGroupProps: logs.LogGroupProps;
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/cognito-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cognito-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 
 const DefaultUserPoolProps: cognito.UserPoolProps = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/cognito-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cognito-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -21,6 +21,9 @@ import * as cognito from 'aws-cdk-lib/aws-cognito';
 const DefaultUserPoolProps: cognito.UserPoolProps = {
 };
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultIdentityPoolProps(userPoolClientId: string, userPoolProviderName: string): cognito.CfnIdentityPoolProps {
   return {
     allowUnauthenticatedIdentities: false,
@@ -32,6 +35,9 @@ export function DefaultIdentityPoolProps(userPoolClientId: string, userPoolProvi
   } as cognito.CfnIdentityPoolProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultUserPoolClientProps(userpool: cognito.UserPool): cognito.UserPoolClientProps {
   return {
     userPool: userpool

--- a/source/patterns/@aws-solutions-constructs/core/lib/cognito-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cognito-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -30,6 +30,9 @@ export interface CognitoOptions {
   readonly userpoolclient: cognito.UserPoolClient
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildUserPool(scope: Construct, userPoolProps?: cognito.UserPoolProps): cognito.UserPool {
   let cognitoUserPoolProps: cognito.UserPoolProps;
 
@@ -59,6 +62,9 @@ export function buildUserPool(scope: Construct, userPoolProps?: cognito.UserPool
   return userPool;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildUserPoolClient(scope: Construct, userPool: cognito.UserPool,
   cognitoUserPoolClientProps?: cognito.UserPoolClientProps): cognito.UserPoolClient {
 
@@ -69,6 +75,9 @@ export function buildUserPoolClient(scope: Construct, userPool: cognito.UserPool
   return new cognito.UserPoolClient(scope, 'CognitoUserPoolClient', userPoolClientProps);
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildIdentityPool(scope: Construct, userpool: cognito.UserPool, userpoolclient: cognito.UserPoolClient,
   identityPoolProps?: cognito.CfnIdentityPoolProps): cognito.CfnIdentityPool {
 
@@ -82,6 +91,9 @@ export function buildIdentityPool(scope: Construct, userpool: cognito.UserPool, 
   return idPool;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function setupCognitoForSearchService(scope: Construct, domainName: string, options: CognitoOptions): iam.Role {
 
   // Create the domain for Cognito UserPool
@@ -126,6 +138,9 @@ export function setupCognitoForSearchService(scope: Construct, domainName: strin
   return cognitoAuthorizedRole;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildCognitoForSearchService(scope: Construct, domainName: string):
   [cognito.UserPool, cognito.UserPoolClient, cognito.CfnIdentityPool, iam.Role] {
   const userPool = buildUserPool(scope);

--- a/source/patterns/@aws-solutions-constructs/core/lib/cognito-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cognito-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cdk from 'aws-cdk-lib';

--- a/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 
 const DefaultTableProps: dynamodb.TableProps = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -66,6 +66,9 @@ export interface BuildDynamoDBTableResponse {
   readonly tableObject?: dynamodb.Table,
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildDynamoDBTable(scope: Construct, props: BuildDynamoDBTableProps): BuildDynamoDBTableResponse {
   checkTableProps(props);
 
@@ -81,6 +84,9 @@ export function buildDynamoDBTable(scope: Construct, props: BuildDynamoDBTablePr
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function checkTableProps(props: BuildDynamoDBTableProps) {
   let errorMessages = '';
   let errorFound = false;
@@ -110,6 +116,9 @@ export interface BuildDynamoDBTableWithStreamResponse {
   readonly tableObject?: dynamodb.Table,
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildDynamoDBTableWithStream(scope: Construct, props: BuildDynamoDBTableWithStreamProps): BuildDynamoDBTableWithStreamResponse {
   // Conditional DynamoDB Table creation
   if (!props.existingTableInterface) {
@@ -122,6 +131,9 @@ export function buildDynamoDBTableWithStream(scope: Construct, props: BuildDynam
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function getPartitionKeyNameFromTable(table: dynamodb.Table): string {
   const cfnTable = table.node.findChild('Resource') as dynamodb.CfnTable;
   const keySchema = cfnTable.keySchema as dynamodb.CfnTable.KeySchemaProperty[];

--- a/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/dynamodb-table-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { DefaultTableProps, DefaultTableWithStreamProps } from './dynamodb-table-defaults';
 import { consolidateProps } from './utils';

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticache-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticache-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 export function GetDefaultCachePort() {
   // Best practice not to use default port 11211
   return 11222;

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticache-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticache-defaults.ts
@@ -12,15 +12,21 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function GetDefaultCachePort() {
   // Best practice not to use default port 11211
   return 11222;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function GetMemcachedDefaults(id: string, port: number) {
   return {
     clusterName: `${id}-cdk-cluster`,

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticache-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticache-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as cache from "aws-cdk-lib/aws-elasticache";
 import { Construct } from "constructs";

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticache-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticache-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -30,6 +30,9 @@ export interface ObtainMemcachedClusterProps {
   readonly vpc?: ec2.IVpc,
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function obtainMemcachedCluster(
   scope: Construct,
   id: string,
@@ -70,6 +73,9 @@ export function obtainMemcachedCluster(
 
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function createCacheSubnetGroup(
   construct: Construct,
   vpc: ec2.IVpc,
@@ -91,6 +97,9 @@ export function createCacheSubnetGroup(
   });
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function getCachePort(
   clientCacheProps?: cache.CfnCacheClusterProps | any,
   existingCache?: cache.CfnCacheCluster

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -21,6 +21,9 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cdk from 'aws-cdk-lib';
 import { BuildElasticSearchProps } from './elasticsearch-helper';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultCfnDomainProps(domainName: string, cognitoKibanaConfigureRole: iam.Role, props: BuildElasticSearchProps):
   elasticsearch.CfnDomainProps {
   const roleARNs: iam.IPrincipal[] = [];

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as elasticsearch from 'aws-cdk-lib/aws-elasticsearch';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cdk from 'aws-cdk-lib';

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -46,6 +46,9 @@ export interface BuildElasticSearchResponse {
   readonly role: iam.Role
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildElasticSearch(scope: Construct, props: BuildElasticSearchProps): BuildElasticSearchResponse {
 
   let subnetIds: string[] = [];
@@ -96,6 +99,9 @@ export function buildElasticSearch(scope: Construct, props: BuildElasticSearchPr
   return { domain: esDomain, role: cognitoKibanaConfigureRole };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildElasticSearchCWAlarms(scope: Construct): cloudwatch.Alarm[] {
   // Setup CW Alarms for ES
   const alarms: cloudwatch.Alarm[] = new Array();

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as elasticsearch from 'aws-cdk-lib/aws-elasticsearch';
 import { DefaultCfnDomainProps } from './elasticsearch-defaults';
 import { retrievePrivateSubnetIds } from './vpc-helper';

--- a/source/patterns/@aws-solutions-constructs/core/lib/eventbridge-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/eventbridge-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -35,6 +35,9 @@ export interface BuildEventBusProps {
   readonly eventBusProps?: events.EventBusProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildEventBus(scope: Construct, props: BuildEventBusProps): events.IEventBus | undefined {
   // Check whether existing EventBus is provided
   if (props.existingEventBusInterface) {

--- a/source/patterns/@aws-solutions-constructs/core/lib/eventbridge-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/eventbridge-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from 'constructs';
 import * as events from 'aws-cdk-lib/aws-events';

--- a/source/patterns/@aws-solutions-constructs/core/lib/events-rule-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/events-rule-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as events from 'aws-cdk-lib/aws-events';
 
 export function DefaultEventsRuleProps(_targets: events.IRuleTarget[], _eventBus?: events.IEventBus) {

--- a/source/patterns/@aws-solutions-constructs/core/lib/events-rule-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/events-rule-defaults.ts
@@ -12,12 +12,15 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as events from 'aws-cdk-lib/aws-events';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultEventsRuleProps(_targets: events.IRuleTarget[], _eventBus?: events.IEventBus) {
   const defaultEventsRuleProps: events.RuleProps = {
     targets: _targets,

--- a/source/patterns/@aws-solutions-constructs/core/lib/fargate-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/fargate-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,12 +20,18 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultClusterProps() {
   return {
 
   };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultFargateServiceProps(
 ) {
   return {
@@ -37,6 +43,9 @@ export function DefaultFargateServiceProps(
   };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultFargateTaskDefinitionProps(): ecs.FargateTaskDefinitionProps {
   return {
     cpu: 256,
@@ -44,6 +53,9 @@ export function DefaultFargateTaskDefinitionProps(): ecs.FargateTaskDefinitionPr
   };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultApplicationTargetGroupProps(vpc: ec2.IVpc): elb.ApplicationTargetGroupProps {
   return {
     port: 8080,
@@ -55,6 +67,9 @@ export function DefaultApplicationTargetGroupProps(vpc: ec2.IVpc): elb.Applicati
   };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultContainerDefinitionProps(): ecs.ContainerDefinitionOptions | any {
   return {
     memoryReservationMiB: 512,

--- a/source/patterns/@aws-solutions-constructs/core/lib/fargate-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/fargate-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";

--- a/source/patterns/@aws-solutions-constructs/core/lib/fargate-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/fargate-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { Construct } from "constructs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecs from "aws-cdk-lib/aws-ecs";

--- a/source/patterns/@aws-solutions-constructs/core/lib/fargate-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/fargate-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -28,6 +28,9 @@ export interface CreateFargateServiceResponse {
   readonly containerDefinition: ecs.ContainerDefinition
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CreateFargateService(
   scope: Construct,
   id: string,
@@ -210,6 +213,9 @@ function CreateTaskDefinition(
   return { taskDefinition, containerDefinition };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CheckFargateProps(props: any) {
   let errorMessages = "";
   let errorFound = false;
@@ -280,6 +286,9 @@ export function CheckFargateProps(props: any) {
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function getServiceVpcSecurityGroupIds(service: ecs.FargateService): string[] {
   const securityGroupIds: string[] = [];
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-database-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-database-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,7 +20,7 @@ import { CfnDatabaseProps } from "aws-cdk-lib/aws-glue";
 import { Aws } from "aws-cdk-lib";
 
 /**
- * Default database props
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
 export function DefaultGlueDatabaseProps(): CfnDatabaseProps {
   const _databaseProps: CfnDatabaseProps = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-database-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-database-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { CfnDatabaseProps } from "aws-cdk-lib/aws-glue";
 import { Aws } from "aws-cdk-lib";
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-database-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-database-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { CfnDatabase, CfnDatabaseProps } from "aws-cdk-lib/aws-glue";
 import { Construct } from "constructs";
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-database-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-database-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,6 +20,8 @@ import { CfnDatabase, CfnDatabaseProps } from "aws-cdk-lib/aws-glue";
 import { Construct } from "constructs";
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Create an AWS Glue database with the properties provided
  *
  * @param scope

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-job-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-job-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,6 +20,9 @@ import { CfnJobProps } from 'aws-cdk-lib/aws-glue';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import * as s3assets from "aws-cdk-lib/aws-s3-assets";
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultGlueJobProps(jobRole: IRole, userProvidedGlueJobProps: CfnJobProps | any,
   glueSecurityConfigName: string, defaultArguments: {}, etlCodeAsset?: s3assets.Asset): CfnJobProps {
   const glueVersion: string | undefined = userProvidedGlueJobProps.glueVersion;

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-job-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-job-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { CfnJobProps } from 'aws-cdk-lib/aws-glue';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import * as s3assets from "aws-cdk-lib/aws-s3-assets";

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-job-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-job-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { Construct } from 'constructs';
 import * as glue from 'aws-cdk-lib/aws-glue';
 import { Effect, IRole, Policy, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-job-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-job-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -99,6 +99,9 @@ export interface BuildGlueJobResponse {
   readonly loggingBucket?: Bucket,
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildGlueJob(scope: Construct, props: BuildGlueJobProps): BuildGlueJobResponse {
   if (!props.existingCfnJob) {
     if (props.glueJobProps) {
@@ -134,6 +137,9 @@ export interface DeployGlueJobResponse {
   readonly loggingBucket?: Bucket,
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function deployGlueJob(scope: Construct, glueJobProps: glue.CfnJobProps, database: glue.CfnDatabase, table: glue.CfnTable,
   outputDataStore: SinkDataStoreProps, etlCodeAsset?: s3assets.Asset): DeployGlueJobResponse {
 
@@ -220,6 +226,8 @@ export function deployGlueJob(scope: Construct, glueJobProps: glue.CfnJobProps, 
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * This is a helper method to create the Role required for the Glue Job. If a role is already created then this
  * method is not required to be called.
  *
@@ -233,6 +241,8 @@ export function createGlueJobRole(scope: Construct): Role {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * This method creates an AWS Glue table. The method is called when an existing Glue table is not provided
  */
 export function createGlueTable(scope: Construct, database: glue.CfnDatabase, tableProps?: glue.CfnTableProps,
@@ -242,6 +252,8 @@ export function createGlueTable(scope: Construct, database: glue.CfnDatabase, ta
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * This method creates an AWS Glue database. The method is only called with an existing Glue database type is not provided.
  * The method uses the user provided props to override the defaul props for the Glue database
  *

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-table-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-table-defaults.ts
@@ -12,13 +12,16 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as glue from "aws-cdk-lib/aws-glue";
 import { Aws } from "aws-cdk-lib";
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultGlueTableProps(database: glue.CfnDatabase, fieldSchema: glue.CfnTable.ColumnProperty[],
   sourceType?: string, parameters?: any): glue.CfnTableProps | any {
   let _tableProps: glue.CfnTableProps;

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-table-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-table-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as glue from "aws-cdk-lib/aws-glue";
 import { Aws } from "aws-cdk-lib";
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-table-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { CfnTable, CfnTableProps } from "aws-cdk-lib/aws-glue";
 import { Construct } from "constructs";
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-table-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,6 +20,8 @@ import { CfnTable, CfnTableProps } from "aws-cdk-lib/aws-glue";
 import { Construct } from "constructs";
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Method to build the default table props
  *
  * @param scope
@@ -28,6 +30,9 @@ import { Construct } from "constructs";
  * @param sourceType
  * @param parameters - Key value pairs of parameters. If source type is 'Kinesis', pass Kinesis Data Stream name with key
  *  as 'STREAM_NAME'. Example: {STREAM_NAME: 'KinesisStreamConstrct.streamName'}
+ */
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
 export function DefaultGlueTable(scope: Construct, tableProps: CfnTableProps): CfnTable {
   return new CfnTable(scope, 'GlueTable', tableProps);

--- a/source/patterns/@aws-solutions-constructs/core/lib/glue-table-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/glue-table-helper.ts
@@ -31,9 +31,6 @@ import { Construct } from "constructs";
  * @param parameters - Key value pairs of parameters. If source type is 'Kinesis', pass Kinesis Data Stream name with key
  *  as 'STREAM_NAME'. Example: {STREAM_NAME: 'KinesisStreamConstrct.streamName'}
  */
-/**
- * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
- */
 export function DefaultGlueTable(scope: Construct, tableProps: CfnTableProps): CfnTable {
   return new CfnTable(scope, 'GlueTable', tableProps);
 }

--- a/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
 import * as lambda from 'aws-cdk-lib/aws-lambda';

--- a/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/input-validation.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -89,6 +89,9 @@ export interface VerifiedProps {
   readonly openSearchDomainProps?: opensearch.CfnDomainProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CheckProps(propsObject: VerifiedProps | any) {
   let errorMessages = '';
   let errorFound = false;
@@ -247,6 +250,9 @@ export function CheckProps(propsObject: VerifiedProps | any) {
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CheckListValues(allowedPermissions: string[], submittedValues: string[], valueType: string) {
   submittedValues.forEach((submittedValue) => {
     if (!allowedPermissions.includes(submittedValue)) {

--- a/source/patterns/@aws-solutions-constructs/core/lib/iot-topic-rule-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/iot-topic-rule-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as iot from 'aws-cdk-lib/aws-iot';
 
 export function DefaultCfnTopicRuleProps(_actions: iot.CfnTopicRule.ActionProperty[], _sql: string = '') {

--- a/source/patterns/@aws-solutions-constructs/core/lib/iot-topic-rule-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/iot-topic-rule-defaults.ts
@@ -12,12 +12,15 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as iot from 'aws-cdk-lib/aws-iot';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultCfnTopicRuleProps(_actions: iot.CfnTopicRule.ActionProperty[], _sql: string = '') {
   const _topicRulePayload: iot.CfnTopicRule.TopicRulePayloadProperty = {
     ruleDisabled: false,

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as kinesisanalytics from 'aws-cdk-lib/aws-kinesisanalytics';
 
 const DefaultCfnApplicationProps: kinesisanalytics.CfnApplicationProps = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // Imports
 import * as kinesisAnalytics from 'aws-cdk-lib/aws-kinesisanalytics';
 import * as kinesisFirehose from 'aws-cdk-lib/aws-kinesisfirehose';

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-analytics-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -40,6 +40,9 @@ export interface BuildKinesisAnalyticsAppProps {
    readonly kinesisAnalyticsProps?: kinesisAnalytics.CfnApplicationProps | any
  }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildKinesisAnalyticsApp(scope: Construct, props: BuildKinesisAnalyticsAppProps): kinesisAnalytics.CfnApplication {
 
   // Setup the IAM role for Kinesis Analytics

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-firehose-s3-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-firehose-s3-defaults.ts
@@ -12,13 +12,16 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import { CfnDeliveryStreamProps } from 'aws-cdk-lib/aws-kinesisfirehose';
 import { IKey } from 'aws-cdk-lib/aws-kms';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultCfnDeliveryStreamProps(_bucketArn: string, _roleArn: string,
   _logGroupName: string, _logStreamName: string, _kms: IKey, deliveryStreamName?: string): CfnDeliveryStreamProps {
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-firehose-s3-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-firehose-s3-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { CfnDeliveryStreamProps } from 'aws-cdk-lib/aws-kinesisfirehose';
 import { IKey } from 'aws-cdk-lib/aws-kms';
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
 
 const DefaultStreamProps: kinesis.StreamProps = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -41,6 +41,9 @@ export interface BuildKinesisStreamProps {
   readonly kinesisStreamProps?: kinesis.StreamProps
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildKinesisStream(scope: Construct, props: BuildKinesisStreamProps): kinesis.Stream {
 
   if (props.existingStreamObj) {
@@ -56,6 +59,9 @@ export function buildKinesisStream(scope: Construct, props: BuildKinesisStreamPr
   return new kinesis.Stream(scope, 'KinesisStream', kinesisStreamProps);
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildKinesisStreamCWAlarms(scope: Construct): cloudwatch.Alarm[] {
   // Setup CW Alarms for KinesisStream
   const alarms: cloudwatch.Alarm[] = new Array();

--- a/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kinesis-streams-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // Imports
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
 import { DefaultStreamProps } from './kinesis-streams-defaults';

--- a/source/patterns/@aws-solutions-constructs/core/lib/kms-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kms-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { KeyProps } from 'aws-cdk-lib/aws-kms';
 
 const DefaultEncryptionProps: KeyProps = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/kms-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kms-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/kms-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kms-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -22,6 +22,9 @@ import { consolidateProps } from './utils';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from 'constructs';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildEncryptionKey(scope: Construct, keyProps?: kms.KeyProps): kms.Key {
   // Setup the key properties
   let encryptionKeyProps;

--- a/source/patterns/@aws-solutions-constructs/core/lib/kms-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/kms-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { DefaultEncryptionProps } from './kms-defaults';
 import { consolidateProps } from './utils';

--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-defaults.ts
@@ -12,13 +12,16 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultLambdaFunctionProps(lambdaServiceRole: iam.Role): lambda.FunctionProps | any {
 
   const lambdaFunctionProps: lambda.FunctionProps | any = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-event-source-mapping-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-event-source-mapping-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { consolidateProps } from './utils';

--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-event-source-mapping-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-event-source-mapping-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -31,6 +31,9 @@ export interface EventSourceProps {
   readonly sqsDlqQueueProps?: sqs.QueueProps
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DynamoEventSourceProps(scope: Construct, _dynamoEventSourceProps?: EventSourceProps): DynamoEventSourceProps {
 
   const baseProps: DynamoEventSourceProps = {
@@ -58,6 +61,9 @@ export function DynamoEventSourceProps(scope: Construct, _dynamoEventSourceProps
   return consolidateProps(defaultDynamoEventSourceProps, _dynamoEventSourceProps?.eventSourceProps);
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function S3EventSourceProps(_s3EventSourceProps?: S3EventSourceProps) {
 
   const defaultS3EventSourceProps: S3EventSourceProps = {
@@ -67,6 +73,9 @@ export function S3EventSourceProps(_s3EventSourceProps?: S3EventSourceProps) {
   return consolidateProps(defaultS3EventSourceProps, _s3EventSourceProps);
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function KinesisEventSourceProps(scope: Construct, _kinesisEventSourceProps?: EventSourceProps): KinesisEventSourceProps {
   const baseProps: KinesisEventSourceProps = {
     startingPosition: lambda.StartingPosition.TRIM_HORIZON,

--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as ec2 from "aws-cdk-lib/aws-ec2";

--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -48,6 +48,9 @@ export interface BuildLambdaFunctionProps {
   readonly vpc?: ec2.IVpc;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildLambdaFunction(scope: Construct, props: BuildLambdaFunctionProps): lambda.Function {
   // Conditional lambda function creation
   if (!props.existingLambdaObj) {
@@ -74,6 +77,9 @@ export function buildLambdaFunction(scope: Construct, props: BuildLambdaFunction
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function deployLambdaFunction(scope: Construct,
   lambdaFunctionProps: lambda.FunctionProps,
   functionId?: string,
@@ -185,9 +191,13 @@ export function deployLambdaFunction(scope: Construct,
   return lambdafunction;
 }
 
-// A wrapper above Function.addPermision that
-// prevents two different calls to addPermission using
-// the same construct id.
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
+ * A wrapper above Function.addPermision that
+ * prevents two different calls to addPermission using
+ * the same construct id.
+ */
 export function addPermission(targetFunction: lambda.Function, name: string, permission: lambda.Permission): any {
   targetFunction.addPermission(GetNextId(targetFunction.permissionsNode.children, name), permission);
 }
@@ -217,6 +227,9 @@ function GetNextId(children: IConstruct[], coreName: string): string {
   return `${coreName}-${lastSuffix + 1}`;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function getLambdaVpcSecurityGroupIds(lambdaFunction: lambda.Function): string[] {
   const securityGroupIds: string[] = [];
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/mediastore-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/mediastore-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as cdk from 'aws-cdk-lib';
 import * as mediastore from 'aws-cdk-lib/aws-mediastore';
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/mediastore-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/mediastore-defaults.ts
@@ -12,13 +12,16 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as cdk from 'aws-cdk-lib';
 import * as mediastore from 'aws-cdk-lib/aws-mediastore';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function MediaStoreContainerProps(): mediastore.CfnContainerProps {
   return {
     containerName: cdk.Aws.STACK_NAME,

--- a/source/patterns/@aws-solutions-constructs/core/lib/mediastore-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/mediastore-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as cdk from 'aws-cdk-lib';
 import * as mediastore from 'aws-cdk-lib/aws-mediastore';
 import { MediaStoreContainerProps } from './mediastore-defaults';

--- a/source/patterns/@aws-solutions-constructs/core/lib/mediastore-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/mediastore-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -23,6 +23,9 @@ import { consolidateProps } from './utils';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from 'constructs';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function MediaStoreContainer(scope: Construct, mediaStoreContainerProps?: mediastore.CfnContainerProps): mediastore.CfnContainer {
   const defaultprops: mediastore.CfnContainerProps = MediaStoreContainerProps();
   let mediaStoreProps: mediastore.CfnContainerProps;

--- a/source/patterns/@aws-solutions-constructs/core/lib/opensearch-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/opensearch-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -21,6 +21,9 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cdk from 'aws-cdk-lib';
 import { BuildOpenSearchProps } from './opensearch-helper';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultOpenSearchCfnDomainProps(domainName: string, cognitoConfigureRole: iam.Role, props: BuildOpenSearchProps):
   opensearch.CfnDomainProps {
   const roleARNs: iam.IPrincipal[] = [];

--- a/source/patterns/@aws-solutions-constructs/core/lib/opensearch-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/opensearch-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as opensearch from 'aws-cdk-lib/aws-opensearchservice';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cdk from 'aws-cdk-lib';

--- a/source/patterns/@aws-solutions-constructs/core/lib/opensearch-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/opensearch-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as opensearch from 'aws-cdk-lib/aws-opensearchservice';
 import { DefaultOpenSearchCfnDomainProps } from './opensearch-defaults';
 import { retrievePrivateSubnetIds } from './vpc-helper';

--- a/source/patterns/@aws-solutions-constructs/core/lib/opensearch-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/opensearch-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -46,6 +46,9 @@ export interface BuildOpenSearchResponse {
   readonly role: iam.Role
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildOpenSearch(scope: Construct, props: BuildOpenSearchProps): BuildOpenSearchResponse {
   let subnetIds: string[] = [];
   const constructDrivenProps: any = {};
@@ -95,6 +98,9 @@ export function buildOpenSearch(scope: Construct, props: BuildOpenSearchProps): 
   return  { domain: opensearchDomain, role: cognitoDashboardConfigureRole };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildOpenSearchCWAlarms(scope: Construct): cloudwatch.Alarm[] {
   const alarms: cloudwatch.Alarm[] = new Array();
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/override-warning-service.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/override-warning-service.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,6 +20,8 @@ import * as deepdiff from 'deep-diff';
 import { printWarning } from './utils';
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Emits a warning to the console when a prescriptive default value is overridden by the user.
  * @param {object} defaultProps the prescriptive defaults for the pattern.
  * @param {object} userProps the properties provided by the user, to be compared against the defaultProps.

--- a/source/patterns/@aws-solutions-constructs/core/lib/override-warning-service.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/override-warning-service.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as deepdiff from 'deep-diff';
 import { printWarning } from './utils';
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { Bucket, BucketProps } from 'aws-cdk-lib/aws-s3';

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,6 +20,9 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { Bucket, BucketProps } from 'aws-cdk-lib/aws-s3';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultS3Props(loggingBucket?: Bucket, lifecycleRules?: s3.LifecycleRule[]): s3.BucketProps {
   return {
     encryption: s3.BucketEncryption.S3_MANAGED,
@@ -32,6 +35,9 @@ export function DefaultS3Props(loggingBucket?: Bucket, lifecycleRules?: s3.Lifec
   } as BucketProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultLoggingBucketProps(): s3.BucketProps {
   return {
     encryption: s3.BucketEncryption.S3_MANAGED,

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -49,6 +49,9 @@ export interface BuildS3BucketProps {
   readonly logS3AccessLogs?: boolean;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function createLoggingBucket(scope: Construct,
   bucketId: string,
   loggingBucketProps: s3.BucketProps): s3.Bucket {
@@ -81,6 +84,9 @@ export function createLoggingBucket(scope: Construct,
   return loggingBucket;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function createAlbLoggingBucket(scope: Construct,
   bucketId: string,
   loggingBucketProps: s3.BucketProps): s3.Bucket {
@@ -106,6 +112,9 @@ export interface BuildS3BucketResponse {
   readonly loggingBucket?: s3.Bucket
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildS3Bucket(scope: Construct,
   props: BuildS3BucketProps,
   bucketId?: string): BuildS3BucketResponse {
@@ -154,6 +163,9 @@ export function buildS3Bucket(scope: Construct,
   return { bucket: s3Bucket, loggingBucket };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function addCfnNagS3BucketNotificationRulesToSuppress(stackRoot: cdk.Stack, logicalId: string) {
   const notificationsResourceHandler = stackRoot.node.tryFindChild(logicalId) as lambda.Function;
   const notificationsResourceHandlerRoleRole = notificationsResourceHandler.node.findChild('Role') as iam.Role;

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';

--- a/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import {
   CfnNotebookInstanceProps,
   CfnModelProps,

--- a/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -24,6 +24,9 @@ import {
   CfnEndpointProps,
 } from 'aws-cdk-lib/aws-sagemaker';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultSagemakerNotebookProps(
   roleArn: string,
   kmsKeyId: string,
@@ -39,6 +42,9 @@ export function DefaultSagemakerNotebookProps(
   } as CfnNotebookInstanceProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultSagemakerModelProps(
   executionRoleArn: string,
   primaryContainer: CfnModel.ContainerDefinitionProperty,
@@ -51,6 +57,9 @@ export function DefaultSagemakerModelProps(
   } as CfnModelProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultSagemakerEndpointConfigProps(modelName: string, kmsKeyId?: string): CfnEndpointConfigProps {
   return {
     productionVariants: [
@@ -66,6 +75,9 @@ export function DefaultSagemakerEndpointConfigProps(modelName: string, kmsKeyId?
   } as CfnEndpointConfigProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultSagemakerEndpointProps(endpointConfigName: string): CfnEndpointProps {
   return {
     endpointConfigName,

--- a/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -225,6 +225,9 @@ export interface BuildSagemakerNotebookResponse {
   readonly securityGroup?: ec2.SecurityGroup
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildSagemakerNotebook(
   scope: Construct,
   props: BuildSagemakerNotebookProps
@@ -347,6 +350,9 @@ export interface BuildSagemakerEndpointResponse {
   readonly model?: sagemaker.CfnModel
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function BuildSagemakerEndpoint(
   scope: Construct,
   props: BuildSagemakerEndpointProps
@@ -371,6 +377,9 @@ export interface DeploySagemakerEndpointResponse {
   readonly model?: sagemaker.CfnModel
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function deploySagemakerEndpoint(
   scope: Construct,
   props: BuildSagemakerEndpointProps
@@ -415,6 +424,9 @@ export function deploySagemakerEndpoint(
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function createSagemakerModel(
   scope: Construct,
   modelProps: sagemaker.CfnModelProps,
@@ -479,6 +491,9 @@ export function createSagemakerModel(
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function createSagemakerEndpointConfig(
   scope: Construct,
   modelName: string,
@@ -504,6 +519,9 @@ export function createSagemakerEndpointConfig(
   return endpointConfig;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function createSagemakerEndpoint(
   scope: Construct,
   endpointConfigName: string,

--- a/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sagemaker-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as sagemaker from 'aws-cdk-lib/aws-sagemaker';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { buildEncryptionKey } from './kms-helper';

--- a/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { SecretProps } from 'aws-cdk-lib/aws-secretsmanager';
 import { RemovalPolicy } from 'aws-cdk-lib';
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { Secret, SecretProps } from 'aws-cdk-lib/aws-secretsmanager';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from 'constructs';

--- a/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-helper.ts
@@ -31,9 +31,6 @@ import { consolidateProps, addCfnSuppressRules } from './utils';
  * @param id
  * @param secretProps
  */
-/**
- * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
- */
 export function buildSecretsManagerSecret(scope: Construct, id: string, secretProps?: SecretProps): Secret {
   let secret: Secret;
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/secretsmanager-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -23,11 +23,16 @@ import { DefaultSecretProps } from './secretsmanager-defaults';
 import { consolidateProps, addCfnSuppressRules } from './utils';
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Method to build the default AWS Secrets Manager Secret
  *
  * @param scope
  * @param id
  * @param secretProps
+ */
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
 export function buildSecretsManagerSecret(scope: Construct, id: string, secretProps?: SecretProps): Secret {
   let secret: Secret;

--- a/source/patterns/@aws-solutions-constructs/core/lib/security-group-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/security-group-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -28,6 +28,9 @@ export interface SecurityGroupRuleDefinition {
   readonly remoteRule?: boolean
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildSecurityGroup(
   scope: Construct,
   name: string,
@@ -61,6 +64,9 @@ export function buildSecurityGroup(
   return newSecurityGroup;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function CreateSelfReferencingSecurityGroup(scope: Construct, id: string, vpc: ec2.IVpc, cachePort: any) {
   const newCacheSG = new ec2.SecurityGroup(scope, `${id}-cachesg`, {
     vpc,

--- a/source/patterns/@aws-solutions-constructs/core/lib/security-group-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/security-group-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // import { countResources } from "@aws-cdk/assert";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";

--- a/source/patterns/@aws-solutions-constructs/core/lib/sns-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sns-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as sns from 'aws-cdk-lib/aws-sns';
 
 const DefaultSnsTopicProps: sns.TopicProps = {};

--- a/source/patterns/@aws-solutions-constructs/core/lib/sns-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sns-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // Imports
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as kms from 'aws-cdk-lib/aws-kms';

--- a/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sns-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -136,6 +136,9 @@ export interface BuildTopicResponse {
   readonly key?: kms.Key
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildTopic(scope: Construct, props: BuildTopicProps): BuildTopicResponse {
   if (!props.existingTopicObj) {
     // Setup the topic properties

--- a/source/patterns/@aws-solutions-constructs/core/lib/sqs-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sqs-defaults.ts
@@ -12,12 +12,15 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultQueueProps() {
   const _DefaultQueueProps: sqs.QueueProps = {
     encryption: sqs.QueueEncryption.KMS_MANAGED

--- a/source/patterns/@aws-solutions-constructs/core/lib/sqs-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sqs-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 
 export function DefaultQueueProps() {

--- a/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -72,6 +72,9 @@ export interface BuildQueueResponse {
   readonly key?: kms.IKey
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildQueue(scope: Construct, id: string, props: BuildQueueProps): BuildQueueResponse {
 
   if ((props.queueProps?.encryptionMasterKey || props.encryptionKey || props.encryptionKeyProps)
@@ -147,6 +150,9 @@ export interface BuildDeadLetterQueueProps {
   readonly maxReceiveCount?: number
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildDeadLetterQueue(scope: Construct, props: BuildDeadLetterQueueProps): sqs.DeadLetterQueue | undefined {
   if (!props.existingQueueObj && (props.deployDeadLetterQueue || props.deployDeadLetterQueue === undefined)) {
     // Create the Dead Letter Queue

--- a/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/sqs-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // Imports
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as defaults from './sqs-defaults';

--- a/source/patterns/@aws-solutions-constructs/core/lib/ssm-string-parameter-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/ssm-string-parameter-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -20,6 +20,8 @@ import {StringParameter, StringParameterProps} from 'aws-cdk-lib/aws-ssm';
 import {Construct} from 'constructs';
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Method to build the default AWS SSM Parameter Store
  *
  * @param scope

--- a/source/patterns/@aws-solutions-constructs/core/lib/ssm-string-parameter-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/ssm-string-parameter-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import {StringParameter, StringParameterProps} from 'aws-cdk-lib/aws-ssm';
 import {Construct} from 'constructs';
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/step-function-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/step-function-defaults.ts
@@ -12,13 +12,16 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import { ILogGroup } from 'aws-cdk-lib/aws-logs';
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultStateMachineProps(_logGroup: ILogGroup): sfn.StateMachineProps | any {
 
   const stateMachineProps: sfn.StateMachineProps | any = {

--- a/source/patterns/@aws-solutions-constructs/core/lib/step-function-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/step-function-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import { ILogGroup } from 'aws-cdk-lib/aws-logs';
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/step-function-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/step-function-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -33,6 +33,8 @@ export interface BuildStateMachineResponse {
   readonly logGroup: logs.ILogGroup
 }
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Builds and returns a StateMachine.
  * @param scope - the construct to which the StateMachine should be attached to.
  * @param stateMachineProps - user-specified properties to override the default properties.
@@ -113,6 +115,9 @@ export function buildStateMachine(scope: Construct, stateMachineProps: sfn.State
   return { stateMachine: newStateMachine, logGroup };
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildStepFunctionCWAlarms(scope: Construct, sm: sfn.StateMachine): cloudwatch.Alarm[] {
   // Setup CW Alarms for State Machine
   const alarms: cloudwatch.Alarm[] = new Array();

--- a/source/patterns/@aws-solutions-constructs/core/lib/step-function-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/step-function-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 // Imports
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as cdk from 'aws-cdk-lib';

--- a/source/patterns/@aws-solutions-constructs/core/lib/utils.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/utils.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as deepmerge from 'deepmerge';
 import { flagOverriddenDefaults } from './override-warning-service';
 import * as log from 'npmlog';

--- a/source/patterns/@aws-solutions-constructs/core/lib/utils.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/utils.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -67,6 +67,9 @@ function overwriteMerge(target: any[], source: any[]) {
   return target;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function overrideProps(DefaultProps: object, userProps: object, concatArray: boolean = false): any {
   // Notify the user via console output if defaults are overridden
   const overrideWarningsEnabled = (process.env.overrideWarningsEnabled !== 'false');
@@ -87,6 +90,9 @@ export function overrideProps(DefaultProps: object, userProps: object, concatArr
   }
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function printWarning(message: string) {
   // Style the log output
   log.prefixStyle.bold = true;
@@ -96,6 +102,8 @@ export function printWarning(message: string) {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * @summary Creates a resource name in the style of the CDK (string+hash)
  * @param {string[]} parts - the various string components of the name (eg - stackName, solutions construct ID, L2 construct ID)
  * @param {number} maxLength - the longest string that can be returned
@@ -141,6 +149,8 @@ export interface CfnNagSuppressRule {
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Adds CFN NAG suppress rules to the CDK resource.
  * @param resource The CDK resource
  * @param rules The CFN NAG suppress rules
@@ -160,6 +170,8 @@ export function addCfnSuppressRules(resource: cdk.Resource | cdk.CfnResource, ru
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Creates the props to be used to instantiate a CDK L2 construct within a Solutions Construct
  *
  * @param defaultProps The default props to be used by the construct
@@ -185,6 +197,8 @@ export function consolidateProps(defaultProps: object, clientProps?: object, con
 }
 
 /**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
  * Generates a name unique to this location in this stack with this stackname. Truncates to under 64 characters if needed.
  * (will allow 2 copies of the stack with different stack names, but will collide if both stacks have the same name)
  *

--- a/source/patterns/@aws-solutions-constructs/core/lib/vpc-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/vpc-defaults.ts
@@ -19,9 +19,6 @@
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 
 /**
- * Default VPC with public and private subnets
- */
-/**
  * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
 export function DefaultPublicPrivateVpcProps(): ec2.VpcProps {

--- a/source/patterns/@aws-solutions-constructs/core/lib/vpc-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/vpc-defaults.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -21,13 +21,16 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 /**
  * Default VPC with public and private subnets
  */
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultPublicPrivateVpcProps(): ec2.VpcProps {
   return {
   } as ec2.VpcProps;
 }
 
 /**
- * Default VPC with isolated subnets
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
 export function DefaultIsolatedVpcProps(): ec2.VpcProps {
   return {
@@ -43,7 +46,7 @@ export function DefaultIsolatedVpcProps(): ec2.VpcProps {
 }
 
 /**
- * Default VPC with private subnets w/NAT
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
 export function DefaultPrivateVpcProps(): ec2.VpcProps {
   return {

--- a/source/patterns/@aws-solutions-constructs/core/lib/vpc-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/vpc-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 
 /**

--- a/source/patterns/@aws-solutions-constructs/core/lib/vpc-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/vpc-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -42,6 +42,9 @@ export interface BuildVpcProps {
   readonly constructVpcProps?: ec2.VpcProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildVpc(scope: Construct, props: BuildVpcProps): ec2.IVpc {
   if (props?.existingVpc) {
     return props?.existingVpc;
@@ -158,6 +161,9 @@ const endpointSettings: EndpointDefinition[] = [
   }
 ];
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function AddAwsServiceEndpoint(
   scope: Construct,
   vpc: ec2.IVpc,
@@ -237,6 +243,9 @@ function AddGatewayEndpoint(vpc: ec2.IVpc, service: EndpointDefinition, interfac
   });
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function retrievePrivateSubnetIds(vpc: ec2.IVpc) {
   let targetSubnetType;
 

--- a/source/patterns/@aws-solutions-constructs/core/lib/vpc-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/vpc-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";

--- a/source/patterns/@aws-solutions-constructs/core/lib/waf-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/waf-defaults.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import * as waf from "aws-cdk-lib/aws-wafv2";
 
 export function DefaultWafRules(): waf.CfnRuleGroup.RuleProperty[] {

--- a/source/patterns/@aws-solutions-constructs/core/lib/waf-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/waf-defaults.ts
@@ -12,12 +12,15 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
 import * as waf from "aws-cdk-lib/aws-wafv2";
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultWafRules(): waf.CfnRuleGroup.RuleProperty[] {
   return [
     wrapManagedRuleSet("AWSManagedRulesBotControlRuleSet", "AWS", 0),
@@ -30,6 +33,9 @@ export function DefaultWafRules(): waf.CfnRuleGroup.RuleProperty[] {
   ] as waf.CfnWebACL.RuleProperty[];
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function wrapManagedRuleSet(managedGroupName: string, vendorName: string, priority: number) {
   return {
     name: `${vendorName}-${managedGroupName}`,
@@ -49,6 +55,9 @@ export function wrapManagedRuleSet(managedGroupName: string, vendorName: string,
   } as waf.CfnRuleGroup.RuleProperty;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function DefaultWafwebaclProps(webaclScope: string) {
   return {
     defaultAction: {

--- a/source/patterns/@aws-solutions-constructs/core/lib/waf-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/waf-helper.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+/*
+ *  The functions found here in the core library are for internal use and can be changed 
+ *  or removed outside of a major release. We recommend against calling them directly from client code.
+ */
+
 import { Construct } from "constructs";
 import * as waf from "aws-cdk-lib/aws-wafv2";
 import { DefaultWafwebaclProps } from "./waf-defaults";

--- a/source/patterns/@aws-solutions-constructs/core/lib/waf-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/waf-helper.ts
@@ -12,7 +12,7 @@
  */
 
 /*
- *  The functions found here in the core library are for internal use and can be changed 
+ *  The functions found here in the core library are for internal use and can be changed
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
@@ -32,6 +32,9 @@ export interface BuildWebaclProps {
   readonly webaclProps?: waf.CfnWebACLProps;
 }
 
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
 export function buildWebacl(scope: Construct, webaclScope: string, props: BuildWebaclProps): waf.CfnWebACL {
   let webAcl;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Internal core functions are not documented and can change outside the scope of a major release, so should not be used from outside without understanding the risk that they can change. This PR adds comments and JSDoc notices to that effect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.