### PR TITLE
fix(cloudfront-to-s3): Set s3LoggingBucket property

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/lib/index.ts
@@ -117,6 +117,7 @@ export class CloudFrontToS3 extends Construct {
         logS3AccessLogs: props.logS3AccessLogs
       });
       this.s3Bucket = buildS3BucketResponse.bucket;
+      this.s3LoggingBucket = buildS3BucketResponse.loggingBucket;
       bucket = this.s3Bucket;
     } else {
       bucket = props.existingBucketObj;

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -28,6 +28,18 @@ function deploy(stack: cdk.Stack, props?: CloudFrontToS3Props) {
   });
 }
 
+test('construct defaults set properties correctly', () => {
+  const stack = new cdk.Stack();
+  const construct = new CloudFrontToS3(stack, 'test-cloudfront-s3', {});
+
+  expect(construct.cloudFrontWebDistribution).toBeDefined();
+  expect(construct.cloudFrontFunction).toBeDefined();
+  expect(construct.cloudFrontLoggingBucket).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
+  expect(construct.s3LoggingBucket).toBeDefined();
+  expect(construct.s3BucketInterface).toBeDefined();
+});
+
 test('check s3Bucket default encryption', () => {
   const stack = new cdk.Stack();
   deploy(stack);


### PR DESCRIPTION
This PR updates the `cloudfront-to-s3` construct to properly set the `s3LoggingBucket` property with the value returned from the `buildS3Bucket` call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.