### PR TITLE
fix(StepFunctions): Address LogGroup behavior problems

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/eventbridge-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/eventbridge-stepfunctions.test.ts
@@ -17,6 +17,7 @@ import { Duration } from 'aws-cdk-lib';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import '@aws-cdk/assert/jest';
 import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployNewStateMachine(stack: cdk.Stack) {
 
@@ -193,3 +194,27 @@ test('check custom event bus resource with props when deploy:true', () => {
     Name: 'testcustomeventbus'
   });
 });
+
+test('check LogGroup name', () => {
+  const stack = new cdk.Stack();
+
+  deployNewStateMachine(stack);
+
+  // Perform some fancy stuff to examine the specifics of the LogGroupName
+  const expectedPrefix = '/aws/vendedlogs/states/constructs/';
+  const lengthOfDatetimeSuffix = 13;
+
+  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+
+  const logName = LogGroup.testeventbridgestepfunctionsStateMachineLogGroup826A5B74.Properties.LogGroupName;
+  const suffix = logName.slice(-lengthOfDatetimeSuffix);
+
+  // Look for the expected Prefix and the 13 digit time suffix
+  expect(logName.slice(0, expectedPrefix.length)).toEqual(expectedPrefix);
+  expect(IsWholeNumber(suffix)).not.toBe(false);
+});
+
+function IsWholeNumber(target: string): boolean {
+  const numberPattern = /[0-9]{13}/;
+  return target.match(numberPattern) !== null;
+}

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-existing-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-existing-eventbus.expected.json
@@ -147,7 +147,7 @@
     "testeventbridgestepfunctionsneweventbusconstructStateMachineLogGroup6DC6AD59": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventbridgestepfunctionsexistingeventbustesteventbridgestepfunctionsneweventbusconstructstatemachinelogac9442d7e2fa"
+        "LogGroupName": "integ-test-existing-eventbus"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-existing-eventbus.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-existing-eventbus.ts
@@ -50,7 +50,8 @@ const props: EventbridgeToStepfunctionsProps = {
   },
   existingEventBusInterface: existingEventBus,
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "integ-test-existing-eventbus"
   },
 };
 

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-new-eventbus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-new-eventbus.expected.json
@@ -141,7 +141,7 @@
     "testeventbridgestepfunctionsneweventbusconstructStateMachineLogGroup6DC6AD59": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventbridgestepfunctionsneweventbustesteventbridgestepfunctionsneweventbusconstructstatemachinelog651032919fdf"
+        "LogGroupName": "integ-test-new-eventbus"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-new-eventbus.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-new-eventbus.ts
@@ -48,7 +48,8 @@ const props: EventbridgeToStepfunctionsProps = {
   },
   eventBusProps: { eventBusName: 'test' },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "integ-test-new-eventbus"
   },
 };
 

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-no-argument.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-no-argument.expected.json
@@ -3,7 +3,7 @@
     "testeventbridgestepfunctionsconstructStateMachineLogGroup3098B32C": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventbridgestepfunctionsnoargumenttesteventbridgestepfunctionsconstructstatemachinelog56559569213c"
+        "LogGroupName": "integ-test-no-arguments"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-no-argument.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-no-argument.ts
@@ -32,7 +32,8 @@ const props: EventbridgeToStepfunctionsProps = {
     schedule: events.Schedule.rate(Duration.minutes(5))
   },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "integ-test-no-arguments"
   },
 };
 

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-with-lambda.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-with-lambda.expected.json
@@ -141,7 +141,7 @@
     "testeventbridgestepfunctionsandlambdaconstructStateMachineLogGroup7C2D036A": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/eventbridgestepfunctionswithlambdatesteventbridgestepfunctionsandlambdaconstructstatemachinelog1db1bc901e42"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-with-lambda.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.eventbridge-stepfunctions-with-lambda.ts
@@ -46,7 +46,8 @@ const props: EventbridgeToStepfunctionsProps = {
     schedule: events.Schedule.rate(Duration.minutes(5))
   },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
   },
 };
 

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/fargate-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/fargate-stepfunctions.test.ts
@@ -18,6 +18,7 @@ import { FargateToStepfunctions } from "../lib";
 import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Template } from 'aws-cdk-lib/assertions';
 
 const clusterName = "custom-cluster-name";
 const containerName = "custom-container-name";
@@ -311,4 +312,29 @@ function testStateMachineProps(stack: cdk.Stack, userProps?: stepfunctions.State
   const defaultTestProp = { definition: new stepfunctions.Pass(stack, 'StartState') };
 
   return defaults.consolidateProps(defaultTestProp, userProps);
+}
+
+test('check LogGroup name', () => {
+  const stack = new cdk.Stack();
+  const publicApi = true;
+
+  createFargateConstructWithNewResources(stack, publicApi);
+
+  // Perform some fancy stuff to examine the specifics of the LogGroupName
+  const expectedPrefix = '/aws/vendedlogs/states/constructs/';
+  const lengthOfDatetimeSuffix = 13;
+
+  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+
+  const logName = LogGroup.testconstructStateMachineLogGroup2EB4F48B.Properties.LogGroupName;
+  const suffix = logName.slice(-lengthOfDatetimeSuffix);
+
+  // Look for the expected Prefix and the 13 digit time suffix
+  expect(logName.slice(0, expectedPrefix.length)).toEqual(expectedPrefix);
+  expect(IsWholeNumber(suffix)).not.toBe(false);
+});
+
+function IsWholeNumber(target: string): boolean {
+  const numberPattern = /[0-9]{13}/;
+  return target.match(numberPattern) !== null;
 }

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.new-resources.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.new-resources.expected.json
@@ -1076,7 +1076,7 @@
     "testconstructStateMachineLogGroup2EB4F48B": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/newresourcestestconstructstatemachinelog63b3cb15f80b"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.new-resources.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.new-resources.ts
@@ -49,7 +49,8 @@ const constructProps: FargateToStepfunctionsProps = {
   existingFargateServiceObject: createFargateServiceResponse.service,
   stateMachineEnvironmentVariableName: 'CUSTOM_NAME',
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
   }
 };
 

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.no-cloudwatch-alarms.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.no-cloudwatch-alarms.expected.json
@@ -1076,7 +1076,7 @@
     "testconstructStateMachineLogGroup2EB4F48B": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/nocloudwatchalarmstestconstructstatemachinelogdbb9902b27ea"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.no-cloudwatch-alarms.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.no-cloudwatch-alarms.ts
@@ -49,7 +49,8 @@ const constructProps: FargateToStepfunctionsProps = {
   existingFargateServiceObject: createFargateServiceResponse.service,
   createCloudWatchAlarms: false,
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
   }
 };
 

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deploy-lambda.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deploy-lambda.expected.json
@@ -3,7 +3,7 @@
     "testlambdastepfunctionsconstructStateMachineLogGroup1FD4C0D4": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/deploylambdatestlambdastepfunctionsconstructstatemachinelogb258d52dbe27"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deploy-lambda.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deploy-lambda.ts
@@ -36,8 +36,9 @@ const props: LambdaToStepfunctionsProps = {
     definition: startState
   },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
-  },
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
+  }
 };
 
 // Add the pattern

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deployFunctionWithVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deployFunctionWithVpc.expected.json
@@ -4,7 +4,7 @@
     "testlambdastepfunctionsStateMachineLogGroupD3F22A89": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/deployfunctionwithvpctestlambdastepfunctionsstatemachinelog97398dca7a29"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deployFunctionWithVpc.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.deployFunctionWithVpc.ts
@@ -36,10 +36,11 @@ const props: LambdaToStepfunctionsProps = {
   stateMachineProps: {
     definition: startState
   },
-  logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
-  },
   deployVpc: true,
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
+  }
 };
 
 new LambdaToStepfunctions(stack, "test-lambda-stepfunctions", props);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.existing-function.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.existing-function.expected.json
@@ -151,7 +151,7 @@
     "testlambdastepfunctionsconstructStateMachineLogGroup1FD4C0D4": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/existingfunctiontestlambdastepfunctionsconstructstatemachinelog9e0bca5b4cd6"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.existing-function.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.existing-function.ts
@@ -43,8 +43,9 @@ const props: LambdaToStepfunctionsProps = {
     definition: startState
   },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
-  },
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
+  }
 };
 
 // Add the pattern

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-stepfunctions.test.ts
@@ -19,6 +19,7 @@ import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LambdaToStepfunctions } from '../lib';
 import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
 
 // --------------------------------------------------------------
 // Test deployment with new Lambda function
@@ -462,3 +463,40 @@ test("Test bad call with existingVpc and deployVpc", () => {
   // Assertion
   expect(app).toThrowError();
 });
+
+test('check LogGroup name', () => {
+  // Stack
+  const stack = new Stack();
+  // Helper declaration
+  const startState = new stepfunctions.Pass(stack, 'StartState');
+  new LambdaToStepfunctions(stack, 'lambda-to-step-function-stack', {
+    lambdaFunctionProps: {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+      environment: {
+        LAMBDA_NAME: 'existing-function'
+      }
+    },
+    stateMachineProps: {
+      definition: startState
+    }
+  });
+  // Perform some fancy stuff to examine the specifics of the LogGroupName
+  const expectedPrefix = '/aws/vendedlogs/states/constructs/';
+  const lengthOfDatetimeSuffix = 13;
+
+  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+
+  const logName = LogGroup.lambdatostepfunctionstackStateMachineLogGroupEAD4854E.Properties.LogGroupName;
+  const suffix = logName.slice(-lengthOfDatetimeSuffix);
+
+  // Look for the expected Prefix and the 13 digit time suffix
+  expect(logName.slice(0, expectedPrefix.length)).toEqual(expectedPrefix);
+  expect(IsWholeNumber(suffix)).not.toBe(false);
+});
+
+function IsWholeNumber(target: string): boolean {
+  const numberPattern = /[0-9]{13}/;
+  return target.match(numberPattern) !== null;
+}

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.customLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.customLoggingBucket.expected.json
@@ -195,7 +195,7 @@
     "tests3stepfunctionstests3stepfunctionseventrulestepfunctionconstructStateMachineLogGroupB4555776": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/customloggingbuckettests3stepfunctionseventrulestepfunctionconstructstatemachineloga4e9bc58c9e9"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.customLoggingBucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.customLoggingBucket.ts
@@ -39,7 +39,8 @@ new S3ToStepfunctions(stack, 'test-s3-stepfunctions', {
     versioned: true
   },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
   }
 });
 

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.pre-existing-bucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.pre-existing-bucket.expected.json
@@ -160,7 +160,7 @@
     "tests3stepfunctionspreexistingbucketconstructtests3stepfunctionspreexistingbucketconstructeventrulestepfunctionconstructStateMachineLogGroup9D5E3E4D": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/preexistingbuckettests3stepfunctionspreexistingbucketconstructeventrulestepfunctstatemachineloga29d0790019e"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.pre-existing-bucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.pre-existing-bucket.ts
@@ -32,7 +32,8 @@ const props: S3ToStepfunctionsProps = {
     definition: startState
   },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
   },
   logS3AccessLogs: false
 };

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3-stepfunctions-no-argument.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3-stepfunctions-no-argument.expected.json
@@ -116,7 +116,7 @@
     "tests3stepfunctionsconstructtests3stepfunctionsconstructeventrulestepfunctionconstructStateMachineLogGroupE86C2CF5": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/s3stepfunctionsnoargumenttests3stepfunctionsconstructeventrulestepfunctionconstructstatemachinelogf07752992857"
+        "LogGroupName": "with-lambda"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3-stepfunctions-no-argument.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3-stepfunctions-no-argument.ts
@@ -32,7 +32,8 @@ const props: S3ToStepfunctionsProps = {
     removalPolicy: RemovalPolicy.DESTROY,
   },
   logGroupProps: {
-    removalPolicy: RemovalPolicy.DESTROY
+    removalPolicy: RemovalPolicy.DESTROY,
+    logGroupName: "with-lambda"
   },
   logS3AccessLogs: false
 };

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/s3-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/s3-stepfunctions.test.ts
@@ -16,6 +16,7 @@ import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import '@aws-cdk/assert/jest';
 import * as cdk from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployNewStateMachine(stack: cdk.Stack) {
 
@@ -187,3 +188,27 @@ test('s3 bucket with no logging bucket', () => {
   expect(stack).toHaveResource("Custom::S3BucketNotifications", {});
   expect(construct.s3LoggingBucket).toEqual(undefined);
 });
+
+test('check LogGroup name', () => {
+  const stack = new cdk.Stack();
+
+  deployNewStateMachine(stack);
+
+  // Perform some fancy stuff to examine the specifics of the LogGroupName
+  const expectedPrefix = '/aws/vendedlogs/states/constructs/';
+  const lengthOfDatetimeSuffix = 13;
+
+  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+
+  const logName = LogGroup.tests3stepfunctionstests3stepfunctionseventrulestepfunctionconstructStateMachineLogGroupB4555776.Properties.LogGroupName;
+  const suffix = logName.slice(-lengthOfDatetimeSuffix);
+
+  // Look for the expected Prefix and the 13 digit time suffix
+  expect(logName.slice(0, expectedPrefix.length)).toEqual(expectedPrefix);
+  expect(IsWholeNumber(suffix)).not.toBe(false);
+});
+
+function IsWholeNumber(target: string): boolean {
+  const numberPattern = /[0-9]{13}/;
+  return target.match(numberPattern) !== null;
+}

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudwatch-log-group-helper.ts
@@ -26,19 +26,19 @@ import { Construct } from 'constructs';
  * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
 export function buildLogGroup(scope: Construct, logGroupId?: string, logGroupProps?: logs.LogGroupProps): logs.LogGroup {
-  let _logGroupProps: logs.LogGroupProps;
+  let consolidatedLogGroupProps: logs.LogGroupProps;
 
   // Override user provided CW LogGroup props with the DefaultLogGroupProps
-  _logGroupProps = consolidateProps(DefaultLogGroupProps(), logGroupProps);
+  consolidatedLogGroupProps = consolidateProps(DefaultLogGroupProps(), logGroupProps);
 
   // Set the LogGroup Id
-  const _logGroupId = logGroupId ? logGroupId : 'CloudWatchLogGroup';
+  const adjustedLogGroupId = logGroupId ? logGroupId : 'CloudWatchLogGroup';
 
   // Create the CW Log Group
-  const logGroup = new logs.LogGroup(scope, _logGroupId, _logGroupProps);
+  const logGroup = new logs.LogGroup(scope, adjustedLogGroupId, consolidatedLogGroupProps);
 
   // If required, suppress the Cfn Nag WARNINGS
-  if (_logGroupProps.retention === logs.RetentionDays.INFINITE) {
+  if (consolidatedLogGroupProps.retention === logs.RetentionDays.INFINITE) {
     addCfnSuppressRules( logGroup, [
       {
         id: 'W86',
@@ -47,7 +47,7 @@ export function buildLogGroup(scope: Construct, logGroupId?: string, logGroupPro
     ]);
   }
 
-  if (!_logGroupProps.encryptionKey) {
+  if (!consolidatedLogGroupProps.encryptionKey) {
     addCfnSuppressRules( logGroup, [
       {
         id: 'W84',

--- a/source/patterns/@aws-solutions-constructs/core/lib/utils.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/utils.ts
@@ -113,11 +113,13 @@ export function printWarning(message: string) {
  */
 export function generateResourceName(
   parts: string[],
-  maxLength: number
+  maxLength: number,
+  randomize: boolean = false
 ): string {
   const hashLength = 12;
+  const randomizor: string = randomize ? (new Date()).getTime().toString() : "";
 
-  const maxPartLength = Math.floor( (maxLength -  hashLength) / parts.length);
+  const maxPartLength = Math.floor( (maxLength -  hashLength - randomizor.length) / parts.length);
 
   const sha256 = crypto.createHash("sha256");
   let finalName: string = '';
@@ -129,6 +131,7 @@ export function generateResourceName(
 
   const hash = sha256.digest("hex").slice(0, hashLength);
   finalName += hash;
+  finalName += randomizor;
   return finalName.toLowerCase();
 }
 

--- a/source/patterns/@aws-solutions-constructs/core/test/step-function-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/step-function-helper.test.ts
@@ -12,15 +12,14 @@
  */
 
 // Imports
-import { Stack } from "aws-cdk-lib";
+import { Stack, Aws } from "aws-cdk-lib";
 import * as defaults from '../';
 import '@aws-cdk/assert/jest';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import { buildLogGroup } from '../lib/cloudwatch-log-group-helper';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Template } from 'aws-cdk-lib/assertions';
 
-// --------------------------------------------------------------
-// Test deployment w/ custom properties
-// --------------------------------------------------------------
 test('Test deployment w/ custom properties', () => {
   // Stack
   const stack = new Stack();
@@ -33,7 +32,6 @@ test('Test deployment w/ custom properties', () => {
   });
   // Assertion
   expect(buildStateMachineResponse.stateMachine).toBeDefined();
-  expect(buildStateMachineResponse.stateMachine).toBeDefined();
   expect(stack).toCountResources("AWS::Logs::LogGroup", 1);
 
   expect(stack).toHaveResource("AWS::StepFunctions::StateMachine", {
@@ -41,9 +39,6 @@ test('Test deployment w/ custom properties', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Test deployment w/ logging enabled
-// --------------------------------------------------------------
 test('Test deployment w/ logging enabled', () => {
   // Stack
   const stack = new Stack();
@@ -83,9 +78,6 @@ test('Test deployment w/ logging enabled', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Check default Cloudwatch permissions
-// --------------------------------------------------------------
 test('Check default Cloudwatch permissions', () => {
   // Stack
   const stack = new Stack();
@@ -146,9 +138,6 @@ test('Check default Cloudwatch permissions', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Check CW Alarms
-// --------------------------------------------------------------
 test('Count State Machine CW Alarms', () => {
   // Stack
   const stack = new Stack();
@@ -164,3 +153,74 @@ test('Count State Machine CW Alarms', () => {
 
   expect(cwList.length).toEqual(3);
 });
+
+test('Test deployment with custom role', () => {
+  const descriptionText = 'Custom role for State Machine';
+
+  // Stack
+  const stack = new Stack();
+  // Step function definition
+  const startState = new sfn.Pass(stack, 'StartState');
+
+  const customRole = new iam.Role(stack, 'custom-role', {
+    assumedBy: new iam.ServicePrincipal('states.amazonaws.com'),
+    description: descriptionText,
+    inlinePolicies: {
+      InvokePolicy: new iam.PolicyDocument({
+        statements: [new iam.PolicyStatement({
+          resources: [`arn:${Aws.PARTITION}:s3:${Aws.REGION}:${Aws.ACCOUNT_ID}:*`],
+          actions: ['s3:ListBucket']
+        })]
+      })
+    }
+  });
+
+  // Build state machine
+  const buildStateMachineResponse = defaults.buildStateMachine(stack, {
+    definition: startState,
+    role: customRole
+  });
+
+  // Assertion
+  expect(stack).toCountResources("AWS::IAM::Role", 1);
+  expect(buildStateMachineResponse.stateMachine).toBeDefined();
+
+  expect(stack).toHaveResource("AWS::IAM::Role", {
+    Description: descriptionText
+  });
+});
+
+test('Confirm format of name', () => {
+  // Stack
+  const stack = new Stack();
+  // Step function definition
+  const startState = new sfn.Pass(stack, 'StartState');
+  // Build state machine
+  const buildStateMachineResponse = defaults.buildStateMachine(stack, {
+    stateMachineName: 'myStateMachine',
+    definition: startState,
+  });
+  // Assertion
+  expect(buildStateMachineResponse.stateMachine).toBeDefined();
+
+  expect(stack).toHaveResource("AWS::StepFunctions::StateMachine", {
+    StateMachineName: "myStateMachine"
+  });
+
+  // Perform some fancy stuff to examine the specifics of the LogGroupName
+  const expectedPrefix = '/aws/vendedlogs/states/constructs/';
+  const lengthOfDatetimeSuffix = 13;
+
+  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+  const logName = LogGroup.StateMachineLogGroup15B91BCB.Properties.LogGroupName;
+  const suffix = logName.slice(-lengthOfDatetimeSuffix);
+
+  // Look for the expected Prefix and the 13 digit time suffix
+  expect(logName.slice(0, expectedPrefix.length)).toEqual(expectedPrefix);
+  expect(IsWholeNumber(suffix)).not.toBe(false);
+});
+
+function IsWholeNumber(target: string): boolean {
+  const numberPattern = /[0-9]{13}/;
+  return target.match(numberPattern) !== null;
+}

--- a/source/patterns/@aws-solutions-constructs/core/test/utils.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/utils.test.ts
@@ -20,10 +20,7 @@ import * as cdk from 'aws-cdk-lib';
 const parts = [ 'firstportionislong', 'secondsection'];
 const nonAlphaParts = [ 'part-one', 'part-two'];
 
-// --------------------------------------------------------------
-// Test with a truncated part
-// --------------------------------------------------------------
-test('Test with a truncated part', () => {
+test('Test generateResourceName with a truncated part', () => {
   const result = defaults.generateResourceName(parts, 38);
 
   expect(result).toContain(parts[1]);
@@ -32,10 +29,7 @@ test('Test with a truncated part', () => {
 
 });
 
-// --------------------------------------------------------------
-// Test with no truncated parts
-// --------------------------------------------------------------
-test('Test with no truncated parts', () => {
+test('Test generateResourceName with no truncated parts', () => {
   const result = defaults.generateResourceName(parts, 100);
 
   expect(result).toContain(parts[1]);
@@ -43,13 +37,34 @@ test('Test with no truncated parts', () => {
   expect(result.length).toEqual(parts[0].length + parts[1].length + 12);
 });
 
-// --------------------------------------------------------------
-// Test with non Aphanumeric
-// --------------------------------------------------------------
-test('Test with non Aphanumeric', () => {
+test('Test generateResourceName with non Aphanumeric', () => {
   const result = defaults.generateResourceName(nonAlphaParts, 100);
 
   expect(result).toContain('partoneparttwo');
+});
+
+// --------------------------------------------------------------
+// Test with no truncated parts
+// --------------------------------------------------------------
+test('Test generateResourceName with randomized extension', () => {
+  const resultOne = defaults.generateResourceName(parts, 512, true);
+  const startTime = (new Date()).getTime();
+
+  // We need to ensure the time value appended changes between callls
+  let currTime = startTime;
+  while (currTime  === startTime) {
+    currTime = (new Date()).getTime();
+  }
+
+  const resultTwo = defaults.generateResourceName(parts, 512, true);
+
+  expect(resultOne).toContain(parts[1]);
+  expect(resultOne).toContain(parts[0]);
+  expect(resultTwo).toContain(parts[1]);
+  expect(resultTwo).toContain(parts[0]);
+  expect(resultOne).not.toEqual(resultTwo);
+  expect(resultOne.slice(0, -13)).toEqual(resultTwo.slice(0, -13));
+
 });
 
 // --------------------------------------------------------------

--- a/source/patterns/@aws-solutions-constructs/core/test/utils.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/utils.test.ts
@@ -43,9 +43,6 @@ test('Test generateResourceName with non Aphanumeric', () => {
   expect(result).toContain('partoneparttwo');
 });
 
-// --------------------------------------------------------------
-// Test with no truncated parts
-// --------------------------------------------------------------
 test('Test generateResourceName with randomized extension', () => {
   const resultOne = defaults.generateResourceName(parts, 512, true);
   const startTime = (new Date()).getTime();
@@ -67,9 +64,6 @@ test('Test generateResourceName with randomized extension', () => {
 
 });
 
-// --------------------------------------------------------------
-// Test generateIntegStackName
-// --------------------------------------------------------------
 test('Test generateIntegStackName', () => {
   const result = defaults.generateIntegStackName('integ.apigateway-dynamodb-CRUD.js');
   expect(result).toContain('apigateway-dynamodb-CRUD');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Constructs takes control of the physical name of LogGroups to add the /aws/vendedlogs/ prefix, thereby avoiding the Resource Policy size limitations. But this leads to problems when a stack is deployed, destroyed and deployed again - the LogGroup with the fixed name is not destroyed, so a resource exists error is generated.

This PR adds a random suffix to the LogGroup physical name, so that two launches of the stack get different names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.