### PR TITLE
chore(assertion): migrate all tests to assertions library

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/alb-fargate.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/alb-fargate.test.ts
@@ -12,12 +12,11 @@
  */
 
 import { AlbToFargate, AlbToFargateProps } from "../lib";
-// import * as ecs from '@aws-cdk/aws-ecs';
 import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Template } from "aws-cdk-lib/assertions";
 
 test('Test new vpc, load balancer, service', () => {
   // An environment with region is required to enable logging on an ALB
@@ -34,16 +33,17 @@ test('Test new vpc, load balancer, service', () => {
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE'
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     CidrBlock: '10.0.0.0/16',
   });
@@ -64,17 +64,18 @@ test('Test new load balancer, service, existing vpc', () => {
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE'
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     CidrBlock: '172.168.0.0/16'
   });
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
 });
 
 test('Test new service, existing load balancer, vpc', () => {
@@ -103,23 +104,24 @@ test('Test new service, existing load balancer, vpc', () => {
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE'
   });
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::Listener', 1);
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::Listener', 1);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Name: testName
   });
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     CidrBlock: '172.168.0.0/16'
   });
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
 });
 
 test('Test existing load balancer, vpc, service', () => {
@@ -155,23 +157,24 @@ test('Test existing load balancer, vpc, service', () => {
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE'
   });
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::Listener', 1);
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::Listener', 1);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Name: testName
   });
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     CidrBlock: '172.168.0.0/16'
   });
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
 });
 
 test('Test add a second target with rules', () => {
@@ -203,15 +206,16 @@ test('Test add a second target with rules', () => {
 
   new AlbToFargate(stack, 'test-two-construct', testPropsTwo);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE'
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::TargetGroup', 2);
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::ListenerRule', 1);
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::ListenerRule', {
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::TargetGroup', 2);
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::ListenerRule', 1);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerRule', {
     Conditions: [
       {
         Field: "path-pattern",
@@ -223,11 +227,11 @@ test('Test add a second target with rules', () => {
       }
     ],
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     CidrBlock: '172.168.0.0/16'
   });
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
 });
 
 test('Test new vpc, load balancer, service - custom Service Props', () => {
@@ -249,17 +253,18 @@ test('Test new vpc, load balancer, service - custom Service Props', () => {
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     ServiceName: serviceName,
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true
   });
 });
@@ -281,16 +286,17 @@ test('Test new vpc, load balancer, service - custom VPC Props', () => {
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     CidrBlock: testCidr,
   });
@@ -319,22 +325,23 @@ test('Test new vpc, load balancer, service - custom LoadBalancer and targetGroup
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Name: testLoadBalancerName
   });
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     Name: testTargetGroupName
   });
 });
@@ -356,10 +363,11 @@ test('Test HTTPS API with new vpc, load balancer, service', () => {
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE'
   });
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP',
     DefaultActions: [
       {
@@ -372,11 +380,11 @@ test('Test HTTPS API with new vpc, load balancer, service', () => {
       }
     ],
   });
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS',
     Port: 443,
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true
   });
 });
@@ -398,10 +406,11 @@ test('Test HTTPS API with new vpc, load balancer, service and private API', () =
 
   new AlbToFargate(stack, 'test-construct', testProps);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE'
   });
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP',
     DefaultActions: [
       {
@@ -414,15 +423,15 @@ test('Test HTTPS API with new vpc, load balancer, service and private API', () =
       }
     ],
   });
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS',
     Port: 443,
   });
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
   });
-  expect(stack).toCountResources("AWS::EC2::Subnet", 3);
-  expect(stack).toHaveResource("AWS::EC2::Subnet", {
+  template.resourceCountIs("AWS::EC2::Subnet", 3);
+  template.hasResourceProperties("AWS::EC2::Subnet", {
     Tags: [
       {
         Key: "aws-cdk:subnet-name",
@@ -438,7 +447,7 @@ test('Test HTTPS API with new vpc, load balancer, service and private API', () =
       }
     ]
   });
-  expect(stack).not.toHaveResource("AWS::EC2::Subnet", {
+  defaults.expectNonexistence(stack, "AWS::EC2::Subnet", {
     Tags: [
       {
         Key: "aws-cdk:subnet-name",

--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/test/alb-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/test/alb-lambda.test.ts
@@ -15,8 +15,8 @@ import { AlbToLambda, AlbToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
 import * as defaults from '@aws-solutions-constructs/core';
+import { Template } from 'aws-cdk-lib/assertions';
 
 test('Test new load balancer and new lambda function', () => {
   const stack = new cdk.Stack(undefined, undefined, {
@@ -36,7 +36,8 @@ test('Test new load balancer and new lambda function', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing',
     LoadBalancerAttributes: [
       {
@@ -60,19 +61,19 @@ test('Test new load balancer and new lambda function', () => {
     ],
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
 });
@@ -95,26 +96,27 @@ test('Test new load balancer and new lambda function for HTTP api', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toCountResources('AWS::Lambda::Function', 1);
+  template.resourceCountIs('AWS::Lambda::Function', 1);
 
 });
 
@@ -145,23 +147,24 @@ test('Test existing load balancer and new lambda function', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toCountResources('AWS::Lambda::Function', 1);
+  template.resourceCountIs('AWS::Lambda::Function', 1);
 
-  expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+  template.hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
     Scheme: "internet-facing",
   });
 });
@@ -193,26 +196,27 @@ test('Test new load balancer and existing lambda function', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: testFunctionName
   });
 
@@ -250,28 +254,29 @@ test("Test existing load balancer and existing lambda function", () => {
   };
   new AlbToLambda(stack, "test-one", props);
 
-  expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
     Scheme: "internal",
   });
 
-  expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::Listener", {
+  template.hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
     Protocol: "HTTP",
   });
 
-  expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::Listener", {
+  template.hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
     Protocol: "HTTPS",
   });
 
-  expect(stack).toHaveResource(
+  template.hasResourceProperties(
     "AWS::ElasticLoadBalancingV2::ListenerCertificate",
     {}
   );
 
-  expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+  template.hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
     TargetType: "lambda",
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     FunctionName: testFunctionName,
   });
 });
@@ -297,30 +302,31 @@ test('Test new load balancer and new lambda function', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: testFunctionName
   });
 
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
 
 });
 
@@ -358,28 +364,29 @@ test('Test HTTPS adding 2 lambda targets, second with rules', () => {
   };
   new AlbToLambda(stack, 'test-two', secondProps);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::TargetGroup', 2);
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::TargetGroup', 2);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerRule', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerRule', {
     Conditions: [
       {
         Field: "path-pattern",
@@ -427,28 +434,29 @@ test('Test HTTP adding 2 lambda targets, second with rules', () => {
   };
   new AlbToLambda(stack, 'test-two', secondProps);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toCountResources('AWS::ElasticLoadBalancingV2::TargetGroup', 2);
+  template.resourceCountIs('AWS::ElasticLoadBalancingV2::TargetGroup', 2);
 
-  expect(stack).not.toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  defaults.expectNonexistence(stack, 'AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerRule', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerRule', {
     Conditions: [
       {
         Field: "path-pattern",
@@ -483,24 +491,25 @@ test('Test new load balancer and new lambda function', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda',
     Name: 'different-name'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 });
 
@@ -526,7 +535,8 @@ test('Test logging turned off', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).not.toHaveResource('AWS::S3::Bucket', {});
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::S3::Bucket', 0);
 
 });
 
@@ -576,24 +586,25 @@ test('Test custom ALB properties', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing',
     Name: 'custom-name',
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
 });
@@ -619,26 +630,27 @@ test('Test custom logging bucket', () => {
   };
   new AlbToLambda(stack, 'test-one', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing',
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTP'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::Listener', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
     Protocol: 'HTTPS'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::TargetGroup', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
     TargetType: 'lambda'
   });
 
-  expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::ListenerCertificate', {
   });
 
-  expect(stack).toHaveResource('AWS::S3::Bucket', {
+  template.hasResourceProperties('AWS::S3::Bucket', {
     BucketName: 'custom-name'
   });
 

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
@@ -17,6 +17,7 @@ import { ApiGatewayToDynamoDB, ApiGatewayToDynamoDBProps } from "../lib";
 import "@aws-cdk/assert/jest";
 import * as ddb from "aws-cdk-lib/aws-dynamodb";
 import * as api from "aws-cdk-lib/aws-apigateway";
+import { Template } from "aws-cdk-lib/assertions";
 
 test("check properties", () => {
   const stack = new Stack();
@@ -42,7 +43,8 @@ test("check allow CRUD operations", () => {
   };
   new ApiGatewayToDynamoDB(stack, "test-api-gateway-dynamodb", apiGatewayToDynamoDBProps);
 
-  expect(stack).toHaveResource("AWS::IAM::Policy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -84,27 +86,27 @@ test("check allow CRUD operations", () => {
     ],
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Method", {
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "GET",
     AuthorizationType: "AWS_IAM",
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Method", {
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "POST",
     AuthorizationType: "AWS_IAM",
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Method", {
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "PUT",
     AuthorizationType: "AWS_IAM",
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Method", {
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "DELETE",
     AuthorizationType: "AWS_IAM",
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Resource", {
+  template.hasResourceProperties("AWS::ApiGateway::Resource", {
     PathPart: "{id}",
   });
 });
@@ -117,7 +119,8 @@ test("check allow read and update only", () => {
   };
   new ApiGatewayToDynamoDB(stack, "test-api-gateway-dynamodb", apiGatewayToDynamoDBProps);
 
-  expect(stack).toHaveResource("AWS::IAM::Policy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -145,7 +148,7 @@ test("check allow read and update only", () => {
     ],
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Method", {
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "GET",
     AuthorizationType: "AWS_IAM",
   });
@@ -163,7 +166,8 @@ test("check using custom partition key for dynamodb", () => {
   };
   new ApiGatewayToDynamoDB(stack, "test-api-gateway-dynamodb", apiGatewayToDynamoDBProps);
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Resource", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::Resource", {
     PathPart: "{page_id}",
   });
 });
@@ -177,7 +181,8 @@ test("override apiGatewayProps for api gateway", () => {
   };
   new ApiGatewayToDynamoDB(stack, "test-api-gateway-dynamodb", apiGatewayToDynamoDBProps);
 
-  expect(stack).toHaveResource("AWS::ApiGateway::RestApi", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::RestApi", {
     Description: "This is a sample description for api gateway",
   });
 });
@@ -192,7 +197,8 @@ test("Test deployment ApiGateway AuthorizationType override", () => {
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::Method", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "GET",
     AuthorizationType: "NONE",
   });
@@ -216,16 +222,17 @@ test("Test deployment with existing DynamoDB table", () => {
   };
   new ApiGatewayToDynamoDB(stack, "test-api-gateway-dynamodb-default", apiGatewayToDynamoDBProps);
   // Confirm there is only the one table
-  expect(stack).toCountResources("AWS::DynamoDB::Table", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::DynamoDB::Table", 1);
 
   // Confirm that the one table is the one create here
-  expect(stack).toHaveResourceLike("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     ProvisionedThroughput: {
       ReadCapacityUnits: oddReadCapacity,
     }
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Resource", {
+  template.hasResourceProperties("AWS::ApiGateway::Resource", {
     PathPart: `{${oddPartitionKeyName}}`,
   });
 });
@@ -239,7 +246,7 @@ test("check setting allowReadOperation=false for dynamodb", () => {
   });
 
   // Expect two APIG Methods (GET, DELETE) for allowReadOperation and allowDeleteOperation
-  expect(stack1).toCountResources("AWS::ApiGateway::Method", 2);
+  Template.fromStack(stack1).resourceCountIs("AWS::ApiGateway::Method", 2);
 
   const stack2 = new Stack();
 
@@ -249,7 +256,7 @@ test("check setting allowReadOperation=false for dynamodb", () => {
   });
 
   // Expect only one APIG Method (DELETE) for allowDeleteOperation
-  expect(stack2).toCountResources("AWS::ApiGateway::Method", 1);
+  Template.fromStack(stack2).resourceCountIs("AWS::ApiGateway::Method", 1);
 });
 
 test('Construct can override default create request template type', () => {
@@ -259,7 +266,8 @@ test('Construct can override default create request template type', () => {
     createRequestTemplate: 'ok',
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       RequestTemplates: {
@@ -276,7 +284,8 @@ test('Construct can override default read request template type', () => {
     readRequestTemplate: 'ok',
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
     Integration: {
       RequestTemplates: {
@@ -293,7 +302,8 @@ test('Construct can override default update request template type', () => {
     updateRequestTemplate: 'ok',
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'PUT',
     Integration: {
       RequestTemplates: {
@@ -310,7 +320,8 @@ test('Construct can override default delete request template type', () => {
     deleteRequestTemplate: 'ok',
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'DELETE',
     Integration: {
       RequestTemplates: {
@@ -330,7 +341,8 @@ test('Construct accepts additional create request templates', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       RequestTemplates: {
@@ -350,7 +362,8 @@ test('Construct accepts additional read request templates', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
     Integration: {
       RequestTemplates: {
@@ -370,7 +383,8 @@ test('Construct accepts additional update request templates', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'PUT',
     Integration: {
       RequestTemplates: {
@@ -390,7 +404,8 @@ test('Construct accepts additional delete request templates', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'DELETE',
     Integration: {
       RequestTemplates: {
@@ -406,7 +421,8 @@ test('Construct can customize the api resourceName', () => {
     resourceName: 'my-resource-name',
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::Resource", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::Resource", {
     PathPart: "{my-resource-name}",
   });
 });
@@ -422,7 +438,8 @@ test('Construct uses default integration responses', () => {
     updateRequestTemplate: 'update'
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       IntegrationResponses: [
@@ -440,7 +457,7 @@ test('Construct uses default integration responses', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
     Integration: {
       IntegrationResponses: [
@@ -458,7 +475,7 @@ test('Construct uses default integration responses', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'PUT',
     Integration: {
       IntegrationResponses: [
@@ -476,7 +493,7 @@ test('Construct uses default integration responses', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'DELETE',
     Integration: {
       IntegrationResponses: [
@@ -510,7 +527,8 @@ test('Construct uses custom createIntegrationResponses property', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       IntegrationResponses: [
@@ -539,7 +557,8 @@ test('Construct uses custom readIntegrationResponses property', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
     Integration: {
       IntegrationResponses: [
@@ -569,7 +588,8 @@ test('Construct uses custom updateIntegrationResponses property', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'PUT',
     Integration: {
       IntegrationResponses: [
@@ -598,7 +618,8 @@ test('Construct uses custom deleteIntegrationResponses property', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'DELETE',
     Integration: {
       IntegrationResponses: [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/test.apigateway-iot.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/test.apigateway-iot.test.ts
@@ -16,8 +16,7 @@ import * as cdk from "aws-cdk-lib";
 import { ApiGatewayToIot, ApiGatewayToIotProps } from "../lib";
 import * as api from 'aws-cdk-lib/aws-apigateway';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { ResourcePart } from '@aws-cdk/assert';
-import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
 
 // --------------------------------------------------------------
 // Check for ApiGateway params
@@ -47,7 +46,8 @@ test('Test for default IAM Role', () => {
   };
   new ApiGatewayToIot(stack, 'test-apigateway-iot-default-iam-role', props);
   // Check whether default IAM role is creted to access IoT core
-  expect(stack).toHaveResource("AWS::IAM::Role", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Role", {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -125,7 +125,8 @@ test('Test for default Params request validator', () => {
   };
   new ApiGatewayToIot(stack, 'test-apigateway-iot-request-validator', props);
   // Assertion
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::RequestValidator", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::RequestValidator", {
     ValidateRequestBody: false,
     ValidateRequestParameters: true,
   });
@@ -144,7 +145,8 @@ test('Test for default Params Integ Props and Method Props', () => {
 
   // Assertion for {topic-level-7} to ensure all Integration Request Params, Integration Responses,
   // Method Request Params and Method Reponses are intact
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::Method", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "POST",
     AuthorizationType: "AWS_IAM",
     Integration: {
@@ -254,7 +256,8 @@ test('Test for Binary Media types', () => {
   }
   );
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::RestApi", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::RestApi", {
     BinaryMediaTypes: [
       "application/octet-stream",
     ],
@@ -278,7 +281,8 @@ test('Test for Api Name and Desc', () => {
   }
   );
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::RestApi", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::RestApi", {
     Name: 'RestApi-Regional',
     Description: 'Description for the Regional Rest Api'
   });
@@ -327,7 +331,8 @@ test('Test for overriden IAM Role', () => {
 
   new ApiGatewayToIot(stack, 'test-apigateway-iot-overriden-iam-role', props);
   // Check whether default IAM role is creted to access IoT core
-  expect(stack).toHaveResource("AWS::IAM::Role", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Role", {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -411,7 +416,8 @@ test('Test for APi Key Source', () => {
   }
   );
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::RestApi", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::RestApi", {
     ApiKeySourceType: "AUTHORIZER"
   });
 });
@@ -429,7 +435,8 @@ test('Test for Api Key Creation', () => {
   new ApiGatewayToIot(stack, 'test-apigateway-iot-api-key', props);
 
   // Assertion to check for ApiKey
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::Method", {
+  const template = Template.fromStack(stack);
+  template.hasResource("AWS::ApiGateway::Method", {
     Properties : {
       ApiKeyRequired: true
     },
@@ -442,12 +449,12 @@ test('Test for Api Key Creation', () => {
         ]
       }
     }
-  }, ResourcePart.CompleteDefinition);
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::ApiKey", {
+  });
+  template.hasResourceProperties("AWS::ApiGateway::ApiKey", {
     Enabled: true
   });
   // Assertion to check for UsagePlan Api Key Mapping
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::UsagePlanKey", {
+  template.hasResourceProperties("AWS::ApiGateway::UsagePlanKey", {
     KeyType: "API_KEY"
   });
 });
@@ -468,7 +475,8 @@ test('Test for deployment ApiGateway AuthorizationType override', () => {
     }
   });
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::RestApi", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::RestApi", {
     EndpointConfiguration: {
       Types: ["REGIONAL"]
     }
@@ -491,7 +499,8 @@ test('Test for deployment ApiGateway AuthorizationType override', () => {
     }
   });
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::Method", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "POST",
     AuthorizationType: "NONE"
   });
@@ -513,7 +522,8 @@ test('Test for handling fully qualified iotEndpoint', () => {
     }
   });
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::Method", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     Integration: {
       Uri: {
         "Fn::Join": [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/apigateway-kinesisstreams.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/apigateway-kinesisstreams.test.ts
@@ -14,8 +14,8 @@
 // Imports
 import { Stack, Duration } from 'aws-cdk-lib';
 import { ApiGatewayToKinesisStreams } from '../lib';
-import '@aws-cdk/assert/jest';
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test construct properties
@@ -60,7 +60,8 @@ test('Test deployment w/ overwritten properties', () => {
     putRecordsRequestModel: { schema: {} }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Stage', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Stage', {
     MethodSettings: [
       {
         DataTraceEnabled: false,
@@ -77,13 +78,13 @@ test('Test deployment w/ overwritten properties', () => {
     ]
   });
 
-  expect(stack).toHaveResource('AWS::Kinesis::Stream', {
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     ShardCount: 1,
     Name: 'my-stream'
   });
 
   // Test for Cloudwatch Alarms
-  expect(stack).toCountResources('AWS::CloudWatch::Alarm', 2);
+  template.resourceCountIs('AWS::CloudWatch::Alarm', 2);
 });
 
 // --------------------------------------------------------------
@@ -101,7 +102,8 @@ test('Test deployment w/ existing stream', () => {
     createCloudWatchAlarms: false
   });
 
-  expect(stack).toHaveResource('AWS::Kinesis::Stream', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     ShardCount: 5,
     RetentionPeriodHours: 96
   });
@@ -109,7 +111,7 @@ test('Test deployment w/ existing stream', () => {
   expect(construct.cloudwatchAlarms == null);
 
   // Since createCloudWatchAlars is set to false, no Alarm should exist
-  expect(stack).not.toHaveResource('AWS::CloudWatch::Alarm');
+  template.resourceCountIs('AWS::CloudWatch::Alarm', 0);
 });
 
 test('Construct accepts additional PutRecord request templates', () => {
@@ -120,7 +122,8 @@ test('Construct accepts additional PutRecord request templates', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       RequestTemplates: {
@@ -138,7 +141,8 @@ test('Construct accepts additional PutRecords request templates', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       RequestTemplates: {
@@ -152,7 +156,8 @@ test('Construct uses default integration responses', () => {
   const stack = new Stack();
   new ApiGatewayToKinesisStreams(stack, 'api-gateway-kinesis-streams ', {});
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       IntegrationResponses: [
@@ -184,7 +189,8 @@ test('Construct uses custom putRecordIntegrationResponses property', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       IntegrationResponses: [
@@ -212,7 +218,8 @@ test('Construct uses custom putRecordsIntegrationResponses property', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
     Integration: {
       IntegrationResponses: [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/test.apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/test.apigateway-lambda.test.ts
@@ -16,7 +16,8 @@ import { Stack } from "aws-cdk-lib";
 import { ApiGatewayToLambda, ApiGatewayToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as api from 'aws-cdk-lib/aws-apigateway';
-import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
+import * as defaults from '@aws-solutions-constructs/core';
 
 // --------------------------------------------------------------
 // Test for error with existingLambdaObj=undefined (not supplied by user).
@@ -54,7 +55,8 @@ test('Test with lambdaFunctionProps', () => {
   };
   new ApiGatewayToLambda(stack, 'test-apigateway-lambda', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Environment: {
       Variables: {
         OVERRIDE_STATUS: "true",
@@ -121,7 +123,8 @@ test('Test deployment ApiGateway AuthorizationType override', () => {
     }
   });
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::ApiGateway::Method", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
     HttpMethod: "ANY",
     AuthorizationType: "NONE"
   });
@@ -145,5 +148,5 @@ test('Test deployment ApiGateway override cloudWatchRole = false', () => {
     }
   });
   // Assertion 1
-  expect(stack).not.toHaveResource("AWS::ApiGateway::Account", {});
+  defaults.expectNonexistence(stack, "AWS::ApiGateway::Account", {});
 });

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/apigateway-sagemakerendpoint.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/apigateway-sagemakerendpoint.test.ts
@@ -15,7 +15,7 @@
 import { Stack, Aws } from 'aws-cdk-lib';
 import { ApiGatewayToSageMakerEndpoint } from '../lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test construct properties
@@ -74,7 +74,8 @@ test('Test deployment w/ overwritten properties', () => {
     responseMappingTemplate: 'my-response-vtl-template'
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Stage', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Stage', {
     MethodSettings: [
       {
         DataTraceEnabled: false,
@@ -91,11 +92,11 @@ test('Test deployment w/ overwritten properties', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Resource', {
+  template.hasResourceProperties('AWS::ApiGateway::Resource', {
     PathPart: 'my-resource'
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     Integration: {
       IntegrationResponses: [
         {
@@ -121,7 +122,7 @@ test('Test deployment w/ overwritten properties', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike('AWS::IAM::Role', {
+  template.hasResourceProperties('AWS::IAM::Role', {
     Description: 'existing role for SageMaker integration'
   });
 });
@@ -137,7 +138,8 @@ test('Construct accepts additional read request templates', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
     Integration: {
       RequestTemplates: {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
@@ -16,7 +16,7 @@ import * as cdk from "aws-cdk-lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as api from 'aws-cdk-lib/aws-apigateway';
 import * as s3 from "aws-cdk-lib/aws-s3";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployNewFunc(stack: cdk.Stack) {
   const lambdaFunctionProps: lambda.FunctionProps = {
@@ -61,7 +61,7 @@ test('check lambda function properties for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -83,7 +83,7 @@ test('check lambda function role for deploy: false', () => {
 
   useExistingFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -157,7 +157,7 @@ test('override api gateway properties with existingLambdaObj', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+  template.hasResourceProperties('AWS::ApiGateway::RestApi',
     {
       Description: "Override description",
       EndpointConfiguration: {
@@ -186,7 +186,7 @@ test('override api gateway properties without existingLambdaObj', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::RestApi',
+  template.hasResourceProperties('AWS::ApiGateway::RestApi',
     {
       Description: "Override description",
       EndpointConfiguration: {
@@ -221,11 +221,11 @@ test('Cloudfront logging bucket with destroy removal policy and auto delete obje
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/test.cloudfront-apigateway.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/test.cloudfront-apigateway.test.ts
@@ -11,16 +11,15 @@
  *  and limitations under the License.
  */
 
-import { ResourcePart } from '@aws-cdk/assert';
 import { CloudFrontToApiGateway } from "../lib";
 import * as cdk from "aws-cdk-lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as defaults from '@aws-solutions-constructs/core';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import '@aws-cdk/assert/jest';
 import {Duration} from "aws-cdk-lib";
-
+import { Template } from 'aws-cdk-lib/assertions';
 function deploy(stack: cdk.Stack) {
+
   const inProps: lambda.FunctionProps = {
     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
     runtime: lambda.Runtime.NODEJS_14_X,
@@ -50,7 +49,8 @@ test('check getter methods', () => {
 test('test cloudfront DomainName', () => {
   const stack = new cdk.Stack();
   deploy(stack);
-  expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       Origins: [
         {
@@ -101,13 +101,14 @@ test('test cloudfront DomainName', () => {
         }
       ]
     }
-  }, ResourcePart.Properties);
+  });
 });
 
 test('test api gateway lambda service role', () => {
   const stack = new cdk.Stack();
   deploy(stack);
-  expect(stack).toHaveResource("AWS::IAM::Role", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Role", {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -190,11 +191,12 @@ test('Cloudfront logging bucket with destroy removal policy and auto delete obje
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -253,7 +255,8 @@ test('Test the deployment with securityHeadersBehavior instead of HTTP security 
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike("AWS::CloudFront::ResponseHeadersPolicy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::CloudFront::ResponseHeadersPolicy", {
     ResponseHeadersPolicyConfig: {
       SecurityHeadersConfig: {
         ContentSecurityPolicy: {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/cloudfront-mediastore.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/cloudfront-mediastore.test.ts
@@ -12,13 +12,13 @@
  */
 
 // Imports
-import '@aws-cdk/assert/jest';
 import {Stack, RemovalPolicy, Duration} from 'aws-cdk-lib';
 import * as mediastore from 'aws-cdk-lib/aws-mediastore';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { CloudFrontToMediaStore } from '../lib';
 import * as cdk from "aws-cdk-lib";
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test the default deployment pattern variables
@@ -48,7 +48,8 @@ test('Test the deployment without HTTP security headers', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike('AWS::CloudFront::Distribution', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -149,7 +150,8 @@ test('Test the deployment with securityHeadersBehavior instead of HTTP security 
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike("AWS::CloudFront::ResponseHeadersPolicy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::CloudFront::ResponseHeadersPolicy", {
     ResponseHeadersPolicyConfig: {
       SecurityHeadersConfig: {
         ContentSecurityPolicy: {
@@ -202,7 +204,8 @@ test('Test the deployment with existing MediaStore container', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike('AWS::CloudFront::Distribution', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -281,10 +284,10 @@ test('Test the deployment with existing MediaStore container', () => {
       ]
     }
   });
-  expect(stack).toHaveResourceLike('AWS::MediaStore::Container', {
+  template.hasResourceProperties('AWS::MediaStore::Container', {
     ContainerName: 'MyMediaStoreContainer'
   });
-  expect(stack).toHaveResourceLike('AWS::CloudFront::OriginRequestPolicy', {
+  template.hasResourceProperties('AWS::CloudFront::OriginRequestPolicy', {
     OriginRequestPolicyConfig: {
       Comment: 'Policy for Constructs CloudFrontDistributionForMediaStore',
       CookiesConfig: {
@@ -341,7 +344,8 @@ test('Test the deployment with the user provided MediaStore properties', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike('AWS::CloudFront::Distribution', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -420,7 +424,7 @@ test('Test the deployment with the user provided MediaStore properties', () => {
       ]
     }
   });
-  expect(stack).toHaveResourceLike('AWS::MediaStore::Container', {
+  template.hasResourceProperties('AWS::MediaStore::Container', {
     ContainerName: 'MyMediaStoreContainer',
     Policy: '{}',
     LifecyclePolicy: '{}',
@@ -429,7 +433,7 @@ test('Test the deployment with the user provided MediaStore properties', () => {
       ContainerLevelMetrics: 'DISABLED'
     }
   });
-  expect(stack).toHaveResourceLike('AWS::CloudFront::OriginRequestPolicy', {
+  template.hasResourceProperties('AWS::CloudFront::OriginRequestPolicy', {
     OriginRequestPolicyConfig: {
       Comment: 'Policy for Constructs CloudFrontDistributionForMediaStore',
       CookiesConfig: {
@@ -484,7 +488,8 @@ test('Test the deployment with the user provided CloudFront properties', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike('AWS::CloudFront::Distribution', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -574,7 +579,7 @@ test('Test the deployment with the user provided CloudFront properties', () => {
       ]
     }
   });
-  expect(stack).toHaveResourceLike('AWS::MediaStore::Container', {
+  template.hasResourceProperties('AWS::MediaStore::Container', {
     AccessLoggingEnabled: true,
     ContainerName: {
       Ref: 'AWS::StackName'
@@ -589,7 +594,7 @@ test('Test the deployment with the user provided CloudFront properties', () => {
       }
     ]
   });
-  expect(stack).toHaveResourceLike('AWS::CloudFront::OriginRequestPolicy', {
+  template.hasResourceProperties('AWS::CloudFront::OriginRequestPolicy', {
     OriginRequestPolicyConfig: {
       Comment: 'Policy for Constructs CloudFrontDistributionForMediaStore',
       CookiesConfig: {
@@ -624,7 +629,7 @@ test('Test the deployment with the user provided CloudFront properties', () => {
       }
     }
   });
-  expect(stack).toHaveResourceLike('AWS::CloudFront::CloudFrontOriginAccessIdentity', {
+  template.hasResourceProperties('AWS::CloudFront::CloudFrontOriginAccessIdentity', {
     CloudFrontOriginAccessIdentityConfig: {
       Comment: {
         'Fn::Join': [
@@ -658,11 +663,12 @@ test('Cloudfront logging bucket with destroy removal policy and auto delete obje
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -11,13 +11,13 @@
  *  and limitations under the License.
  */
 
-import {ResourcePart} from '@aws-cdk/assert';
-import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cdk from "aws-cdk-lib";
 import {Duration, RemovalPolicy, Stack} from "aws-cdk-lib";
 import {CloudFrontToS3, CloudFrontToS3Props} from "../lib";
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as defaults from '@aws-solutions-constructs/core';
 
 function deploy(stack: cdk.Stack, props?: CloudFrontToS3Props) {
   return new CloudFrontToS3(stack, 'test-cloudfront-s3', {
@@ -31,7 +31,8 @@ function deploy(stack: cdk.Stack, props?: CloudFrontToS3Props) {
 test('check s3Bucket default encryption', () => {
   const stack = new cdk.Stack();
   deploy(stack);
-  expect(stack).toHaveResource('AWS::S3::Bucket', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::S3::Bucket', {
     BucketEncryption: {
       ServerSideEncryptionConfiguration: [{
         ServerSideEncryptionByDefault: {
@@ -45,7 +46,8 @@ test('check s3Bucket default encryption', () => {
 test('check s3Bucket public access block configuration', () => {
   const stack = new cdk.Stack();
   deploy(stack);
-  expect(stack).toHaveResource('AWS::S3::Bucket', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::S3::Bucket', {
     PublicAccessBlockConfiguration: {
       BlockPublicAcls: true,
       BlockPublicPolicy: true,
@@ -71,7 +73,8 @@ test('test s3Bucket override publicAccessBlockConfiguration', () => {
 
   new CloudFrontToS3(stack, 'test-cloudfront-s3', props);
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     PublicAccessBlockConfiguration: {
       BlockPublicAcls: false,
       BlockPublicPolicy: true,
@@ -94,11 +97,12 @@ test('check existing bucket', () => {
 
   new CloudFrontToS3(stack, 'test-cloudfront-s3', props);
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: "my-bucket"
   });
 
-  expect(stack).toHaveResource("AWS::S3::BucketPolicy", {
+  template.hasResource("AWS::S3::BucketPolicy", {
     Metadata: {
       cfn_nag: {
         rules_to_suppress: [
@@ -109,7 +113,7 @@ test('check existing bucket', () => {
         ]
       }
     }
-  }, ResourcePart.CompleteDefinition);
+  });
 });
 
 test('check exception for Missing existingObj from props for deploy = false', () => {
@@ -161,7 +165,8 @@ test("Test existingBucketObj", () => {
   });
   // Assertion
   expect(construct.cloudFrontWebDistribution !== null);
-  expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       Origins: [
         {
@@ -222,7 +227,8 @@ test('test cloudfront with custom domain names', () => {
 
   new CloudFrontToS3(stack, 'test-cloudfront-s3', props);
 
-  expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       Aliases: [
         "mydomains"
@@ -247,11 +253,12 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -277,11 +284,12 @@ test('Cloudfront logging bucket with destroy removal policy and auto delete obje
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -329,7 +337,8 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toCountResources("AWS::S3::Bucket", 2);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 2);
   expect(construct.s3LoggingBucket).toEqual(undefined);
 });
 
@@ -343,7 +352,8 @@ test('CloudFront origin path present when provided', () => {
     originPath: '/testPath'
   });
 
-  expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig:
     {
       Origins: [
@@ -360,7 +370,7 @@ test('CloudFront origin path should not be present if not provided', () => {
 
   new CloudFrontToS3(stack, 'cloudfront-s3', {});
 
-  expect(stack).not.toHaveResourceLike("AWS::CloudFront::Distribution", {
+  defaults.expectNonexistence(stack, "AWS::CloudFront::Distribution", {
     DistributionConfig:
     {
       Origins: [
@@ -394,7 +404,8 @@ test('Test the deployment with securityHeadersBehavior instead of HTTP security 
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike("AWS::CloudFront::ResponseHeadersPolicy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::CloudFront::ResponseHeadersPolicy", {
     ResponseHeadersPolicyConfig: {
       SecurityHeadersConfig: {
         ContentSecurityPolicy: {

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/test.cognito-apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/test.cognito-apigateway-lambda.test.ts
@@ -16,7 +16,7 @@ import * as cdk from "aws-cdk-lib";
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as api from 'aws-cdk-lib/aws-apigateway';
-import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
 
 function deployNewFunc(stack: cdk.Stack) {
   const lambdaFunctionProps: lambda.FunctionProps = {
@@ -49,7 +49,8 @@ test('override cognito properties', () => {
     cognitoUserPoolProps
   });
 
-  expect(stack).toHaveResource('AWS::Cognito::UserPool',
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Cognito::UserPool',
     {
       AdminCreateUserConfig: {
         AllowAdminCreateUserOnly: true
@@ -117,7 +118,8 @@ test('override cognito cognitoUserPoolClientProps', () => {
     cognitoUserPoolClientProps
   });
 
-  expect(stack).toHaveResource('AWS::Cognito::UserPoolClient', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
     ExplicitAuthFlows: [
       "ALLOW_USER_SRP_AUTH",
       "ALLOW_REFRESH_TOKEN_AUTH"
@@ -138,7 +140,8 @@ test('Check for default Cognito Auth Type', () => {
     lambdaFunctionProps
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     ResourceId: {
       "Fn::GetAtt": [
         "testcognitoapigatewaylambdaLambdaRestApi2E272431",
@@ -151,7 +154,7 @@ test('Check for default Cognito Auth Type', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApiproxy23E1DA20"
     },
@@ -181,7 +184,8 @@ test('override Auth Type to COGNITO', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     ResourceId: {
       "Fn::GetAtt": [
         "testcognitoapigatewaylambdaLambdaRestApi2E272431",
@@ -194,7 +198,7 @@ test('override Auth Type to COGNITO', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApiproxy23E1DA20"
     },
@@ -224,7 +228,8 @@ test('Try to override Auth Type to NONE', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     ResourceId: {
       "Fn::GetAtt": [
         "testcognitoapigatewaylambdaLambdaRestApi2E272431",
@@ -237,7 +242,7 @@ test('Try to override Auth Type to NONE', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApiproxy23E1DA20"
     },
@@ -267,7 +272,8 @@ test('Override apiGatewayProps', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     OperationName: "foo-bar",
     ResourceId: {
       "Fn::GetAtt": [
@@ -281,7 +287,7 @@ test('Override apiGatewayProps', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     OperationName: "foo-bar",
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApiproxy23E1DA20"
@@ -313,7 +319,8 @@ test('Override apiGatewayProps to support CORS', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: "ANY",
     ResourceId: {
       "Fn::GetAtt": [
@@ -327,7 +334,7 @@ test('Override apiGatewayProps to support CORS', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: "ANY",
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApiproxy23E1DA20"
@@ -338,7 +345,7 @@ test('Override apiGatewayProps to support CORS', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: "OPTIONS",
     ResourceId: {
       "Fn::GetAtt": [
@@ -349,7 +356,7 @@ test('Override apiGatewayProps to support CORS', () => {
     AuthorizationType: "NONE"
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: "OPTIONS",
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApiproxy23E1DA20"
@@ -381,7 +388,8 @@ test('Override apiGatewayProps with proxy = false and add POST method', () => {
   // Super imporant to call this method to Apply the Cognito Authorizers
   c.addAuthorizers();
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: "POST",
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApifoo89ACA437"
@@ -392,7 +400,7 @@ test('Override apiGatewayProps with proxy = false and add POST method', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Resource', {
+  template.hasResourceProperties('AWS::ApiGateway::Resource', {
     PathPart: "foo",
   });
 });
@@ -419,7 +427,8 @@ test('Override apiGatewayProps with proxy = false and add OPTIONS method', () =>
   // Mandatory to call this method to Apply the Cognito Authorizers
   c.addAuthorizers();
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Method', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: "OPTIONS",
     ResourceId: {
       Ref: "testcognitoapigatewaylambdaLambdaRestApifoo89ACA437"
@@ -427,7 +436,7 @@ test('Override apiGatewayProps with proxy = false and add OPTIONS method', () =>
     AuthorizationType: "NONE",
   });
 
-  expect(stack).toHaveResource('AWS::ApiGateway::Resource', {
+  template.hasResourceProperties('AWS::ApiGateway::Resource', {
     PathPart: "foo",
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/dynamodbstreams-lambda-elasticsearch-kibana.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/dynamodbstreams-lambda-elasticsearch-kibana.test.ts
@@ -16,7 +16,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as defaults from '@aws-solutions-constructs/core';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployNewFunc(stack: cdk.Stack) {
   const props: DynamoDBStreamsToLambdaToElasticSearchAndKibanaProps = {
@@ -40,14 +40,14 @@ test('check domain names', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Cognito::UserPoolDomain', {
+  template.hasResourceProperties('AWS::Cognito::UserPoolDomain', {
     Domain: "test-domain",
     UserPoolId: {
       Ref: "testdynamodbstreamlambdaelasticsearchstackLambdaToElasticSearchCognitoUserPoolF99F93E5"
     }
   });
 
-  expect(stack).toHaveResource('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     DomainName: "test-domain",
   });
 });
@@ -95,7 +95,7 @@ test('Test minimal deployment with VPC construct props', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -104,7 +104,7 @@ test('Test minimal deployment with VPC construct props', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -120,7 +120,7 @@ test('Test minimal deployment with VPC construct props', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 
@@ -151,7 +151,7 @@ test('Test minimal deployment with an existing private VPC', () => {
     existingVpc: vpc
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -160,7 +160,7 @@ test('Test minimal deployment with an existing private VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -176,7 +176,7 @@ test('Test minimal deployment with an existing private VPC', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 
@@ -195,7 +195,7 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     existingVpc: vpc
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -204,7 +204,7 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -220,6 +220,6 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/test/dynamodbstreams-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/test/dynamodbstreams-lambda.test.ts
@@ -15,7 +15,7 @@ import { DynamoDBStreamsToLambda, DynamoDBStreamsToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
 
 function deployNewFunc(stack: cdk.Stack) {
   const props: DynamoDBStreamsToLambdaProps = {
@@ -33,7 +33,8 @@ test('check lambda EventSourceMapping', () => {
   const stack = new cdk.Stack();
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
     EventSourceArn: {
       "Fn::GetAtt": [
         "testlambdadynamodbstackDynamoTable8138E93B",
@@ -67,7 +68,8 @@ test('check DynamoEventSourceProps override', () => {
 
   new DynamoDBStreamsToLambda(stack, 'test-lambda-dynamodb-stack', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
     EventSourceArn: {
       "Fn::GetAtt": [
         "testlambdadynamodbstackDynamoTable8138E93B",
@@ -86,7 +88,8 @@ test('check lambda permission to read dynamodb stream', () => {
   const stack = new cdk.Stack();
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Policy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -154,7 +157,8 @@ test('check dynamodb table stream override', () => {
   };
 
   new DynamoDBStreamsToLambda(stack, 'test-lambda-dynamodb-stack', props);
-  expect(stack).toHaveResource('AWS::DynamoDB::Table', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::DynamoDB::Table', {
     KeySchema: [
       {
         AttributeName: "id",
@@ -241,11 +245,12 @@ test('check dynamodb table stream override with ITable', () => {
 
   new DynamoDBStreamsToLambda(stack, 'test-lambda-dynamodb-stack', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
     EventSourceArn: "arn:aws:dynamodb:us-east-1:xxxxxxxxxxxxx:table/existing-table/stream/2020-06-22T18:34:05.824",
   });
 
-  expect(stack).toHaveResource('AWS::IAM::Policy', {
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/test/eventbridge-kinesisstreams.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/test/eventbridge-kinesisstreams.test.ts
@@ -14,7 +14,7 @@
 import * as cdk from "aws-cdk-lib";
 import * as events from "aws-cdk-lib/aws-events";
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
-import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
 import {EventbridgeToKinesisStreams, EventbridgeToKinesisStreamsProps} from '../lib';
 
 // --------------------------------------------------------------
@@ -51,7 +51,8 @@ test('Test default AWS managed encryption key property', () => {
   deployNewStack(stack);
 
   // Assertions
-  expect(stack).toHaveResource('AWS::Kinesis::Stream', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     StreamEncryption: {
       EncryptionType: "KMS",
       KeyId: "alias/aws/kinesis"
@@ -81,7 +82,8 @@ test('Test existing resources', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::Kinesis::Stream', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     Name: 'existing-stream',
     ShardCount: 5,
     RetentionPeriodHours: 48,
@@ -106,7 +108,8 @@ test('check eventbus property, snapshot & eventbus exists', () => {
   expect(construct.eventsRole !== null);
   expect(construct.eventBus !== null);
   // Check whether eventbus exists
-  expect(stack).toHaveResource('AWS::Events::EventBus');
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
 });
 
 test('check exception while passing existingEventBus & eventBusProps', () => {
@@ -143,7 +146,8 @@ test('check custom event bus resource with props when deploy:true', () => {
   };
   new EventbridgeToKinesisStreams(stack, 'test-new-eventbridge-with-props-kinsesisstreams', props);
 
-  expect(stack).toHaveResource('AWS::Events::EventBus', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::EventBus', {
     Name: `testeventbus`
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/test/eventbridge-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/test/eventbridge-lambda.test.ts
@@ -14,7 +14,7 @@
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as events from 'aws-cdk-lib/aws-events';
 import { EventbridgeToLambdaProps, EventbridgeToLambda } from '../lib/index';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as cdk from 'aws-cdk-lib';
 
 function deployNewFunc(stack: cdk.Stack) {
@@ -54,7 +54,8 @@ test('check lambda function properties for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -76,7 +77,8 @@ test('check lambda function permission for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Permission', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Permission', {
     Action: "lambda:InvokeFunction",
     FunctionName: {
       "Fn::GetAtt": [
@@ -99,7 +101,8 @@ test('check lambda function role for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -158,7 +161,8 @@ test('check events rule properties for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Events::Rule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::Rule', {
     ScheduleExpression: "rate(5 minutes)",
     State: "ENABLED",
     Targets: [
@@ -209,7 +213,8 @@ test('check eventbus property, snapshot & eventbus exists', () => {
   expect(construct.lambdaFunction !== null);
   expect(construct.eventBus !== null);
   // Check whether eventbus exists
-  expect(stack).toHaveResource('AWS::Events::EventBus');
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
 });
 
 test('check exception while passing existingEventBus & eventBusProps', () => {
@@ -256,7 +261,8 @@ test('check custom event bus resource with props when deploy:true', () => {
   };
   new EventbridgeToLambda(stack, 'test-new-eventbridge-with-props-lambda', props);
 
-  expect(stack).toHaveResource('AWS::Events::EventBus', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::EventBus', {
     Name: `testeventbus`
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
@@ -15,7 +15,7 @@ import * as cdk from "aws-cdk-lib";
 import * as events from "aws-cdk-lib/aws-events";
 import * as sns from "aws-cdk-lib/aws-sns";
 import * as defaults from '@aws-solutions-constructs/core';
-import '@aws-cdk/assert/jest';
+import { Template } from "aws-cdk-lib/assertions";
 import { EventbridgeToSns, EventbridgeToSnsProps } from "../lib";
 
 function deployNewStack(stack: cdk.Stack) {
@@ -45,7 +45,8 @@ test('check if the event rule has permission/policy in place in sns for it to be
 
   expect(testConstruct.snsTopic).toBeDefined();
   expect(testConstruct.encryptionKey).toBeDefined();
-  expect(stack).toHaveResource('AWS::SNS::TopicPolicy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::TopicPolicy', {
     PolicyDocument: {
       Statement: [
         {
@@ -144,7 +145,8 @@ test('check events rule properties', () => {
   const stack = new cdk.Stack();
   deployNewStack(stack);
 
-  expect(stack).toHaveResource('AWS::Events::Rule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::Rule', {
     ScheduleExpression: "rate(5 minutes)",
     State: "ENABLED",
     Targets: [
@@ -175,7 +177,8 @@ test('check properties', () => {
 test('check the sns topic properties', () => {
   const stack = new cdk.Stack();
   deployNewStack(stack);
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "testEncryptionKeyB55BFDBC",
@@ -200,7 +203,8 @@ test('check the sns topic properties with existing KMS key', () => {
 
   new EventbridgeToSns(stack, 'test-events-rule-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -209,7 +213,7 @@ test('check the sns topic properties with existing KMS key', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     Description: "my-key",
     EnableKeyRotation: true
   });
@@ -226,7 +230,8 @@ test('check eventbus property, snapshot & eventbus exists', () => {
   expect(construct.eventBus !== null);
 
   // Check whether eventbus exists
-  expect(stack).toHaveResource('AWS::Events::EventBus');
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
 });
 
 test('check exception while passing existingEventBus & eventBusProps', () => {
@@ -263,7 +268,8 @@ test('check custom event bus resource with props when deploy:true', () => {
   };
   new EventbridgeToSns(stack, 'test-new-eventbridge-sns', props);
 
-  expect(stack).toHaveResource('AWS::Events::EventBus', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::EventBus', {
     Name: 'testcustomeventbus'
   });
 });
@@ -285,7 +291,8 @@ test('Topic is encrypted when key is provided on topicProps.masterKey prop', () 
 
   new EventbridgeToSns(stack, 'test-events-rule-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -294,7 +301,7 @@ test('Topic is encrypted when key is provided on topicProps.masterKey prop', () 
     }
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     Description: "my-key",
     EnableKeyRotation: true
   });
@@ -314,7 +321,8 @@ test('Topic is encrypted when keyProps are provided', () => {
 
   new EventbridgeToSns(stack, 'test-events-rule-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "testeventsrulesqsEncryptionKey19AB0C02",
@@ -323,7 +331,7 @@ test('Topic is encrypted when keyProps are provided', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     Description: "my-key",
     EnableKeyRotation: true
   });
@@ -341,7 +349,8 @@ test('Topic is encrypted with AWS-managed KMS key when enableEncryptionWithCusto
 
   new EventbridgeToSns(stack, 'test-events-rule-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::Join": [
         "",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/test/eventbridge-sqs-queue.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/test/eventbridge-sqs-queue.test.ts
@@ -14,7 +14,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { EventbridgeToSqs, EventbridgeToSqsProps } from '../lib';
 import * as events from "aws-cdk-lib/aws-events";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 
 function deployNewStack(stack: cdk.Stack) {
@@ -45,7 +45,8 @@ test('check the sqs queue properties', () => {
   expect(buildQueueResponse.sqsQueue).toBeDefined();
   expect(buildQueueResponse.encryptionKey).toBeDefined();
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "testeventbridgesqsEncryptionKey811BDC23",
@@ -82,7 +83,8 @@ test('check the sqs queue properties with existing KMS key', () => {
   expect(buildQueueResponse.sqsQueue).toBeDefined();
   expect(buildQueueResponse.encryptionKey).toBeDefined();
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -100,7 +102,7 @@ test('check the sqs queue properties with existing KMS key', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     Description: "my-key",
     EnableKeyRotation: true
   });
@@ -109,7 +111,8 @@ test('check the sqs queue properties with existing KMS key', () => {
 test('check if the event rule has permission/policy in place in sqs queue for it to be able to send messages to the queue.', () => {
   const stack = new cdk.Stack();
   deployNewStack(stack);
-  expect(stack).toHaveResource('AWS::SQS::QueuePolicy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::QueuePolicy', {
     PolicyDocument:  {
       Statement: [
         {
@@ -199,7 +202,8 @@ test('check if the event rule has permission/policy in place in sqs queue for it
 test('check if the dead letter queue policy is setup', () => {
   const stack = new cdk.Stack();
   deployNewStack(stack);
-  expect(stack).toHaveResource('AWS::SQS::QueuePolicy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::QueuePolicy', {
     PolicyDocument:  {
       Statement: [
         {
@@ -290,7 +294,8 @@ test('check eventbus property, snapshot & eventbus exists', () => {
   expect(construct.eventBus !== null);
 
   // Check whether eventbus exists
-  expect(stack).toHaveResource('AWS::Events::EventBus');
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
 });
 
 test('check exception while passing existingEventBus & eventBusProps', () => {
@@ -327,7 +332,8 @@ test('check custom event bus resource with props when deploy:true', () => {
   };
   new EventbridgeToSqs(stack, 'test-new-eventbridge-sqs', props);
 
-  expect(stack).toHaveResource('AWS::Events::EventBus', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::EventBus', {
     Name: 'testcustomeventbus'
   });
 });
@@ -349,7 +355,8 @@ test('Queue is encrypted when key is provided on queueProps.encryptionMasterKey 
 
   new EventbridgeToSqs(stack, 'test-eventbridge-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -358,7 +365,7 @@ test('Queue is encrypted when key is provided on queueProps.encryptionMasterKey 
     }
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     Description: "my-key",
     EnableKeyRotation: true
   });
@@ -378,7 +385,8 @@ test('Queue is encrypted when key keyProps are provided', () => {
 
   new EventbridgeToSqs(stack, 'test-eventbridge-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "testeventbridgesqsEncryptionKey811BDC23",
@@ -387,7 +395,7 @@ test('Queue is encrypted when key keyProps are provided', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     Description: "my-key",
     EnableKeyRotation: true
   });
@@ -405,7 +413,8 @@ test('Queue is encrypted with SQS-managed KMS key when enableEncryptionWithCusto
 
   new EventbridgeToSqs(stack, 'test-eventbridge-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 });
@@ -423,7 +432,8 @@ test('Queue purging flag grants correct permissions', () => {
 
   new EventbridgeToSqs(stack, 'test-eventbridge-sqs', props);
 
-  expect(stack).toHaveResource('AWS::SQS::QueuePolicy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::QueuePolicy', {
     PolicyDocument:  {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/eventbridge-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/eventbridge-stepfunctions.test.ts
@@ -15,7 +15,6 @@ import * as events from 'aws-cdk-lib/aws-events';
 import { EventbridgeToStepfunctions, EventbridgeToStepfunctionsProps } from '../lib/index';
 import { Duration } from 'aws-cdk-lib';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
-import '@aws-cdk/assert/jest';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 
@@ -59,7 +58,8 @@ test('check events rule role policy permissions', () => {
 
   deployNewStateMachine(stack);
 
-  expect(stack).toHaveResource("AWS::IAM::Policy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -80,7 +80,8 @@ test('check events rule properties', () => {
 
   deployNewStateMachine(stack);
 
-  expect(stack).toHaveResource('AWS::Events::Rule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::Rule', {
     ScheduleExpression: "rate(5 minutes)",
     State: "ENABLED",
     Targets: [
@@ -145,7 +146,8 @@ test('check eventbus property, snapshot & eventbus exists', () => {
   expect(construct.eventBus !== null);
 
   // Check whether eventbus exists
-  expect(stack).toHaveResource('AWS::Events::EventBus');
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
 });
 
 test('check exception while passing existingEventBus & eventBusProps', () => {
@@ -190,7 +192,8 @@ test('check custom event bus resource with props when deploy:true', () => {
   };
   new EventbridgeToStepfunctions(stack, 'test-new-eventbridge-stepfunctions', props);
 
-  expect(stack).toHaveResource('AWS::Events::EventBus', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::EventBus', {
     Name: 'testcustomeventbus'
   });
 });
@@ -204,7 +207,8 @@ test('check LogGroup name', () => {
   const expectedPrefix = '/aws/vendedlogs/states/constructs/';
   const lengthOfDatetimeSuffix = 13;
 
-  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+  const template = Template.fromStack(stack);
+  const LogGroup = template.findResources("AWS::Logs::LogGroup");
 
   const logName = LogGroup.testeventbridgestepfunctionsStateMachineLogGroup826A5B74.Properties.LogGroupName;
   const suffix = logName.slice(-lengthOfDatetimeSuffix);

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/test/fargate-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/test/fargate-dynamodb.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToDynamoDB } from "../lib";
@@ -52,7 +52,8 @@ test('New service/new table, public API, new VPC', () => {
   expect(construct.dynamoTable !== null);
   expect(construct.dynamoTableInterface !== null);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
     LaunchType: 'FARGATE',
     DesiredCount: 2,
@@ -63,15 +64,15 @@ test('New service/new table, public API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: clusterName
   });
 
-  expect(stack).toHaveResourceLike("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     TableName: tableName
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -106,7 +107,7 @@ test('New service/new table, public API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Family: familyName,
     ContainerDefinitions: [
       {
@@ -135,11 +136,11 @@ test('New service/new table, public API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -155,10 +156,10 @@ test('New service/new table, public API, new VPC', () => {
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::DynamoDB::Table', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::DynamoDB::Table', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new table, private API, new VPC', () => {
@@ -180,7 +181,8 @@ test('New service/new table, private API, new VPC', () => {
     tablePermissions: 'Read',
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -190,15 +192,15 @@ test('New service/new table, private API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     TableName: tableName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -229,7 +231,7 @@ test('New service/new table, private API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -245,10 +247,10 @@ test('New service/new table, private API, new VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::DynamoDB::Table', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::DynamoDB::Table', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/existing table, private API, existing VPC', () => {
@@ -274,7 +276,8 @@ test('New service/existing table, private API, existing VPC', () => {
     tablePermissions: 'ALL'
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -284,14 +287,14 @@ test('New service/existing table, private API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     TableName: tableName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -313,7 +316,7 @@ test('New service/existing table, private API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -331,10 +334,10 @@ test('New service/existing table, private API, existing VPC', () => {
   expect(construct.dynamoTable == null);
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::DynamoDB::Table', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::DynamoDB::Table', 1);
 });
 
 test('Existing service/new table, public API, existing VPC', () => {
@@ -373,11 +376,12 @@ test('Existing service/new table, public API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -422,15 +426,15 @@ test('Existing service/new table, public API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     TableName: tableName
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -465,7 +469,7 @@ test('Existing service/new table, public API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -483,10 +487,10 @@ test('Existing service/new table, public API, existing VPC', () => {
   expect(construct.dynamoTable == null);
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::DynamoDB::Table', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::DynamoDB::Table', 1);
 });
 
 test('Existing service/existing table, private API, existing VPC', () => {
@@ -524,11 +528,12 @@ test('Existing service/existing table, private API, existing VPC', () => {
     existingTableInterface: existingTable
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -573,14 +578,14 @@ test('Existing service/existing table, private API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     TableName: tableName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -608,7 +613,7 @@ test('Existing service/existing table, private API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -626,10 +631,10 @@ test('Existing service/existing table, private API, existing VPC', () => {
   expect(construct.dynamoTable == null);
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::DynamoDB::Table', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::DynamoDB::Table', 1);
 });
 
 test('test error invalid table permission', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/test/fargate-eventbridge.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/test/fargate-eventbridge.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToEventbridge } from "../lib";
@@ -43,7 +43,8 @@ test('Check for new service', () => {
 
   createFargateConstructWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
     LaunchType: 'FARGATE',
     DesiredCount: 2,
@@ -54,7 +55,7 @@ test('Check for new service', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -93,7 +94,8 @@ test('Check for an existing service', () => {
     existingVpc,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
     LaunchType: 'FARGATE',
     DesiredCount: 2,
@@ -104,7 +106,7 @@ test('Check for an existing service', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -119,7 +121,7 @@ test('Check for an existing service', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::ECS::Service", 1);
+  template.resourceCountIs("AWS::ECS::Service", 1);
 });
 
 test('Check for IAM put events policy for created bus', () => {
@@ -128,7 +130,8 @@ test('Check for IAM put events policy for created bus', () => {
 
   createFargateConstructWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -167,7 +170,8 @@ test('Check for IAM put events policy for default event bus', () => {
     fargateServiceProps: { serviceName },
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -212,14 +216,15 @@ test('Check for public/private VPC', () => {
 
   createFargateConstructWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: testCidr
   });
 
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::Events::EventBus', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::EC2::InternetGateway', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('Check for isolated VPC', () => {
@@ -228,14 +233,15 @@ test('Check for isolated VPC', () => {
 
   createFargateConstructWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: testCidr
   });
 
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::Events::EventBus', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('Check for an existing VPC', () => {
@@ -254,11 +260,12 @@ test('Check for an existing VPC', () => {
     existingVpc,
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "172.168.0.0/16"
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
 });
 
 test('Check for custom ARN resource', () => {
@@ -277,7 +284,8 @@ test('Check for custom ARN resource', () => {
     eventBusEnvironmentVariableName: customEnvName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Family: familyName,
     ContainerDefinitions: [
       {
@@ -333,7 +341,8 @@ test('Check for an existing event bus', () => {
   });
 
   expect(construct.eventBus).toBeDefined();
-  expect(stack).toHaveResource("AWS::Events::EventBus", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Events::EventBus", {
     Name: customName
   });
 });
@@ -345,7 +354,8 @@ test('Check for custom event bus props', () => {
 
   createFargateConstructWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::Events::EventBus", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Events::EventBus", {
     Name: eventBusName
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/fargate-opensearch.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/fargate-opensearch.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToOpenSearch } from "../lib";
@@ -55,11 +55,12 @@ test('Test domain and cognito domain name', () => {
     cognitoDomainName: COGNITO_DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     DomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::Cognito::UserPoolDomain", {
+  template.hasResourceProperties("AWS::Cognito::UserPoolDomain", {
     Domain: COGNITO_DOMAIN_NAME
   });
 });
@@ -87,7 +88,8 @@ test('Test cognito dashboard role IAM policy', () => {
 
   deployStackWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -187,7 +189,8 @@ test('Test custom environment variable name', () => {
     domainEndpointEnvironmentVariableName: CUSTOM_ENV_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -235,7 +238,8 @@ test('New service/new domain, public API, new VPC', () => {
 
   deployStackWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -246,11 +250,11 @@ test('New service/new domain, public API, new VPC', () => {
     ServiceName: SERVICE_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     DomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -260,11 +264,11 @@ test('New service/new domain, public API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: CLUSTER_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -304,15 +308,15 @@ test('New service/new domain, public API, new VPC', () => {
     Family: FAMILY_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::OpenSearchService::Domain', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::OpenSearchService::Domain', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new domain, private API, new VPC', () => {
@@ -321,11 +325,12 @@ test('New service/new domain, private API, new VPC', () => {
 
   deployStackWithNewResources(stack, publicApi);
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     DomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -336,11 +341,11 @@ test('New service/new domain, private API, new VPC', () => {
     ServiceName: SERVICE_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: CLUSTER_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -380,15 +385,15 @@ test('New service/new domain, private API, new VPC', () => {
     Family: FAMILY_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::OpenSearchService::Domain', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::OpenSearchService::Domain', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new domain, public API, existing VPC', () => {
@@ -403,11 +408,12 @@ test('New service/new domain, public API, existing VPC', () => {
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     DomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -417,7 +423,7 @@ test('New service/new domain, public API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -456,15 +462,15 @@ test('New service/new domain, public API, existing VPC', () => {
     ],
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::OpenSearchService::Domain', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::OpenSearchService::Domain', 1);
 });
 
 test('New service/new domain, private API, existing VPC', () => {
@@ -479,11 +485,12 @@ test('New service/new domain, private API, existing VPC', () => {
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     DomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -493,7 +500,7 @@ test('New service/new domain, private API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -532,15 +539,15 @@ test('New service/new domain, private API, existing VPC', () => {
     ],
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::OpenSearchService::Domain', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::OpenSearchService::Domain', 1);
 });
 
 test('Existing service/new domain, public API, existing VPC', () => {
@@ -567,15 +574,16 @@ test('Existing service/new domain, public API, existing VPC', () => {
     openSearchDomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     DomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: SERVICE_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -614,15 +622,15 @@ test('Existing service/new domain, public API, existing VPC', () => {
     ],
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::OpenSearchService::Domain', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::OpenSearchService::Domain', 1);
 });
 
 test('Existing service/new domain, private API, existing VPC', () => {
@@ -649,15 +657,16 @@ test('Existing service/new domain, private API, existing VPC', () => {
     openSearchDomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     DomainName: DOMAIN_NAME
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: SERVICE_NAME,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -696,15 +705,15 @@ test('Existing service/new domain, private API, existing VPC', () => {
     ],
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::OpenSearchService::Domain', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::OpenSearchService::Domain', 1);
 });
 
 test('Check error for using OpenSearch VPC prop parameter', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/test/fargate-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/test/fargate-s3.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToS3 } from "../lib";
@@ -48,7 +48,8 @@ test('New service/new bucket, public API, new VPC', () => {
   expect(construct.s3Bucket !== null);
   expect(construct.s3BucketInterface !== null);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -58,22 +59,22 @@ test('New service/new bucket, public API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Family: familyName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: clusterName
   });
 
-  expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: bucketName
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -158,7 +159,7 @@ test('New service/new bucket, public API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Essential: true,
@@ -186,15 +187,15 @@ test('New service/new bucket, public API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::S3::Bucket', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::S3::Bucket', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new bucket, private API, new VPC', () => {
@@ -218,7 +219,8 @@ test('New service/new bucket, private API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -228,7 +230,7 @@ test('New service/new bucket, private API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: bucketName,
     BucketEncryption: {
       ServerSideEncryptionConfiguration: [{
@@ -239,15 +241,15 @@ test('New service/new bucket, private API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: loggingBucketName
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -303,10 +305,10 @@ test('New service/new bucket, private API, new VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::S3::Bucket', 2);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::S3::Bucket', 2);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('Specify bad bucket permission', () => {
@@ -358,7 +360,8 @@ test('New service/existing bucket, private API, existing VPC', () => {
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -368,14 +371,14 @@ test('New service/existing bucket, private API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: bucketName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -416,10 +419,10 @@ test('New service/existing bucket, private API, existing VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::S3::Bucket', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::S3::Bucket', 1);
 });
 
 test('Existing service/new bucket, public API, existing VPC', () => {
@@ -459,11 +462,12 @@ test('Existing service/new bucket, public API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -508,19 +512,19 @@ test('Existing service/new bucket, public API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: bucketName
   });
 
-  expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: loggingBucketName
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -561,10 +565,10 @@ test('Existing service/new bucket, public API, existing VPC', () => {
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::S3::Bucket', 2);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::S3::Bucket', 2);
 });
 
 // Test existing service/existing bucket, private API, new VPC
@@ -600,11 +604,12 @@ test('Existing service/existing bucket, private API, existing VPC', () => {
     bucketPermissions: ['Write']
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -649,14 +654,14 @@ test('Existing service/existing bucket, private API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: bucketName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -694,8 +699,8 @@ test('Existing service/existing bucket, private API, existing VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::S3::Bucket', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::S3::Bucket', 1);
 });

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/test/fargate-secretsmanager.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/test/fargate-secretsmanager.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToSecretsmanager } from "../lib";
@@ -49,7 +49,8 @@ test('New service/new secret, public API, new VPC', () => {
   expect(construct.container !== null);
   expect(construct.secret !== null);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
     LaunchType: 'FARGATE',
     DesiredCount: 2,
@@ -60,15 +61,15 @@ test('New service/new secret, public API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: clusterName
   });
 
-  expect(stack).toHaveResourceLike("AWS::SecretsManager::Secret", {
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     Name: secretName
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -85,7 +86,7 @@ test('New service/new secret, public API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Family: familyName,
     ContainerDefinitions: [
       {
@@ -114,11 +115,11 @@ test('New service/new secret, public API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: cidr
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -134,10 +135,10 @@ test('New service/new secret, public API, new VPC', () => {
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SecretsManager::Secret', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new secret, private API, new VPC', () => {
@@ -154,7 +155,8 @@ test('New service/new secret, private API, new VPC', () => {
     grantWriteAccess: 'readwrite',
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -164,7 +166,7 @@ test('New service/new secret, private API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -200,15 +202,15 @@ test('New service/new secret, private API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SecretsManager::Secret", {
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     Name: secretName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -236,7 +238,7 @@ test('New service/new secret, private API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -252,10 +254,10 @@ test('New service/new secret, private API, new VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SecretsManager::Secret', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/existing secret, private API, existing VPC', () => {
@@ -275,7 +277,8 @@ test('New service/existing secret, private API, existing VPC', () => {
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -285,7 +288,7 @@ test('New service/existing secret, private API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -321,14 +324,14 @@ test('New service/existing secret, private API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SecretsManager::Secret", {
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     Name: secretName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -345,7 +348,7 @@ test('New service/existing secret, private API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -361,10 +364,10 @@ test('New service/existing secret, private API, existing VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::SecretsManager::Secret', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 1);
 });
 
 test('Existing service/new secret, public API, existing VPC', () => {
@@ -395,11 +398,12 @@ test('Existing service/new secret, public API, existing VPC', () => {
     grantWriteAccess: 'readwrite'
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -435,15 +439,15 @@ test('Existing service/new secret, public API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SecretsManager::Secret", {
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     Name: secretName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -471,7 +475,7 @@ test('Existing service/new secret, public API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -487,10 +491,10 @@ test('Existing service/new secret, public API, existing VPC', () => {
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::SecretsManager::Secret', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 1);
 });
 
 test('Existing service/existing secret, private API, existing VPC', () => {
@@ -521,11 +525,12 @@ test('Existing service/existing secret, private API, existing VPC', () => {
     existingSecretObj
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -561,15 +566,15 @@ test('Existing service/existing secret, private API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SecretsManager::Secret", {
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     Name: secretName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -586,7 +591,7 @@ test('Existing service/existing secret, private API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -602,10 +607,10 @@ test('Existing service/existing secret, private API, existing VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::SecretsManager::Secret', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 1);
 });
 
 test('Test error invalid secret permission', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/test/fargate-sns.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/test/fargate-sns.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToSns } from "../lib";
@@ -44,7 +44,8 @@ test('New service/new topic, public API, new VPC', () => {
   });
 
   expect(testConstruct.snsTopic).toBeDefined();
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -54,22 +55,22 @@ test('New service/new topic, public API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Family: 'family-name'
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: clusterName
   });
 
-  expect(stack).toHaveResourceLike("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: topicName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Essential: true,
@@ -97,14 +98,14 @@ test('New service/new topic, public API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SNS::Topic', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SNS::Topic', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new topic, private API, new VPC', () => {
@@ -121,7 +122,8 @@ test('New service/new topic, private API, new VPC', () => {
     vpcProps: { ipAddresses: ec2.IpAddresses.cidr('172.0.0.0/16') }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -131,18 +133,18 @@ test('New service/new topic, private API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
 
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SNS::Topic', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SNS::Topic', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/existing topic, private API, existing VPC', () => {
@@ -166,7 +168,8 @@ test('New service/existing topic, private API, existing VPC', () => {
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -176,15 +179,15 @@ test('New service/existing topic, private API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: topicName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SNS::Topic', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SNS::Topic', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('Existing service/new topic, public API, existing VPC', () => {
@@ -216,11 +219,12 @@ test('Existing service/new topic, public API, existing VPC', () => {
     topicNameEnvironmentVariableName: 'CUSTOM_NAME',
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -264,14 +268,14 @@ test('Existing service/new topic, public API, existing VPC', () => {
       }
     ]
   });
-  expect(stack).toHaveResourceLike("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SNS::Topic', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SNS::Topic', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 // Test existing service/existing topic, private API, new VPC
@@ -308,11 +312,12 @@ test('Existing service/existing topic, private API, existing VPC', () => {
     existingTopicObject: existingTopic
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -357,15 +362,15 @@ test('Existing service/existing topic, private API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: topicName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SNS::Topic', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SNS::Topic', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('Topic is encrypted with imported CMK when set on encryptionKey prop', () => {
@@ -380,7 +385,8 @@ test('Topic is encrypted with imported CMK when set on encryptionKey prop', () =
     encryptionKey: cmk
   });
 
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -404,7 +410,8 @@ test('Topic is encrypted with imported CMK when set on topicProps.masterKey prop
     }
   });
 
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -427,7 +434,8 @@ test('Topic is encrypted with provided encrytionKeyProps', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',
@@ -436,7 +444,7 @@ test('Topic is encrypted with provided encrytionKeyProps', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Alias', {
+  template.hasResourceProperties('AWS::KMS::Alias', {
     AliasName: 'alias/new-key-alias-from-props',
     TargetKeyId: {
       'Fn::GetAtt': [
@@ -457,7 +465,8 @@ test('Topic is encrypted by default with AWS-managed KMS key when no other encry
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       'Fn::Join': [
         "",
@@ -484,7 +493,8 @@ test('Topic is encrypted with customer managed KMS Key when enable encryption fl
     enableEncryptionWithCustomerManagedKey: true
   });
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/test/fargate-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/test/fargate-sqs.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToSqs } from "../lib";
@@ -47,7 +47,8 @@ test('New service/new queue, dlq, public API, new VPC', () => {
     queuePermissions: ['Read', 'Write']
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -63,26 +64,26 @@ test('New service/new queue, dlq, public API, new VPC', () => {
   expect(construct.sqsQueue !== null);
   expect(construct.deadLetterQueue !== null);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Family: familyName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: clusterName
   });
 
-  expect(stack).toHaveResourceLike("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: queueName
   });
 
-  expect(stack).toHaveResourceLike("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: deadLetterQueueName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Essential: true,
@@ -110,11 +111,11 @@ test('New service/new queue, dlq, public API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -152,10 +153,10 @@ test('New service/new queue, dlq, public API, new VPC', () => {
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SQS::Queue', 2);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SQS::Queue', 2);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new queue, private API, new VPC', () => {
@@ -172,7 +173,8 @@ test('New service/new queue, private API, new VPC', () => {
     queuePermissions: ['Read']
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -182,15 +184,15 @@ test('New service/new queue, private API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -214,10 +216,10 @@ test('New service/new queue, private API, new VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SQS::Queue', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SQS::Queue', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/existing fifo queue, private API, existing VPC', () => {
@@ -240,7 +242,8 @@ test('New service/existing fifo queue, private API, existing VPC', () => {
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -250,16 +253,16 @@ test('New service/existing fifo queue, private API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: queueName,
     FifoQueue: true
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -281,10 +284,10 @@ test('New service/existing fifo queue, private API, existing VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SQS::Queue', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SQS::Queue', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('Existing service/new queue, public API, existing VPC', () => {
@@ -324,11 +327,12 @@ test('Existing service/new queue, public API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -372,23 +376,23 @@ test('Existing service/new queue, public API, existing VPC', () => {
       }
     ]
   });
-  expect(stack).toHaveResourceLike("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: queueName
   });
 
-  expect(stack).toHaveResourceLike("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: dlqName
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SQS::Queue', 2);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SQS::Queue', 2);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 // Test existing service/existing queue, private API, new VPC
@@ -423,11 +427,12 @@ test('Existing service/existing queue, private API, existing VPC', () => {
     existingQueueObj: existingQueue
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -472,18 +477,18 @@ test('Existing service/existing queue, private API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: queueName
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SQS::Queue', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SQS::Queue', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('Test bad queuePermissions', () => {
@@ -519,7 +524,8 @@ test('Queue is encrypted with imported CMK when set on encryptionKey prop', () =
     encryptionKey: cmk
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -543,7 +549,8 @@ test('Queue is encrypted with imported CMK when set on queueProps.encryptionMast
     }
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -566,11 +573,12 @@ test('Queue is encrypted with provided encrytionKeyProps', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Alias', {
+  template.hasResourceProperties('AWS::KMS::Alias', {
     AliasName: 'alias/new-key-alias-from-props',
     TargetKeyId: {
       'Fn::GetAtt': [
@@ -591,7 +599,8 @@ test('Queue is encrypted with SQS-managed KMS key when no other encryption propr
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 });
@@ -607,7 +616,8 @@ test('Queue is encrypted with customer managed KMS Key when enable encryption fl
     enableEncryptionWithCustomerManagedKey: true
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "testconstructEncryptionKey6153B053",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/test/fargate-ssmstringparameter.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/test/fargate-ssmstringparameter.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as cdk from "aws-cdk-lib";
 import { FargateToSsmstringparameter } from "../lib";
@@ -52,7 +52,8 @@ test('New service/new parameter store, public API, new VPC', () => {
   expect(construct.container !== null);
   expect(construct.stringParameter !== null);
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
     LaunchType: 'FARGATE',
     DesiredCount: 2,
@@ -63,16 +64,16 @@ test('New service/new parameter store, public API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: clusterName
   });
 
-  expect(stack).toHaveResourceLike("AWS::SSM::Parameter", {
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Name: parameterName,
     Value: stringValue
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -111,7 +112,7 @@ test('New service/new parameter store, public API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Family: familyName,
     ContainerDefinitions: [
       {
@@ -140,11 +141,11 @@ test('New service/new parameter store, public API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -160,10 +161,10 @@ test('New service/new parameter store, public API, new VPC', () => {
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SSM::Parameter', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SSM::Parameter', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/new parameter store, private API, new VPC', () => {
@@ -181,7 +182,8 @@ test('New service/new parameter store, private API, new VPC', () => {
     stringParameterPermissions: 'readwrite',
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -191,7 +193,7 @@ test('New service/new parameter store, private API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -227,16 +229,16 @@ test('New service/new parameter store, private API, new VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SSM::Parameter", {
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Name: parameterName,
     Value: stringValue
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.0.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -303,7 +305,7 @@ test('New service/new parameter store, private API, new VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -319,10 +321,10 @@ test('New service/new parameter store, private API, new VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::SSM::Parameter', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::SSM::Parameter', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
 });
 
 test('New service/existing parameter store, private API, existing VPC', () => {
@@ -340,7 +342,8 @@ test('New service/existing parameter store, private API, existing VPC', () => {
     ecrRepositoryArn: defaults.fakeEcrRepoArn,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     LaunchType: 'FARGATE',
     DesiredCount: 2,
     DeploymentConfiguration: {
@@ -350,7 +353,7 @@ test('New service/existing parameter store, private API, existing VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -386,15 +389,15 @@ test('New service/existing parameter store, private API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SSM::Parameter", {
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Name: parameterName,
     Value: stringValue
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -433,7 +436,7 @@ test('New service/existing parameter store, private API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -449,10 +452,10 @@ test('New service/existing parameter store, private API, existing VPC', () => {
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::SSM::Parameter', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::SSM::Parameter', 1);
 });
 
 test('Existing service/new parameter store, public API, existing VPC', () => {
@@ -484,11 +487,12 @@ test('Existing service/new parameter store, public API, existing VPC', () => {
     stringParameterPermissions: 'readwrite'
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -524,16 +528,16 @@ test('Existing service/new parameter store, public API, existing VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SSM::Parameter", {
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Name: parameterName,
     Value: stringValue
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -600,7 +604,7 @@ test('Existing service/new parameter store, public API, existing VPC', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -616,10 +620,10 @@ test('Existing service/new parameter store, public API, existing VPC', () => {
   });
 
   // Confirm we created a Public/Private VPC
-  expect(stack).toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::SSM::Parameter', 1);
+  template.hasResourceProperties('AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::SSM::Parameter', 1);
 });
 
 test('Existing service/existing parameter store, private API, existing VPC', () => {
@@ -648,11 +652,12 @@ test('Existing service/existing parameter store, private API, existing VPC', () 
     existingStringParameterObj: existingParameterStore
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::Service", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
   });
 
-  expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Environment: [
@@ -688,15 +693,15 @@ test('Existing service/existing parameter store, private API, existing VPC', () 
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::SSM::Parameter", {
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Name: parameterName,
     Value: stringValue
   });
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: '172.168.0.0/16'
   });
 
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -735,7 +740,7 @@ test('Existing service/existing parameter store, private API, existing VPC', () 
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -751,10 +756,10 @@ test('Existing service/existing parameter store, private API, existing VPC', () 
   });
 
   // Confirm we created an Isolated VPC
-  expect(stack).not.toHaveResourceLike('AWS::EC2::InternetGateway', {});
-  expect(stack).toCountResources('AWS::EC2::VPC', 1);
-  expect(stack).toCountResources('AWS::ECS::Service', 1);
-  expect(stack).toCountResources('AWS::SSM::Parameter', 1);
+  defaults.expectNonexistence(stack, 'AWS::EC2::InternetGateway', {});
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::ECS::Service', 1);
+  template.resourceCountIs('AWS::SSM::Parameter', 1);
 });
 
 test('Test error invalid string parameter permission', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/test/test.iot-kinesisfirehose-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/test/test.iot-kinesisfirehose-s3.test.ts
@@ -14,7 +14,7 @@
 import { IotToKinesisFirehoseToS3, IotToKinesisFirehoseToS3Props } from "../lib";
 import * as cdk from "aws-cdk-lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deploy(stack: cdk.Stack) {
   const props: IotToKinesisFirehoseToS3Props = {
@@ -39,7 +39,8 @@ test('check iot topic rule properties', () => {
 
   deploy(stack);
 
-  expect(stack).toHaveResource('AWS::IoT::TopicRule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IoT::TopicRule', {
     TopicRulePayload: {
       Actions: [
         {
@@ -94,7 +95,8 @@ test('check firehose and s3 overrides', () => {
   };
   new IotToKinesisFirehoseToS3(stack, 'test-iot-firehose-s3', props);
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     PublicAccessBlockConfiguration: {
       BlockPublicAcls: false,
       BlockPublicPolicy: true,
@@ -103,7 +105,7 @@ test('check firehose and s3 overrides', () => {
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::KinesisFirehose::DeliveryStream", {
+  template.hasResourceProperties("AWS::KinesisFirehose::DeliveryStream", {
     ExtendedS3DestinationConfiguration: {
       BufferingHints: {
         IntervalInSeconds: 600,
@@ -179,11 +181,12 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -245,5 +248,6 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toCountResources("AWS::S3::Bucket", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 1);
 });

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/test/test.iot-kinesisstreams.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/test/test.iot-kinesisstreams.test.ts
@@ -16,8 +16,7 @@ import * as cdk from "aws-cdk-lib";
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
 import * as iot from 'aws-cdk-lib/aws-iot';
 import * as iam from 'aws-cdk-lib/aws-iam';
-// import * as defaults from '@aws-solutions-constructs/core';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 const iotTopicRuleProps: iot.CfnTopicRuleProps = {
   topicRulePayload: {
@@ -35,7 +34,8 @@ test('check iot topic rule properties', () => {
   };
   const construct = new IotToKinesisStreams(stack, 'test-iot-kinesisstreams', props);
 
-  expect(stack).toHaveResource('AWS::IoT::TopicRule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IoT::TopicRule', {
     TopicRulePayload: {
       Actions: [
         {
@@ -58,7 +58,7 @@ test('check iot topic rule properties', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::Kinesis::Stream', {
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     ShardCount: 1,
     RetentionPeriodHours: 24,
     StreamEncryption: {
@@ -89,13 +89,14 @@ test('check existing kinesis stream', () => {
   };
   const construct = new IotToKinesisStreams(stack, 'test-iot-kinesisstreams', props);
 
-  expect(stack).toHaveResourceLike('AWS::Kinesis::Stream', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     ShardCount: 2,
     RetentionPeriodHours: 25,
     Name: 'testexistingstream'
   });
 
-  expect(stack).not.toHaveResource('AWS::CloudWatch::Alarm');
+  template.resourceCountIs('AWS::CloudWatch::Alarm', 0);
 
   expect(construct.iotTopicRule).toBeDefined();
   expect(construct.iotActionsRole).toBeDefined();
@@ -117,7 +118,8 @@ test('check new kinesis stream with override props', () => {
   };
   const construct = new IotToKinesisStreams(stack, 'test-iot-kinesisstreams', props);
 
-  expect(stack).toHaveResourceLike('AWS::Kinesis::Stream', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     ShardCount: 5,
     RetentionPeriodHours: 30,
     Name: 'testnewstream'
@@ -162,7 +164,8 @@ test('check existing action in topic rule props', () => {
   new IotToKinesisStreams(stack, 'test-iot-kinesisstreams', props);
 
   // Check multiple actions in the Topic Rule
-  expect(stack).toHaveResource('AWS::IoT::TopicRule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IoT::TopicRule', {
     TopicRulePayload: {
       Actions: [
         {
@@ -198,13 +201,13 @@ test('check existing action in topic rule props', () => {
     RuleName: "testiotrulename"
   });
 
-  expect(stack).toHaveResourceLike('AWS::Kinesis::Stream', {
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     ShardCount: 5,
     RetentionPeriodHours: 30,
     Name: 'testnewstream'
   });
 
-  expect(stack).toCountResources('AWS::Kinesis::Stream', 2);
+  template.resourceCountIs('AWS::Kinesis::Stream', 2);
 });
 
 test('check name confict', () => {
@@ -216,7 +219,8 @@ test('check name confict', () => {
   new IotToKinesisStreams(stack, 'test-iot-kinesisstreams1', props);
   new IotToKinesisStreams(stack, 'test-iot-kinesisstreams2', props);
 
-  expect(stack).toCountResources('AWS::Kinesis::Stream', 2);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::Kinesis::Stream', 2);
 });
 
 test('check construct chaining', () => {
@@ -233,7 +237,8 @@ test('check construct chaining', () => {
   };
   new IotToKinesisStreams(stack, 'test-iot-kinesisstreams2', props2);
 
-  expect(stack).toCountResources('AWS::Kinesis::Stream', 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::Kinesis::Stream', 1);
 });
 
 test('check error when stream props and existing stream is supplied', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/test/iot-lambda-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/test/iot-lambda-dynamodb.test.ts
@@ -15,7 +15,7 @@ import { IotToLambdaToDynamoDB, IotToLambdaToDynamoDBProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployStack(stack: cdk.Stack) {
   const props: IotToLambdaToDynamoDBProps = {
@@ -42,7 +42,8 @@ test('check lambda function properties', () => {
 
   deployStack(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -67,7 +68,8 @@ test('check lambda function permission', () => {
 
   deployStack(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Permission', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Permission', {
     Action: "lambda:InvokeFunction",
     FunctionName: {
       "Fn::GetAtt": [
@@ -90,7 +92,8 @@ test('check iot lambda function role', () => {
 
   deployStack(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -149,7 +152,8 @@ test('check iot topic rule properties', () => {
 
   deployStack(stack);
 
-  expect(stack).toHaveResource('AWS::IoT::TopicRule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IoT::TopicRule', {
     TopicRulePayload: {
       Actions: [
         {
@@ -176,7 +180,8 @@ test('check dynamo table properties', () => {
 
   deployStack(stack);
 
-  expect(stack).toHaveResource('AWS::DynamoDB::Table', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::DynamoDB::Table', {
     KeySchema: [
       {
         AttributeName: "id",
@@ -201,7 +206,8 @@ test('check lambda function policy ', () => {
 
   deployStack(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Policy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -345,7 +351,8 @@ test('check lambda function custom environment variable', () => {
 
   new IotToLambdaToDynamoDB(stack, 'test-lambda-dynamodb-stack', props);
 
-  expect(stack).toHaveResourceLike('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -383,7 +390,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -404,17 +412,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -446,7 +454,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -467,18 +476,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -508,7 +517,8 @@ test("Test minimal deployment with an existing VPC", () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -529,7 +539,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/test/iot-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/test/iot-lambda.test.ts
@@ -14,7 +14,7 @@
 import { IotToLambda, IotToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployNewFunc(stack: cdk.Stack) {
   const props: IotToLambdaProps = {
@@ -64,7 +64,8 @@ test('check lambda function properties for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -81,7 +82,8 @@ test('check lambda function permission for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Permission', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Permission', {
     Action: "lambda:InvokeFunction",
     FunctionName: {
       "Fn::GetAtt": [
@@ -104,7 +106,8 @@ test('check iot lambda function role for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -163,7 +166,8 @@ test('check iot topic rule properties for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IoT::TopicRule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IoT::TopicRule', {
     TopicRulePayload: {
       Actions: [
         {
@@ -189,7 +193,8 @@ test('check lambda function properties for deploy: false', () => {
 
   useExistingFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -206,7 +211,8 @@ test('check lambda function permissions for deploy: false', () => {
 
   useExistingFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Permission', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Permission', {
     Action: "lambda:InvokeFunction",
     FunctionName: {
       "Fn::GetAtt": [
@@ -229,7 +235,8 @@ test('check iot lambda function role for deploy: false', () => {
 
   useExistingFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/test/iot-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/test/iot-sqs.test.ts
@@ -14,9 +14,10 @@
 // Imports
 import { Stack } from "aws-cdk-lib";
 import { IotToSqs, IotToSqsProps } from "../lib";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as kms from 'aws-cdk-lib/aws-kms';
+import * as defaults from '@aws-solutions-constructs/core';
 
 // --------------------------------------------------------------
 // Pattern deployment with default props
@@ -37,7 +38,8 @@ test('Pattern deployment with default props', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a default sqs queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "testiotsqsEncryptionKey64EE64B1",
@@ -47,12 +49,12 @@ test('Pattern deployment with default props', () => {
   });
 
   // Creates a dead letter queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
   // Creates an IoT Topic Rule
-  expect(stack).toHaveResource("AWS::IoT::TopicRule", {
+  template.hasResourceProperties("AWS::IoT::TopicRule", {
     TopicRulePayload: {
       Actions: [
         {
@@ -74,7 +76,7 @@ test('Pattern deployment with default props', () => {
   });
 
   // Creates an encryption key
-  expect(stack).toHaveResource("AWS::KMS::Key", {
+  template.hasResourceProperties("AWS::KMS::Key", {
     EnableKeyRotation: true
   });
 });
@@ -104,7 +106,8 @@ test('Pattern deployment with existing queue', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a default sqs queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "existing-queue-obj"
   });
 });
@@ -135,7 +138,8 @@ test('Pattern deployment with queue and dead letter queue props', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a queue using the provided props
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "queue-name",
     RedrivePolicy: {
       deadLetterTargetArn: {
@@ -149,7 +153,7 @@ test('Pattern deployment with queue and dead letter queue props', () => {
   });
 
   // Creates a dead letter queue using the provided props
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "dlq-name"
   });
 });
@@ -178,12 +182,13 @@ test('Pattern deployment with dead letter queue turned off', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a queue using the provided props
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "queue-name"
   });
 
   // Does not create the default dead letter queue
-  expect(stack).not.toHaveResource("AWS::SQS::Queue", {
+  defaults.expectNonexistence(stack, "AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 });
@@ -216,7 +221,8 @@ test('Pattern deployment with custom maxReceiveCount', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a queue using the provided props
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "queue-name",
     RedrivePolicy: {
       deadLetterTargetArn: {
@@ -251,17 +257,18 @@ test('Pattern deployment without creating a KMS key', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a default sqs queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
   // Creates a dead letter queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
   // Creates an IoT Topic Rule
-  expect(stack).toHaveResource("AWS::IoT::TopicRule", {
+  template.hasResourceProperties("AWS::IoT::TopicRule", {
     TopicRulePayload: {
       Actions: [
         {
@@ -283,7 +290,7 @@ test('Pattern deployment without creating a KMS key', () => {
   });
 
   // Does not create an encryption key
-  expect(stack).not.toHaveResource("AWS::KMS::Key");
+  template.resourceCountIs("AWS::KMS::Key", 0);
 });
 
 // --------------------------------------------------------------
@@ -312,7 +319,8 @@ test('Pattern deployment with existing KMS key', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a default sqs queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "existingkey205DFC01",
@@ -322,12 +330,12 @@ test('Pattern deployment with existing KMS key', () => {
   });
 
   // Creates a dead letter queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
   // Creates an IoT Topic Rule
-  expect(stack).toHaveResource("AWS::IoT::TopicRule", {
+  template.hasResourceProperties("AWS::IoT::TopicRule", {
     TopicRulePayload: {
       Actions: [
         {
@@ -349,7 +357,7 @@ test('Pattern deployment with existing KMS key', () => {
   });
 
   // Uses the provided key
-  expect(stack).toHaveResource("AWS::KMS::Key", {
+  template.hasResourceProperties("AWS::KMS::Key", {
     EnableKeyRotation: false
   });
 });
@@ -382,7 +390,8 @@ test('Pattern deployment with existing KMS key', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a default sqs queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "existingkey205DFC01",
@@ -392,12 +401,12 @@ test('Pattern deployment with existing KMS key', () => {
   });
 
   // Creates a dead letter queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
   // Creates an IoT Topic Rule
-  expect(stack).toHaveResource("AWS::IoT::TopicRule", {
+  template.hasResourceProperties("AWS::IoT::TopicRule", {
     TopicRulePayload: {
       Actions: [
         {
@@ -419,7 +428,7 @@ test('Pattern deployment with existing KMS key', () => {
   });
 
   // Uses the provided key
-  expect(stack).toHaveResource("AWS::KMS::Key", {
+  template.hasResourceProperties("AWS::KMS::Key", {
     EnableKeyRotation: false
   });
 });
@@ -448,7 +457,8 @@ test('Pattern deployment passing KMS key props', () => {
   new IotToSqs(stack, 'test-iot-sqs', props);
 
   // Creates a default sqs queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "testiotsqsEncryptionKey64EE64B1",
@@ -458,12 +468,12 @@ test('Pattern deployment passing KMS key props', () => {
   });
 
   // Creates a dead letter queue
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 
   // Creates an IoT Topic Rule
-  expect(stack).toHaveResource("AWS::IoT::TopicRule", {
+  template.hasResourceProperties("AWS::IoT::TopicRule", {
     TopicRulePayload: {
       Actions: [
         {
@@ -485,11 +495,11 @@ test('Pattern deployment passing KMS key props', () => {
   });
 
   // Uses the props to create the key
-  expect(stack).toHaveResource("AWS::KMS::Key", {
+  template.hasResourceProperties("AWS::KMS::Key", {
     EnableKeyRotation: false
   });
 
-  expect(stack).toHaveResource("AWS::KMS::Alias", {
+  template.hasResourceProperties("AWS::KMS::Alias", {
     AliasName: "alias/new-key-alias-from-props",
     TargetKeyId: {
       "Fn::GetAtt": [

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/test/kinesisfirehose-s3-and-kinesisanalytics.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/test/kinesisfirehose-s3-and-kinesisanalytics.test.ts
@@ -15,7 +15,7 @@
 import { Stack, RemovalPolicy } from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { KinesisFirehoseToAnalyticsAndS3, KinesisFirehoseToAnalyticsAndS3Props } from '../lib';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test Case 2 - Test the getter methods
@@ -92,7 +92,8 @@ test('test kinesisFirehose override ', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::KinesisFirehose::DeliveryStream", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::KinesisFirehose::DeliveryStream", {
     ExtendedS3DestinationConfiguration: {
       BufferingHints: {
         IntervalInSeconds: 600,
@@ -157,11 +158,12 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -210,5 +212,6 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toCountResources("AWS::S3::Bucket", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 1);
 });

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/test/kinesisstreams-kinesisfirehose-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/test/kinesisstreams-kinesisfirehose-s3.test.ts
@@ -13,7 +13,7 @@
 
 import { KinesisStreamsToKinesisFirehoseToS3, KinesisStreamsToKinesisFirehoseToS3Props } from '../lib';
 import * as cdk from 'aws-cdk-lib';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -38,7 +38,8 @@ test('test kinesisFirehose override ', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::KinesisFirehose::DeliveryStream", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::KinesisFirehose::DeliveryStream", {
     ExtendedS3DestinationConfiguration: {
       BufferingHints: {
         IntervalInSeconds: 600,
@@ -55,7 +56,8 @@ test('test kinesisFirehose.deliveryStreamType override ', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::KinesisFirehose::DeliveryStream", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::KinesisFirehose::DeliveryStream", {
     DeliveryStreamType: 'KinesisStreamAsSource'
   });
 });
@@ -79,7 +81,8 @@ test('test kinesisFirehose.kinesisStreamSourceConfiguration override ', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::KinesisFirehose::DeliveryStream", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::KinesisFirehose::DeliveryStream", {
     KinesisStreamSourceConfiguration: {
       KinesisStreamARN: {
         "Fn::GetAtt": [
@@ -106,7 +109,8 @@ test('test kinesisStreamProps override ', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::Kinesis::Stream", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Kinesis::Stream", {
     ShardCount: 3
   });
 });
@@ -199,11 +203,12 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -232,5 +237,6 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toCountResources("AWS::S3::Bucket", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 1);
 });

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/kinesisstreams-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/kinesisstreams-lambda.test.ts
@@ -16,7 +16,7 @@ import { Stack, Duration } from "aws-cdk-lib";
 import { KinesisStreamsToLambda, KinesisStreamsToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test properties
@@ -66,13 +66,14 @@ test('Test existing resources', () => {
 
   });
 
-  expect(stack).toHaveResource('AWS::Kinesis::Stream', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     Name: 'existing-stream',
     ShardCount: 5,
     RetentionPeriodHours: 48,
   });
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
   });
@@ -96,7 +97,8 @@ test('test sqsDlqQueueProps override', () => {
   };
   new KinesisStreamsToLambda(stack, 'test-kinesis-streams-lambda', props);
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "hello-world",
     VisibilityTimeout: 50
   });

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/test/lambda-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/test/lambda-dynamodb.test.ts
@@ -11,13 +11,12 @@
  *  and limitations under the License.
  */
 
-import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
 import { LambdaToDynamoDB, LambdaToDynamoDBProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployNewFunc(stack: cdk.Stack) {
   const props: LambdaToDynamoDBProps = {
@@ -59,7 +58,8 @@ test('check lambda function properties for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -84,7 +84,8 @@ test('check dynamo table properties for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::DynamoDB::Table', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::DynamoDB::Table', {
     KeySchema: [
       {
         AttributeName: "id",
@@ -109,7 +110,8 @@ test('check lambda function role for deploy: true', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -168,7 +170,8 @@ test('check lambda function policy default table permissions', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Policy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -218,7 +221,8 @@ test('check lambda function properties for deploy: false', () => {
 
   useExistingFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -235,7 +239,8 @@ test('check lambda function role for existing function', () => {
 
   useExistingFunc(stack);
 
-  expect(stack).toHaveResource('AWS::IAM::Role', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -299,7 +304,8 @@ test('check for no prop', () => {
   };
   new LambdaToDynamoDB(stack, 'test-iot-lambda-stack', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": [
@@ -333,7 +339,8 @@ test('check lambda function policy ReadOnly table permissions', () => {
 
   new LambdaToDynamoDB(stack, 'test-lambda-dynamodb-stack', props);
 
-  expectCDK(stack).to(haveResource('AWS::IAM::Policy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -371,7 +378,7 @@ test('check lambda function policy ReadOnly table permissions', () => {
       ],
       Version: "2012-10-17"
     }
-  }));
+  });
 
 });
 
@@ -389,7 +396,8 @@ test('check lambda function policy WriteOnly table permissions', () => {
 
   new LambdaToDynamoDB(stack, 'test-lambda-dynamodb-stack', props);
 
-  expectCDK(stack).to(haveResource('AWS::IAM::Policy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -424,7 +432,7 @@ test('check lambda function policy WriteOnly table permissions', () => {
       ],
       Version: "2012-10-17"
     }
-  }));
+  });
 
 });
 
@@ -442,7 +450,8 @@ test('check lambda function policy ReadWrite table permissions', () => {
 
   new LambdaToDynamoDB(stack, 'test-lambda-dynamodb-stack', props);
 
-  expectCDK(stack).to(haveResource('AWS::IAM::Policy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -484,7 +493,7 @@ test('check lambda function policy ReadWrite table permissions', () => {
       ],
       Version: "2012-10-17"
     }
-  }));
+  });
 
 });
 
@@ -502,7 +511,8 @@ test('check lambda function policy All table permissions', () => {
 
   new LambdaToDynamoDB(stack, 'test-lambda-dynamodb-stack', props);
 
-  expectCDK(stack).to(haveResource('AWS::IAM::Policy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -531,7 +541,7 @@ test('check lambda function policy All table permissions', () => {
       ],
       Version: "2012-10-17"
     }
-  }));
+  });
 
 });
 
@@ -548,7 +558,8 @@ test('check lambda function custom environment variable', () => {
 
   new LambdaToDynamoDB(stack, 'test-lambda-dynamodb-stack', props);
 
-  expectCDK(stack).to(haveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -559,7 +570,7 @@ test('check lambda function custom environment variable', () => {
         }
       }
     }
-  }));
+  });
 });
 
 // --------------------------------------------------------------
@@ -578,7 +589,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -599,17 +611,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -633,7 +645,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -654,18 +667,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -687,7 +700,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -708,7 +722,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/test/lambda-elasticachememcached.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/test/lambda-elasticachememcached.test.ts
@@ -12,16 +12,13 @@
  */
 
 // Imports
-// import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
-// import { LambdaToElasticachememcached, LambdaToElasticachememcachedProps } from "../lib";
-// import * as lambda from '@aws-cdk/aws-lambda';
-// import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
 import * as defaults from "@aws-solutions-constructs/core";
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { LambdaToElasticachememcached } from "../lib";
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Template } from "aws-cdk-lib/assertions";
 
 const testPort = 12321;
 const testFunctionName = "something-unique";
@@ -40,7 +37,8 @@ test("When provided a VPC, does not create a second VPC", () => {
     },
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
 });
 
 test("When provided an existingCache, does not create a second cache", () => {
@@ -59,8 +57,9 @@ test("When provided an existingCache, does not create a second cache", () => {
     },
   });
 
-  expect(stack).toCountResources("AWS::ElastiCache::CacheCluster", 1);
-  expect(stack).toHaveResourceLike("AWS::ElastiCache::CacheCluster", {
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::ElastiCache::CacheCluster", 1);
+  template.hasResourceProperties("AWS::ElastiCache::CacheCluster", {
     Port: testPort,
   });
 });
@@ -82,8 +81,9 @@ test("When provided an existingFunction, does not create a second function", () 
     existingLambdaObj: existingFunction,
   });
 
-  expect(stack).toCountResources("AWS::Lambda::Function", 1);
-  expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::Lambda::Function", 1);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     FunctionName: testFunctionName,
   });
 });
@@ -102,7 +102,8 @@ test("Test custom environment variable name", () => {
     cacheEndpointEnvironmentVariableName: testEnvironmentVariableName,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Environment: {
       Variables: {
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
@@ -143,7 +144,8 @@ test("Test setting custom function properties", () => {
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     FunctionName: testFunctionName,
   });
 });
@@ -162,7 +164,8 @@ test("Test setting custom cache properties", () => {
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::ElastiCache::CacheCluster", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::ElastiCache::CacheCluster", {
     ClusterName: testClusterName,
   });
 });
@@ -181,7 +184,8 @@ test("Test setting custom VPC properties", () => {
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: testCidrBlock,
   });
 });
@@ -196,11 +200,12 @@ test("Test all default values", () => {
     },
   });
 
-  expect(stack).toCountResources("AWS::Lambda::Function", 1);
-  expect(stack).toCountResources("AWS::ElastiCache::CacheCluster", 1);
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::Lambda::Function", 1);
+  template.resourceCountIs("AWS::ElastiCache::CacheCluster", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
 
-  expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Environment: {
       Variables: {
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
@@ -231,7 +236,7 @@ test("Test all default values", () => {
   });
 
   // All values taken from elasticache-defaults.ts
-  expect(stack).toHaveResourceLike("AWS::ElastiCache::CacheCluster", {
+  template.hasResourceProperties("AWS::ElastiCache::CacheCluster", {
     CacheNodeType: "cache.t3.medium",
     Engine: "memcached",
     NumCacheNodes: 2,
@@ -239,7 +244,7 @@ test("Test all default values", () => {
     AZMode: "cross-az",
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
@@ -259,7 +264,8 @@ test('Test for the proper self referencing security group', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::SecurityGroupIngress", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
     IpProtocol: "TCP",
     FromPort: 22223,
     ToPort: 22223,

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/lambda-elasticsearch-kibana.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/lambda-elasticsearch-kibana.test.ts
@@ -15,7 +15,7 @@ import { LambdaToElasticSearchAndKibana, LambdaToElasticSearchAndKibanaProps } f
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 
 function deployNewFunc(stack: cdk.Stack) {
@@ -32,14 +32,15 @@ test('check domain names', () => {
 
   deployNewFunc(stack);
 
-  expect(stack).toHaveResource('AWS::Cognito::UserPoolDomain', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Cognito::UserPoolDomain', {
     Domain: "test-domain",
     UserPoolId: {
       Ref: "testlambdaelasticsearchstackCognitoUserPool05D1387E"
     }
   });
 
-  expect(stack).toHaveResource('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     DomainName: "test-domain",
   });
 });
@@ -102,7 +103,8 @@ test('check lambda function custom environment variable', () => {
 
   new LambdaToElasticSearchAndKibana(stack, 'test-lambda-elasticsearch-stack', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -129,7 +131,8 @@ test('check override cognito domain name with provided cognito domain name', () 
 
   new LambdaToElasticSearchAndKibana(stack, 'test-lambda-elasticsearch-stack', props);
 
-  expect(stack).toHaveResource('AWS::Cognito::UserPoolDomain', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Cognito::UserPoolDomain', {
     Domain: 'test-cognito-domain'
   });
 });
@@ -143,7 +146,8 @@ test("Test minimal deployment that deploys a VPC in 2 AZ without vpcProps", () =
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -164,7 +168,7 @@ test("Test minimal deployment that deploys a VPC in 2 AZ without vpcProps", () =
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -177,7 +181,7 @@ test("Test minimal deployment that deploys a VPC in 2 AZ without vpcProps", () =
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
@@ -194,7 +198,8 @@ test("Test minimal deployment that deploys a VPC in 3 AZ without vpcProps", () =
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -218,7 +223,7 @@ test("Test minimal deployment that deploys a VPC in 3 AZ without vpcProps", () =
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -234,7 +239,7 @@ test("Test minimal deployment that deploys a VPC in 3 AZ without vpcProps", () =
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
@@ -264,7 +269,8 @@ test("Test ES cluster deploy to 1 AZ when user set zoneAwarenessEnabled to false
     }
   });
 
-  expect(stack).toHaveResource("AWS::Elasticsearch::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     ElasticsearchClusterConfig: {
       DedicatedMasterCount: 3,
       DedicatedMasterEnabled: true,
@@ -273,7 +279,7 @@ test("Test ES cluster deploy to 1 AZ when user set zoneAwarenessEnabled to false
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -311,7 +317,8 @@ test("Test ES cluster deploy to 2 AZ when user set availabilityZoneCount to 2", 
     }
   });
 
-  expect(stack).toHaveResource("AWS::Elasticsearch::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     ElasticsearchClusterConfig: {
       DedicatedMasterCount: 3,
       DedicatedMasterEnabled: true,
@@ -323,7 +330,7 @@ test("Test ES cluster deploy to 2 AZ when user set availabilityZoneCount to 2", 
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -352,7 +359,8 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     existingVpc: vpc
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -361,7 +369,7 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -377,7 +385,7 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 
@@ -408,7 +416,8 @@ test('Test minimal deployment with an existing private VPC', () => {
     existingVpc: vpc
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -417,7 +426,7 @@ test('Test minimal deployment with an existing private VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -433,7 +442,7 @@ test('Test minimal deployment with an existing private VPC', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 
@@ -451,7 +460,8 @@ test('Test minimal deployment with VPC construct props', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -460,7 +470,7 @@ test('Test minimal deployment with VPC construct props', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::Elasticsearch::Domain", {
+  template.hasResourceProperties("AWS::Elasticsearch::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -476,7 +486,7 @@ test('Test minimal deployment with VPC construct props', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/test/aws-lambda-kinesisfirehose.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/test/aws-lambda-kinesisfirehose.test.ts
@@ -12,7 +12,7 @@
  */
 
 // Imports
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { LambdaToKinesisFirehose } from '../lib';
@@ -56,13 +56,14 @@ test('Test existing function is utilized correctly', () => {
     existingLambdaObj: existingFunction
   });
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: testName
   });
 
   // This is 2 because there's a lambda function in the custom resource to
   // delete all the objects when cleaning up the s3 bucket in kinesisfirehose-s3
-  expect(stack).toCountResources('AWS::Lambda::Function', 2);
+  template.resourceCountIs('AWS::Lambda::Function', 2);
 });
 
 test('Test that lambda function props are incorporated', () => {
@@ -81,7 +82,8 @@ test('Test that lambda function props are incorporated', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: testName
   });
 });
@@ -108,11 +110,12 @@ test('Test that new VPC is created', () => {
 
   expect(construct.vpc !== null);
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: cidrRange
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",
@@ -148,13 +151,14 @@ test('Test that existing VPC is used', () => {
   expect(construct.vpc !== null);
 
   // Make sure we didn't deploy a new one anyway
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: cidrInGetTestVpc
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     ServiceName: {
       "Fn::Join": [
         "",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/lambda-opensearch.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/lambda-opensearch.test.ts
@@ -14,7 +14,7 @@
 import { LambdaToOpenSearch, LambdaToOpenSearchProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 import { getTestVpc } from "@aws-solutions-constructs/core";
 
@@ -88,7 +88,8 @@ test('Check for an existing Lambda object', () => {
 
   new LambdaToOpenSearch(stack, 'test-lambda-opensearch-stack', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'test-function'
   });
 
@@ -104,7 +105,8 @@ test('Check Lambda function custom environment variable', () => {
 
   new LambdaToOpenSearch(stack, 'test-lambda-opensearch-stack', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -126,14 +128,15 @@ test('Check domain name', () => {
 
   deployLambdaToOpenSearch(stack);
 
-  expect(stack).toHaveResource('AWS::Cognito::UserPoolDomain', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Cognito::UserPoolDomain', {
     Domain: "test-domain",
     UserPoolId: {
       Ref: "testlambdaopensearchstackCognitoUserPoolF5169460"
     }
   });
 
-  expect(stack).toHaveResource('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     DomainName: "test-domain",
   });
 });
@@ -148,7 +151,8 @@ test('Check cognito domain name override', () => {
 
   new LambdaToOpenSearch(stack, 'test-lambda-opensearch-stack', props);
 
-  expect(stack).toHaveResource('AWS::Cognito::UserPoolDomain', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Cognito::UserPoolDomain', {
     Domain: 'test-cogn-domain'
   });
 });
@@ -165,7 +169,8 @@ test('Check engine version override', () => {
 
   new LambdaToOpenSearch(stack, 'test-lambda-opensearch-stack', props);
 
-  expect(stack).toHaveResource('AWS::OpenSearchService::Domain', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     EngineVersion: 'OpenSearch_1.0'
   });
 });
@@ -179,7 +184,8 @@ test("Test minimal deployment that deploys a VPC in 2 AZ without vpcProps", () =
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -200,7 +206,7 @@ test("Test minimal deployment that deploys a VPC in 2 AZ without vpcProps", () =
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -213,7 +219,7 @@ test("Test minimal deployment that deploys a VPC in 2 AZ without vpcProps", () =
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
@@ -230,7 +236,8 @@ test("Test minimal deployment that deploys a VPC in 3 AZ without vpcProps", () =
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -254,7 +261,7 @@ test("Test minimal deployment that deploys a VPC in 3 AZ without vpcProps", () =
     },
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -270,7 +277,7 @@ test("Test minimal deployment that deploys a VPC in 3 AZ without vpcProps", () =
     }
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
@@ -300,7 +307,8 @@ test("Test cluster deploy to 1 AZ when user set zoneAwarenessEnabled to false", 
     }
   });
 
-  expect(stack).toHaveResource("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     ClusterConfig: {
       DedicatedMasterCount: 3,
       DedicatedMasterEnabled: true,
@@ -309,7 +317,7 @@ test("Test cluster deploy to 1 AZ when user set zoneAwarenessEnabled to false", 
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -347,7 +355,8 @@ test("Test cluster deploy to 2 AZ when user set availabilityZoneCount to 2", () 
     }
   });
 
-  expect(stack).toHaveResource("AWS::OpenSearchService::Domain", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     ClusterConfig: {
       DedicatedMasterCount: 3,
       DedicatedMasterEnabled: true,
@@ -359,7 +368,7 @@ test("Test cluster deploy to 2 AZ when user set availabilityZoneCount to 2", () 
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -388,7 +397,8 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     existingVpc: vpc
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -397,7 +407,7 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -413,7 +423,7 @@ test('Test minimal deployment with an existing isolated VPC', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 
@@ -432,7 +442,8 @@ test('Test minimal deployment with an existing private VPC', () => {
     existingVpc: vpc
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -441,7 +452,7 @@ test('Test minimal deployment with an existing private VPC', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -457,7 +468,7 @@ test('Test minimal deployment with an existing private VPC', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 
@@ -475,7 +486,8 @@ test('Test minimal deployment with VPC construct props', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::EC2::VPC", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::EC2::VPC", {
     Tags: [
       {
         Key: "Name",
@@ -484,7 +496,7 @@ test('Test minimal deployment with VPC construct props', () => {
     ]
   });
 
-  expect(stack).toHaveResourceLike("AWS::OpenSearchService::Domain", {
+  template.hasResourceProperties("AWS::OpenSearchService::Domain", {
     VPCOptions: {
       SubnetIds: [
         {
@@ -500,7 +512,7 @@ test('Test minimal deployment with VPC construct props', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::EC2::VPC", 1);
+  template.resourceCountIs("AWS::EC2::VPC", 1);
   expect(construct.vpc).toBeDefined();
 });
 

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/test/lambda-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/test/lambda-s3.test.ts
@@ -18,7 +18,7 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { LambdaToS3 } from '../lib';
 import { CreateScrapBucket } from '@aws-solutions-constructs/core';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test the getter methods
@@ -61,7 +61,8 @@ test('Test the bucketProps override', () => {
       websiteIndexDocument: 'index.main.html'
     }
   });
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     WebsiteConfiguration: {
       IndexDocument: 'index.main.html'
     }
@@ -84,7 +85,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -105,17 +107,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -139,7 +141,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -160,18 +163,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -193,7 +196,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -214,7 +218,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Gateway",
   });
 });
@@ -297,7 +301,8 @@ test('Test lambda function custom environment variable', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -387,11 +392,12 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -422,7 +428,8 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toCountResources("AWS::S3::Bucket", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 1);
 });
 
 test('Test bad bucket permission', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/test/aws-lambda-sagemakerendpoint.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/test/aws-lambda-sagemakerendpoint.test.ts
@@ -17,7 +17,7 @@ import { LambdaToSagemakerEndpoint, LambdaToSagemakerEndpointProps } from '../li
 import * as defaults from '@aws-solutions-constructs/core';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // -----------------------------------------------------------------------------------------
 // Pattern deployment with new Lambda function, new Sagemaker endpoint and deployVpc = true
@@ -43,7 +43,8 @@ test('Pattern deployment with new Lambda function, new Sagemaker endpoint, deplo
   };
   new LambdaToSagemakerEndpoint(stack, 'test-lambda-sagemaker', constructProps);
 
-  expect(stack).toHaveResourceLike('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Environment: {
       Variables: {
         SAGEMAKER_ENDPOINT_NAME: {
@@ -68,7 +69,7 @@ test('Pattern deployment with new Lambda function, new Sagemaker endpoint, deplo
     },
   });
   // Assertion 3
-  expect(stack).toHaveResourceLike('AWS::SageMaker::Model', {
+  template.hasResourceProperties('AWS::SageMaker::Model', {
     ExecutionRoleArn: {
       'Fn::GetAtt': ['testlambdasagemakerSagemakerRoleD84546B8', 'Arn'],
     },
@@ -94,7 +95,7 @@ test('Pattern deployment with new Lambda function, new Sagemaker endpoint, deplo
   });
 
   // Assertion 4
-  expect(stack).toHaveResourceLike('AWS::SageMaker::EndpointConfig', {
+  template.hasResourceProperties('AWS::SageMaker::EndpointConfig', {
     ProductionVariants: [
       {
         InitialInstanceCount: 1,
@@ -112,7 +113,7 @@ test('Pattern deployment with new Lambda function, new Sagemaker endpoint, deplo
   });
 
   // Assertion 5
-  expect(stack).toHaveResourceLike('AWS::SageMaker::Endpoint', {
+  template.hasResourceProperties('AWS::SageMaker::Endpoint', {
     EndpointConfigName: {
       'Fn::GetAtt': ['testlambdasagemakerSagemakerEndpointConfig6BABA334', 'EndpointConfigName'],
     },
@@ -145,7 +146,8 @@ test('Pattern deployment with existing Lambda function, new Sagemaker endpoint, 
   };
   new LambdaToSagemakerEndpoint(stack, 'test-lambda-sagemaker', constructProps);
 
-  expect(stack).toHaveResourceLike('AWS::SageMaker::Model', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SageMaker::Model', {
     ExecutionRoleArn: {
       'Fn::GetAtt': ['testlambdasagemakerSagemakerRoleD84546B8', 'Arn'],
     },
@@ -156,7 +158,7 @@ test('Pattern deployment with existing Lambda function, new Sagemaker endpoint, 
   });
 
   // Assertion 3
-  expect(stack).toHaveResourceLike('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Environment: {
       Variables: {
         SAGEMAKER_ENDPOINT_NAME: {
@@ -198,7 +200,8 @@ test('Pattern deployment with new Lambda function, new Sagemaker endpoint, deplo
   };
   new LambdaToSagemakerEndpoint(stack, 'test-lambda-sagemaker', constructProps);
   // Assertion 1
-  expect(stack).toHaveResourceLike('AWS::IAM::Role', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {
       Statement: [
         {
@@ -214,21 +217,21 @@ test('Pattern deployment with new Lambda function, new Sagemaker endpoint, deplo
   });
 
   // Assertion 2: ReplaceDefaultSecurityGroup, ReplaceEndpointDefaultSecurityGroup, and ReplaceModelDefaultSecurityGroup
-  expect(stack).toCountResources('AWS::EC2::SecurityGroup', 3);
+  template.resourceCountIs('AWS::EC2::SecurityGroup', 3);
   // Assertion 3
-  expect(stack).toCountResources('AWS::EC2::Subnet', 2);
+  template.resourceCountIs('AWS::EC2::Subnet', 2);
   // Assertion 4
-  expect(stack).toCountResources('AWS::EC2::InternetGateway', 0);
+  template.resourceCountIs('AWS::EC2::InternetGateway', 0);
   // Assertion 5: SAGEMAKER_RUNTIME VPC Interface
-  expect(stack).toHaveResource('AWS::EC2::VPCEndpoint', {
+  template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Interface',
   });
   // Assertion 6: S3 VPC Endpoint
-  expect(stack).toHaveResource('AWS::EC2::VPCEndpoint', {
+  template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Gateway',
   });
   // Assertion 7
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
@@ -311,21 +314,22 @@ test('Pattern deployment with existing Lambda function (with VPC), new Sagemaker
   new LambdaToSagemakerEndpoint(stack, 'test-lambda-sagemaker', constructProps);
 
   // Assertion 2: ReplaceDefaultSecurityGroup, ReplaceEndpointDefaultSecurityGroup, and ReplaceModelDefaultSecurityGroup
-  expect(stack).toCountResources('AWS::EC2::SecurityGroup', 3);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::EC2::SecurityGroup', 3);
   // Assertion 3
-  expect(stack).toCountResources('AWS::EC2::Subnet', 2);
+  template.resourceCountIs('AWS::EC2::Subnet', 2);
   // Assertion 4
-  expect(stack).toCountResources('AWS::EC2::InternetGateway', 0);
+  template.resourceCountIs('AWS::EC2::InternetGateway', 0);
   // Assertion 5: SAGEMAKER_RUNTIME VPC Interface
-  expect(stack).toHaveResource('AWS::EC2::VPCEndpoint', {
+  template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Interface',
   });
   // Assertion 6: S3 VPC Endpoint
-  expect(stack).toHaveResource('AWS::EC2::VPCEndpoint', {
+  template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Gateway',
   });
   // Assertion 7
-  expect(stack).toHaveResource('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
@@ -565,7 +569,8 @@ test('Test lambda function custom environment variable', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'python3.8',
     Environment: {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/lambda-secretsmanager.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/lambda-secretsmanager.test.ts
@@ -17,7 +17,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LambdaToSecretsmanager } from '../lib';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from "@aws-solutions-constructs/core";
 
 // --------------------------------------------------------------
@@ -60,7 +60,8 @@ test('Test deployment w/ existing secret', () => {
     existingSecretObj: existingSecret
   });
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SecretsManager::Secret", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     GenerateSecretString: {},
   });
   // Assertion 2
@@ -86,7 +87,8 @@ test('Test deployment w/ existing function', () => {
     secretProps: { removalPolicy: RemovalPolicy.DESTROY },
   });
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SecretsManager::Secret", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     GenerateSecretString: {},
   });
   // Assertion 2
@@ -110,7 +112,8 @@ test('Test minimal deployment write access to Secret', () => {
     grantWriteAccess: 'ReadWrite'
   });
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SecretsManager::Secret", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     GenerateSecretString: {},
   });
 
@@ -133,7 +136,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -154,17 +158,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -189,7 +193,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -210,18 +215,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -244,7 +249,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -265,7 +271,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 });
@@ -351,7 +357,8 @@ test('Test lambda function custom environment variable', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -392,7 +399,8 @@ test('Test overriding secretProps to pass a customer provided CMK', () => {
   });
 
   // Assertion 1
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -406,7 +414,7 @@ test('Test overriding secretProps to pass a customer provided CMK', () => {
   });
 
   // Assertion 2
-  expect(stack).toHaveResource("AWS::SecretsManager::Secret", {
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
     GenerateSecretString: {},
     KmsKeyId: {
       "Fn::GetAtt": [
@@ -417,7 +425,7 @@ test('Test overriding secretProps to pass a customer provided CMK', () => {
   });
 
   // Assertion 3
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     Description: "secret-key",
     EnableKeyRotation: true
   });

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/test/lambda-sns.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/test/lambda-sns.test.ts
@@ -18,8 +18,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as sns from "aws-cdk-lib/aws-sns";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LambdaToSns, LambdaToSnsProps } from '../lib';
-import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test deployment with new Lambda function
@@ -40,7 +39,8 @@ test('Test deployment with new Lambda function', () => {
   });
 
   expect(testConstruct.snsTopic).toBeDefined();
-  expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Environment: {
       Variables: {
         LAMBDA_NAME: 'deployed-function',
@@ -56,7 +56,7 @@ test('Test deployment with new Lambda function', () => {
       }
     }
   });
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::Join": [
         "",
@@ -104,9 +104,10 @@ test('Test deployment with existing existingTopicObj', () => {
     existingTopicObj: topic
   });
 
-  expectCDK(stack).to(haveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: "custom-topic"
-  }));
+  });
 });
 
 // --------------------------------------------------------------
@@ -128,9 +129,10 @@ test('override topicProps', () => {
 
   new LambdaToSns(stack, 'test-sns-lambda', props);
 
-  expectCDK(stack).to(haveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: "custom-topic"
-  }));
+  });
 });
 
 // --------------------------------------------------------------
@@ -171,7 +173,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -192,17 +195,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -226,7 +229,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -247,18 +251,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -280,7 +284,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -301,7 +306,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 });
@@ -382,7 +387,8 @@ test('Test lambda function custom environment variable', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -418,7 +424,8 @@ test('Topic is encrypted with imported CMK when set on encryptionKey prop', () =
     encryptionKey: cmk
   });
 
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -446,7 +453,8 @@ test('Topic is encrypted with imported CMK when set on topicProps.masterKey prop
     }
   });
 
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -473,7 +481,8 @@ test('Topic is encrypted with provided encrytionKeyProps', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',
@@ -482,7 +491,7 @@ test('Topic is encrypted with provided encrytionKeyProps', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Alias', {
+  template.hasResourceProperties('AWS::KMS::Alias', {
     AliasName: 'alias/new-key-alias-from-props',
     TargetKeyId: {
       'Fn::GetAtt': [
@@ -507,7 +516,8 @@ test('Topic is encrypted by default with AWS-managed KMS key when no other encry
     },
   });
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::Join": [
         "",
@@ -546,7 +556,8 @@ test('Topic is encrypted with customer managed KMS Key when enable encryption fl
     enableEncryptionWithCustomerManagedKey: true
   });
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/lambda-sqs-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/lambda-sqs-lambda.test.ts
@@ -18,7 +18,7 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as defaults from '@aws-solutions-constructs/core';
 import { LambdaToSqsToLambda, LambdaToSqsToLambdaProps } from '../lib';
 import { haveResourceLike } from '@aws-cdk/assert';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test minimal deployment
@@ -44,17 +44,18 @@ test('Test minimal deployment', () => {
   new LambdaToSqsToLambda(stack, 'lambda-sqs-lambda', props);
 
   // Assertion 2: test for an producer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'producer-function'
   });
   // Assertion 3: test for a consumer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'consumer-function'
   });
-  // Assertion 4: test for a queue
-  expect(stack).toHaveResource('AWS::SQS::Queue');
+  // Assertion 4: test for a queue (queue and DLQ)
+  template.resourceCountIs('AWS::SQS::Queue', 2);
   // Assertion 5: test for send-message permissions (only) on the producer function
-  expect(stack).toHaveResourceLike('AWS::IAM::Policy', {
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -84,7 +85,7 @@ test('Test minimal deployment', () => {
     }
   });
   // Assertion 6: test for consume-message permissions (only) on the consumer function
-  expect(stack).toHaveResourceLike('AWS::IAM::Policy', {
+  template.hasResourceProperties('AWS::IAM::Policy', {
     PolicyDocument: {
       Statement: [
         {
@@ -145,11 +146,12 @@ test('Test deployment w/ existing producer function', () => {
   new LambdaToSqsToLambda(stack, 'lambda-sqs-lambda', props);
 
   // Assertion 2: test for the existing producer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'existing-producer-function'
   });
   // Assertion 3: test for the deployed consumer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'deployed-consumer-function'
   });
 });
@@ -182,11 +184,12 @@ test('Test deployment w/ existing consumer function', () => {
   new LambdaToSqsToLambda(stack, 'lambda-sqs-lambda', props);
 
   // Assertion 2: test for the deployed producer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'deployed-producer-function'
   });
   // Assertion 3: test for the existing consumer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'existing-consumer-function'
   });
 });
@@ -222,7 +225,8 @@ test('Test deployment w/ existing queue', () => {
   new LambdaToSqsToLambda(stack, 'lambda-sqs-lambda', props);
 
   // Assertion 2: test for the existing queue
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     QueueName: 'existing-queue'
   });
 });
@@ -318,11 +322,12 @@ test('Test overrides for producer and consumer functions', () => {
   new LambdaToSqsToLambda(stack, 'lambda-sqs-lambda', props);
 
   // Assertion 2: test for updated runtime on producer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Runtime: "nodejs14.x"
   });
   // Assertion 3: test for updated runtime on consumer function
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Runtime: "nodejs14.x"
   });
 });
@@ -385,7 +390,8 @@ test('Test lambda function custom environment variable', () => {
   new LambdaToSqsToLambda(stack, 'lambda-sqs-lambda', props);
 
   // Assertion
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     FunctionName: 'producer-function',
     Environment: {
       Variables: {
@@ -422,7 +428,8 @@ test('Pattern deployment w/ batch size', () => {
   };
   new LambdaToSqsToLambda(stack, 'test-lambda-sqs-lambda', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
     BatchSize: 5
   });
 });
@@ -450,7 +457,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -471,17 +479,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -512,7 +520,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -533,18 +542,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -573,7 +582,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -594,7 +604,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/lambda-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/lambda-sqs.test.ts
@@ -17,7 +17,7 @@ import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LambdaToSqs } from '../lib';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Test the getter methods
@@ -60,7 +60,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -81,17 +82,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -115,7 +116,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -136,18 +138,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -169,7 +171,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -190,7 +193,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 });
@@ -270,7 +273,8 @@ test('Test lambda function custom environment variable', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -300,7 +304,8 @@ test('Queue is encrypted with imported CMK when set on encryptionKey prop', () =
     encryptionKey: cmk
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -328,7 +333,8 @@ test('Queue is encrypted with imported CMK when set on queueProps.encryptionMast
     }
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -355,7 +361,8 @@ test('Queue is encrypted with provided encrytionKeyProps', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',
@@ -364,7 +371,7 @@ test('Queue is encrypted with provided encrytionKeyProps', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Alias', {
+  template.hasResourceProperties('AWS::KMS::Alias', {
     AliasName: 'alias/new-key-alias-from-props',
     TargetKeyId: {
       'Fn::GetAtt': [
@@ -389,7 +396,8 @@ test('Queue is encrypted by default with SQS-managed KMS key when no other encry
     },
   });
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 });
@@ -409,7 +417,8 @@ test('Queue is encrypted with customer managed KMS Key when enable encryption fl
     enableEncryptionWithCustomerManagedKey: true
   });
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',
@@ -445,7 +454,8 @@ test('Queue purging flag grants correct permissions', () => {
     deployDeadLetterQueue: false
   });
 
-  expect(stack).toHaveResource('AWS::SQS::QueuePolicy', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::QueuePolicy', {
     PolicyDocument:  {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/lambda-ssmstringparameter.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/lambda-ssmstringparameter.test.ts
@@ -16,7 +16,7 @@ import { Stack } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LambdaToSsmstringparameter } from '../lib';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import * as defaults from "@aws-solutions-constructs/core";
 
@@ -42,7 +42,8 @@ test('Test lambda function custom environment variable', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -96,7 +97,8 @@ test('Test deployment w/ existing String Parameter', () => {
     existingStringParameterObj: existingStringParam
   });
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SSM::Parameter", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Type: "String",
     Value: "test-string-value"
   });
@@ -124,7 +126,8 @@ test('Test deployment w/ existing function', () => {
     stringParameterProps: { stringValue: "test-string-value" },
   });
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SSM::Parameter", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Type: "String",
     Value: "test-string-value"
   });
@@ -149,7 +152,7 @@ test('Test minimal deployment write access to String Parameter ', () => {
     stringParameterPermissions: 'ReadWrite'
   });
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SSM::Parameter", {
+  template.hasResourceProperties("AWS::SSM::Parameter", {
     Type: "String",
     Value: "test-string-value"
   });
@@ -173,7 +176,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -194,17 +198,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -229,7 +233,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -250,18 +255,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -284,7 +289,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -305,7 +311,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-stepfunctions.test.ts
@@ -18,7 +18,6 @@ import * as defaults from '@aws-solutions-constructs/core';
 import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LambdaToStepfunctions } from '../lib';
-import '@aws-cdk/assert/jest';
 import { Template } from "aws-cdk-lib/assertions";
 
 // --------------------------------------------------------------
@@ -43,7 +42,8 @@ test('Test deployment with new Lambda function', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Environment: {
       Variables: {
         LAMBDA_NAME: 'deploy-function',
@@ -80,7 +80,8 @@ test('Test deployment with existing Lambda function', () => {
     }
   });
 
-  expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Environment: {
       Variables: {
         LAMBDA_NAME: 'existing-function'
@@ -114,7 +115,8 @@ test('Test invocation permissions', () => {
     }
   });
   // Assertion 1
-  expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -224,7 +226,8 @@ test('Test lambda function custom environment variable', () => {
   });
 
   // Assertion
-  expect(stack).toHaveResourceLike('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Runtime: 'nodejs14.x',
     Environment: {
@@ -258,7 +261,8 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     deployVpc: true
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -279,17 +283,17 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -317,7 +321,8 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     deployVpc: true,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -338,18 +343,18 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPC", {
+  template.hasResourceProperties("AWS::EC2::VPC", {
     CidrBlock: "192.68.0.0/16",
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 
-  expect(stack).toCountResources("AWS::EC2::Subnet", 2);
-  expect(stack).toCountResources("AWS::EC2::InternetGateway", 0);
+  template.resourceCountIs("AWS::EC2::Subnet", 2);
+  template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
 // --------------------------------------------------------------
@@ -374,7 +379,8 @@ test("Test minimal deployment with an existing VPC", () => {
     existingVpc: testVpc,
   });
 
-  expect(stack).toHaveResource("AWS::Lambda::Function", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Lambda::Function", {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -395,7 +401,7 @@ test("Test minimal deployment with an existing VPC", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::EC2::VPCEndpoint", {
+  template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
     VpcEndpointType: "Interface",
   });
 });
@@ -486,7 +492,8 @@ test('check LogGroup name', () => {
   const expectedPrefix = '/aws/vendedlogs/states/constructs/';
   const lengthOfDatetimeSuffix = 13;
 
-  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+  const template = Template.fromStack(stack);
+  const LogGroup = template.findResources("AWS::Logs::LogGroup");
 
   const logName = LogGroup.lambdatostepfunctionstackStateMachineLogGroupEAD4854E.Properties.LogGroupName;
   const suffix = logName.slice(-lengthOfDatetimeSuffix);

--- a/source/patterns/@aws-solutions-constructs/aws-route53-alb/test/route53-alb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-alb/test/route53-alb.test.ts
@@ -16,7 +16,7 @@ import { Stack } from "aws-cdk-lib";
 import { Route53ToAlb, Route53ToAlbProps } from '../lib';
 import * as r53 from 'aws-cdk-lib/aws-route53';
 import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 
 test('Test Public API, new VPC', () => {
@@ -36,17 +36,18 @@ test('Test Public API, new VPC', () => {
 
   new Route53ToAlb(stack, 'test-route53-alb', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internet-facing'
   });
 
-  expect(stack).toHaveResourceLike('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
     InstanceTenancy: "default",
   });
 
-  expect(stack).toHaveResourceLike('AWS::Route53::RecordSet', {
+  template.hasResourceProperties('AWS::Route53::RecordSet', {
     Name: 'www.example-test.com.',
     Type: 'A'
   });
@@ -74,17 +75,18 @@ test('Test Private API, existing VPC', () => {
 
   new Route53ToAlb(stack, 'test-route53-alb', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internal'
   });
 
-  expect(stack).toHaveResourceLike('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
     InstanceTenancy: "default",
   });
 
-  expect(stack).toHaveResourceLike('AWS::Route53::RecordSet', {
+  template.hasResourceProperties('AWS::Route53::RecordSet', {
     Name: 'www.example-test.com.',
     Type: 'A'
   });
@@ -106,17 +108,18 @@ test('Test Private API, new VPC', () => {
 
   new Route53ToAlb(stack, 'test-route53-alb', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internal'
   });
 
-  expect(stack).toHaveResourceLike('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
     InstanceTenancy: "default",
   });
 
-  expect(stack).toHaveResourceLike('AWS::Route53::RecordSet', {
+  template.hasResourceProperties('AWS::Route53::RecordSet', {
     Name: 'www.example-test.com.',
     Type: 'A'
   });
@@ -203,17 +206,18 @@ test('Test with privateHostedZoneProps', () => {
 
   new Route53ToAlb(stack, 'test-error', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internal'
   });
 
-  expect(stack).toHaveResourceLike('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
     InstanceTenancy: "default",
   });
 
-  expect(stack).toHaveResourceLike('AWS::Route53::RecordSet', {
+  template.hasResourceProperties('AWS::Route53::RecordSet', {
     Name: 'www.example-test.com.',
     Type: 'A'
   });
@@ -341,18 +345,19 @@ test('Test providing loadBalancerProps', () => {
 
   new Route53ToAlb(stack, 'test-route53-alb', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internal',
     Name: 'find-this-name'
   });
 
-  expect(stack).toHaveResourceLike('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
     InstanceTenancy: "default",
   });
 
-  expect(stack).toHaveResourceLike('AWS::Route53::RecordSet', {
+  template.hasResourceProperties('AWS::Route53::RecordSet', {
     Name: 'www.example-test.com.',
     Type: 'A'
   });
@@ -384,18 +389,19 @@ test('Test providing an existingLoadBalancer', () => {
 
   new Route53ToAlb(stack, 'test-route53-alb', props);
 
-  expect(stack).toHaveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: 'internal',
     Name: 'find-this-name'
   });
 
-  expect(stack).toHaveResourceLike('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
     InstanceTenancy: "default",
   });
 
-  expect(stack).toHaveResourceLike('AWS::Route53::RecordSet', {
+  template.hasResourceProperties('AWS::Route53::RecordSet', {
     Name: 'www.example-test.com.',
     Type: 'A'
   });

--- a/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/test/test.route53-apigateway.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/test/test.route53-apigateway.test.ts
@@ -17,7 +17,7 @@ import { Route53ToApiGateway, Route53ToApiGatewayProps } from "../lib";
 import * as route53 from "aws-cdk-lib/aws-route53";
 import * as defaults from "@aws-solutions-constructs/core";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
-import "@aws-cdk/assert/jest";
+import { Template } from 'aws-cdk-lib/assertions';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
 // Deploying Public/Private Existing Hosted Zones
@@ -249,7 +249,8 @@ test("Test for providing private hosted zone props", () => {
     existingCertificateInterface: certificate
   });
 
-  expect(stack).toHaveResource("AWS::Route53::HostedZone", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Route53::HostedZone", {
     Name: "www.private-zone.com.",
     VPCs: [
       {
@@ -273,7 +274,8 @@ test("Integration test for A record creation in Public Hosted Zone ", () => {
   deployApi(stack, true);
 
   // Assertions
-  expect(stack).toHaveResource("AWS::Route53::RecordSet", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Route53::RecordSet", {
     Name: "www.test-example.com.",
     Type: "A",
     AliasTarget: {
@@ -295,7 +297,7 @@ test("Integration test for A record creation in Public Hosted Zone ", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::RestApi", {
+  template.hasResourceProperties("AWS::ApiGateway::RestApi", {
     EndpointConfiguration: {
       Types: [
         "REGIONAL"
@@ -314,7 +316,8 @@ test("Integration test for A record creation in Private Hosted Zone ", () => {
   deployApi(stack, false);
 
   // Assertions
-  expect(stack).toHaveResource("AWS::Route53::RecordSet", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::Route53::RecordSet", {
     Name: "www.test-example.com.",
     Type: "A",
     AliasTarget: {
@@ -336,7 +339,7 @@ test("Integration test for A record creation in Private Hosted Zone ", () => {
     },
   });
 
-  expect(stack).toHaveResource("AWS::Route53::HostedZone", {
+  template.hasResourceProperties("AWS::Route53::HostedZone", {
     Name: "www.test-example.com.",
     VPCs: [
       {
@@ -350,7 +353,7 @@ test("Integration test for A record creation in Private Hosted Zone ", () => {
     ],
   });
 
-  expect(stack).toHaveResource("AWS::ApiGateway::RestApi", {
+  template.hasResourceProperties("AWS::ApiGateway::RestApi", {
     EndpointConfiguration: {
       Types: [
         "REGIONAL"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/test/s3-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/test/s3-lambda.test.ts
@@ -15,7 +15,7 @@ import { S3ToLambda, S3ToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import { CreateScrapBucket } from '@aws-solutions-constructs/core';
 
 function deployNewFunc(stack: cdk.Stack) {
@@ -86,11 +86,12 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -121,7 +122,8 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toCountResources("AWS::S3::Bucket", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 1);
 });
 
 test('check properties with existing S3 bucket', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/test.s3-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/test.s3-sqs.test.ts
@@ -17,7 +17,7 @@ import { S3ToSqs, S3ToSqsProps } from "../lib";
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as s3 from 'aws-cdk-lib/aws-s3';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 
 // --------------------------------------------------------------
@@ -59,7 +59,8 @@ test('Test deployment w/ existing queue', () => {
     existingQueueObj: queue
   });
   // Assertion 1
-  expect(stack).toHaveResource("Custom::S3BucketNotifications", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("Custom::S3BucketNotifications", {
     NotificationConfiguration: {
       QueueConfigurations: [
         {
@@ -89,7 +90,8 @@ test('Test deployment w/ existing Bucket', () => {
     existingBucketObj: buildS3BucketResponse.bucket
   });
   // Assertion 1
-  expect(stack).toHaveResource("Custom::S3BucketNotifications", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("Custom::S3BucketNotifications", {
     NotificationConfiguration: {
       QueueConfigurations: [
         {
@@ -122,7 +124,8 @@ test('Pattern deployment w/ bucket versioning turned off', () => {
     }
   };
   new S3ToSqs(stack, 'test-s3-sqs', props);
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     PublicAccessBlockConfiguration: {
       BlockPublicAcls: false,
       BlockPublicPolicy: true,
@@ -152,7 +155,8 @@ test('Test deployment w/ s3 event types and filters', () => {
   };
   new S3ToSqs(stack, 'test-s3-sqs', props);
   // Assertion 1
-  expect(stack).toHaveResource("Custom::S3BucketNotifications", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("Custom::S3BucketNotifications", {
     NotificationConfiguration: {
       QueueConfigurations: [
         {
@@ -195,10 +199,11 @@ test('Test deployment w/ SSE encryption enabled using customer managed KMS CMK',
   });
 
   // Assertion 1
-  expect(stack).toHaveResource("Custom::S3BucketNotifications");
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("Custom::S3BucketNotifications", 1);
 
   // Assertion 2
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "tests3sqsEncryptionKeyFD4D5946",
@@ -208,7 +213,7 @@ test('Test deployment w/ SSE encryption enabled using customer managed KMS CMK',
   });
 
   // Assertion 3
-  expect(stack).toHaveResource('AWS::KMS::Key', {
+  template.hasResourceProperties('AWS::KMS::Key', {
     EnableKeyRotation: true
   });
 });
@@ -251,11 +256,12 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::S3::Bucket", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::S3::Bucket", {
     AccessControl: "LogDeliveryWrite"
   });
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -281,7 +287,8 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toCountResources("AWS::S3::Bucket", 1);
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 1);
 });
 
 test('Queue is encrypted with imported CMK when set on encryptionKey prop', () => {
@@ -291,7 +298,8 @@ test('Queue is encrypted with imported CMK when set on encryptionKey prop', () =
     encryptionKey: key
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -309,7 +317,8 @@ test('Queue is encrypted with provided encryptionKeyProps', () => {
     }
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "tests3sqsEncryptionKeyFD4D5946",
@@ -318,7 +327,7 @@ test('Queue is encrypted with provided encryptionKeyProps', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Alias', {
+  template.hasResourceProperties('AWS::KMS::Alias', {
     AliasName: 'alias/new-key-alias-from-props',
     TargetKeyId: {
       "Fn::GetAtt": [
@@ -338,7 +347,8 @@ test('Queue is encrypted with imported CMK when set on queueProps.encryptionMast
     }
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -353,7 +363,8 @@ test('Queue is encrypted by default with Customer-managed KMS key when no other 
   new S3ToSqs(stack, 'test-s3-sqs', {
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "tests3sqsEncryptionKeyFD4D5946",
@@ -369,7 +380,8 @@ test('Queue is encrypted with SQS-managed KMS Key when enable encryption flag is
     enableEncryptionWithCustomerManagedKey: false
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/s3-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/s3-stepfunctions.test.ts
@@ -13,7 +13,6 @@
 
 import { S3ToStepfunctions, S3ToStepfunctionsProps } from '../lib/index';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
-import '@aws-cdk/assert/jest';
 import * as cdk from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Template } from 'aws-cdk-lib/assertions';
@@ -58,7 +57,8 @@ test('override eventRuleProps', () => {
 
   new S3ToStepfunctions(stack, 'test-s3-stepfunctions', props);
 
-  expect(stack).toHaveResource('AWS::Events::Rule', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Events::Rule', {
     EventPattern: {
       "source": [
         "aws.s3"
@@ -153,9 +153,10 @@ test('s3 bucket with bucket, loggingBucket, and auto delete objects', () => {
 
   new S3ToStepfunctions(stack, 'test-s3-stepfunctions', testProps);
 
-  expect(stack).toHaveResource("Custom::S3BucketNotifications", {});
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("Custom::S3BucketNotifications", {});
 
-  expect(stack).toHaveResource("Custom::S3AutoDeleteObjects", {
+  template.hasResourceProperties("Custom::S3AutoDeleteObjects", {
     ServiceToken: {
       "Fn::GetAtt": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
@@ -185,7 +186,8 @@ test('s3 bucket with no logging bucket', () => {
     logS3AccessLogs: false
   });
 
-  expect(stack).toHaveResource("Custom::S3BucketNotifications", {});
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("Custom::S3BucketNotifications", {});
   expect(construct.s3LoggingBucket).toEqual(undefined);
 });
 
@@ -198,7 +200,8 @@ test('check LogGroup name', () => {
   const expectedPrefix = '/aws/vendedlogs/states/constructs/';
   const lengthOfDatetimeSuffix = 13;
 
-  const LogGroup = Template.fromStack(stack).findResources("AWS::Logs::LogGroup");
+  const template = Template.fromStack(stack);
+  const LogGroup = template.findResources("AWS::Logs::LogGroup");
 
   const logName = LogGroup.tests3stepfunctionstests3stepfunctionseventrulestepfunctionconstructStateMachineLogGroupB4555776.Properties.LogGroupName;
   const suffix = logName.slice(-lengthOfDatetimeSuffix);

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/sns-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/sns-lambda.test.ts
@@ -11,13 +11,12 @@
  *  and limitations under the License.
  */
 
-import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
 import { SnsToLambda, SnsToLambdaProps } from "../lib";
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as cdk from "aws-cdk-lib";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployNewFunc(stack: cdk.Stack) {
   const props: SnsToLambdaProps = {
@@ -56,9 +55,10 @@ test('override topicProps', () => {
 
   new SnsToLambda(stack, 'test-sns-lambda', props);
 
-  expectCDK(stack).to(haveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: "custom-topic"
-  }));
+  });
 });
 
 test('provide existingTopicObj', () => {
@@ -79,9 +79,10 @@ test('provide existingTopicObj', () => {
 
   new SnsToLambda(stack, 'test-sns-lambda', props);
 
-  expectCDK(stack).to(haveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: "custom-topic"
-  }));
+  });
 });
 
 test('Topic is encrypted with imported CMK when set on encryptionKey prop', () => {
@@ -98,7 +99,8 @@ test('Topic is encrypted with imported CMK when set on encryptionKey prop', () =
 
   new SnsToLambda(stack, 'test-sns-lambda', props);
 
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -124,7 +126,8 @@ test('Topic is encrypted with imported CMK when set on topicProps.masterKey prop
 
   new SnsToLambda(stack, 'test-sns-lambda', props);
 
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -150,7 +153,8 @@ test('Topic is encrypted with provided encrytionKeyProps', () => {
 
   new SnsToLambda(stack, 'test-sns-lambda', props);
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testsnslambdaEncryptionKeyDDDF040B',
@@ -159,7 +163,7 @@ test('Topic is encrypted with provided encrytionKeyProps', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Alias', {
+  template.hasResourceProperties('AWS::KMS::Alias', {
     AliasName: 'alias/new-key-alias-from-props',
     TargetKeyId: {
       'Fn::GetAtt': [
@@ -183,7 +187,8 @@ test('Topic is encrypted by default with AWS-managed KMS key when no other encry
 
   new SnsToLambda(stack, 'test-sns-lambda', props);
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       "Fn::Join": [
         "",
@@ -221,7 +226,8 @@ test('Topic is encrypted with customer managed KMS Key when enable encryption fl
 
   new SnsToLambda(stack, 'test-sns-lambda', props);
 
-  expect(stack).toHaveResource('AWS::SNS::Topic', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SNS::Topic', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testsnslambdaEncryptionKeyDDDF040B',

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/sns-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/sns-sqs.test.ts
@@ -17,7 +17,7 @@ import { SnsToSqs, SnsToSqsProps } from "../lib";
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as kms from 'aws-cdk-lib/aws-kms';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 // --------------------------------------------------------------
 // Pattern deployment with new Topic, new Queue and
@@ -32,7 +32,8 @@ test('Pattern deployment w/ new Topic, new Queue and default props', () => {
   expect(testConstruct.snsTopic).toBeDefined();
   expect(testConstruct.encryptionKey).toBeDefined();
   // Assertion 2
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -41,7 +42,7 @@ test('Pattern deployment w/ new Topic, new Queue and default props', () => {
     }
   });
   // Assertion 3
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -50,7 +51,7 @@ test('Pattern deployment w/ new Topic, new Queue and default props', () => {
     }
   });
   // Assertion 4
-  expect(stack).toHaveResource("AWS::SNS::Subscription", {
+  template.hasResourceProperties("AWS::SNS::Subscription", {
     Protocol: "sqs",
     TopicArn: {
       Ref: "testsnssqsSnsTopic2CD0065B"
@@ -88,7 +89,8 @@ test('Pattern deployment w/ new topic, new queue, and overridden props', () => {
   };
   new SnsToSqs(stack, 'test-sns-sqs', props);
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: "new-topic",
     KmsMasterKeyId: {
       "Fn::GetAtt": [
@@ -98,12 +100,12 @@ test('Pattern deployment w/ new topic, new queue, and overridden props', () => {
     }
   });
   // Assertion 2
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "new-queue.fifo",
     FifoQueue: true
   });
   // Assertion 3
-  expect(stack).toHaveResource("AWS::KMS::Key", {
+  template.hasResourceProperties("AWS::KMS::Key", {
     EnableKeyRotation: false
   });
 });
@@ -150,11 +152,12 @@ test('Test deployment w/ existing queue, and topic', () => {
   // Assertion 2
   expect(app.snsTopic !== null);
   // Assertion 3
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     TopicName: "existing-topic-obj"
   });
   // Assertion 4
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "existing-queue-obj"
   });
 });
@@ -175,11 +178,12 @@ test('Test deployment with imported encryption key', () => {
     encryptionKey: kmsKey
   });
   // Assertion 2
-  expect(stack).toHaveResource("AWS::KMS::Key", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::KMS::Key", {
     EnableKeyRotation: false
   });
   // Assertion 3
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "importedkey38675D68",
@@ -206,7 +210,8 @@ test('Test deployment with SNS managed KMS key', () => {
     enableEncryptionWithCustomerManagedKey: false
   });
   // Assertion 2
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::Join": [
         "",
@@ -229,7 +234,7 @@ test('Test deployment with SNS managed KMS key', () => {
     }
   });
   // Assertion 3
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "snstosqsstackqueueKey743636E7",
@@ -253,7 +258,8 @@ test('Test deployment with CMK encrypted SNS Topic', () => {
     }
   });
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -293,7 +299,8 @@ test('Pattern deployment w/ existing topic and FIFO queue', () => {
   new SnsToSqs(stack, 'test-sns-sqs', props);
 
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     FifoQueue: true,
     RedrivePolicy: {
       deadLetterTargetArn: {
@@ -336,7 +343,8 @@ test('Pattern deployment w/ existing topic and Standard queue', () => {
   new SnsToSqs(stack, 'test-sns-sqs', props);
 
   // Assertion 1
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     RedrivePolicy: {
       deadLetterTargetArn: {
         "Fn::GetAtt": [
@@ -359,7 +367,8 @@ test('Check raw message delivery is true', () => {
   };
   new SnsToSqs(stack, 'test-sns-sqs', props);
 
-  expect(stack).toHaveResource("AWS::SNS::Subscription", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Subscription", {
     Protocol: "sqs",
     TopicArn: {
       Ref: "testsnssqsSnsTopic2CD0065B"
@@ -390,7 +399,8 @@ test('Check for filter policy', () => {
 
   new SnsToSqs(stack, 'test-sns-sqs', props);
 
-  expect(stack).toHaveResource("AWS::SNS::Subscription", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Subscription", {
     FilterPolicy: {
       color: [
         "red",
@@ -415,7 +425,8 @@ test('Check SNS dead letter queue', () => {
 
   new SnsToSqs(stack, 'test-sns-sqs', props);
 
-  expect(stack).toHaveResource("AWS::SNS::Subscription", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Subscription", {
     RedrivePolicy: {
       deadLetterTargetArn: {
         "Fn::GetAtt": [
@@ -439,7 +450,8 @@ test('Construct uses topicProps.masterKey when specified', () => {
 
   new SnsToSqs(stack, 'test-sns-sqs', props);
 
-  expect(stack).toHaveResource("AWS::SNS::Topic", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmkfortopic0904647B",
@@ -461,7 +473,8 @@ test('Construct uses queueProps.encryptionMasterKey when specified', () => {
 
   new SnsToSqs(stack, 'test-sns-sqs', props);
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmkforqueue4E093476",

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/test/test.sqs-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/test/test.sqs-lambda.test.ts
@@ -15,7 +15,7 @@
 import { Stack } from "aws-cdk-lib";
 import { SqsToLambda, SqsToLambdaProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as kms from 'aws-cdk-lib/aws-kms';
 
 // --------------------------------------------------------------
@@ -44,7 +44,8 @@ test('Pattern deployment w/ new Lambda function and overridden props', () => {
   // Assertion 1
   expect(app.sqsQueue).toHaveProperty('fifo', true);
   // Assertion 2
-  expect(stack).toHaveResource('AWS::Lambda::Function', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Environment: {
       Variables: {
         OVERRIDE: "TRUE",
@@ -132,7 +133,8 @@ test('Pattern deployment w/ batch size', () => {
   };
   new SqsToLambda(stack, 'test-sqs-lambda', props);
 
-  expect(stack).toHaveResource('AWS::Lambda::EventSourceMapping', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
     BatchSize: 5
   });
 });
@@ -153,7 +155,8 @@ test('Queue is encrypted with imported CMK when set on encryptionKey prop', () =
     encryptionKey: cmk
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -181,7 +184,8 @@ test('Queue is encrypted with imported CMK when set on queueProps.encryptionMast
     }
   });
 
-  expect(stack).toHaveResource("AWS::SQS::Queue", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "cmk01DE03DA",
@@ -208,7 +212,8 @@ test('Queue is encrypted with provided encrytionKeyProps', () => {
     }
   });
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',
@@ -217,7 +222,7 @@ test('Queue is encrypted with provided encrytionKeyProps', () => {
     },
   });
 
-  expect(stack).toHaveResource('AWS::KMS::Alias', {
+  template.hasResourceProperties('AWS::KMS::Alias', {
     AliasName: 'alias/new-key-alias-from-props',
     TargetKeyId: {
       'Fn::GetAtt': [
@@ -242,7 +247,8 @@ test('Queue is encrypted by default with SQS-managed KMS key when no other encry
     },
   });
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 });
@@ -262,7 +268,8 @@ test('Queue is encrypted with customer managed KMS Key when enable encryption fl
     enableEncryptionWithCustomerManagedKey: true
   });
 
-  expect(stack).toHaveResource('AWS::SQS::Queue', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::SQS::Queue', {
     KmsMasterKeyId: {
       'Fn::GetAtt': [
         'testconstructEncryptionKey6153B053',

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/test/test.wafwebacl-alb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/test/test.wafwebacl-alb.test.ts
@@ -17,7 +17,7 @@ import { WafwebaclToAlb } from "../lib";
 import * as waf from "aws-cdk-lib/aws-wafv2";
 import * as defaults from '@aws-solutions-constructs/core';
 import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployLoadBalancer(stack: cdk.Stack) {
   const myVpc = defaults.getTestVpc(stack);
@@ -77,7 +77,8 @@ test('Test default deployment', () => {
   expect(construct.webacl !== null);
   expect(construct.loadBalancer !== null);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     Rules: [
       {
         Name: "AWS-AWSManagedRulesBotControlRuleSet",
@@ -232,7 +233,8 @@ test('Test user provided acl props', () => {
 
   deployConstruct(stack, webaclProps);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: false,
       MetricName: "webACL",
@@ -298,7 +300,8 @@ test('Test existing web ACL', () => {
 
   deployConstruct(stack, undefined, webacl);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: true,
       MetricName: "webACL",
@@ -306,5 +309,5 @@ test('Test existing web ACL', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::WAFv2::WebACL", 1);
+  template.resourceCountIs("AWS::WAFv2::WebACL", 1);
 });

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/test.wafwebacl-apigateway.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/test.wafwebacl-apigateway.test.ts
@@ -17,7 +17,7 @@ import { WafwebaclToApiGateway } from "../lib";
 import * as api from 'aws-cdk-lib/aws-apigateway';
 import * as waf from "aws-cdk-lib/aws-wafv2";
 import * as defaults from '@aws-solutions-constructs/core';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployConstruct(stack: cdk.Stack, constructProps?: waf.CfnWebACLProps) {
   const restApi = new api.RestApi(stack, 'test-api', {});
@@ -69,7 +69,8 @@ test('Test default deployment', () => {
   expect(construct.webacl !== null);
   expect(construct.apiGateway !== null);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     Rules: [
       {
         Name: "AWS-AWSManagedRulesBotControlRuleSet",
@@ -224,7 +225,8 @@ test('Test user provided acl props', () => {
 
   deployConstruct(stack, webaclProps);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: false,
       MetricName: "webACL",
@@ -296,7 +298,8 @@ test('Test existing web ACL', () => {
     existingApiGatewayInterface: restApi
   });
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: true,
       MetricName: "webACL",
@@ -304,5 +307,5 @@ test('Test existing web ACL', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::WAFv2::WebACL", 1);
+  template.resourceCountIs("AWS::WAFv2::WebACL", 1);
 });

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/test/test.wafwebacl-appsync.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/test/test.wafwebacl-appsync.test.ts
@@ -17,7 +17,7 @@ import { WafwebaclToAppsync } from "../lib";
 import * as waf from "aws-cdk-lib/aws-wafv2";
 import * as defaults from "@aws-solutions-constructs/core";
 import * as appsync from "aws-cdk-lib/aws-appsync";
-import "@aws-cdk/assert/jest";
+import { Template } from "aws-cdk-lib/assertions";
 
 function deployAppsyncGraphqlApi(stack: cdk.Stack) {
   return new appsync.CfnGraphQLApi(stack, "new-api", {
@@ -79,7 +79,8 @@ test("Test default deployment", () => {
   expect(construct.webacl !== null);
   expect(construct.appsyncApi !== null);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     Rules: [
       {
         Name: "AWS-AWSManagedRulesBotControlRuleSet",
@@ -234,7 +235,8 @@ test("Test user provided acl props", () => {
 
   deployConstruct(stack, webaclProps);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: false,
       MetricName: "webACL",
@@ -300,7 +302,8 @@ test("Test existing web ACL", () => {
 
   deployConstruct(stack, undefined, webacl);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: true,
       MetricName: "webACL",
@@ -308,5 +311,5 @@ test("Test existing web ACL", () => {
     },
   });
 
-  expect(stack).toCountResources("AWS::WAFv2::WebACL", 1);
+  template.resourceCountIs("AWS::WAFv2::WebACL", 1);
 });

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/test/test.wafwebacl-cloudfront.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/test/test.wafwebacl-cloudfront.test.ts
@@ -19,7 +19,7 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as waf from "aws-cdk-lib/aws-wafv2";
 import * as defaults from '@aws-solutions-constructs/core';
-import '@aws-cdk/assert/jest';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function deployConstruct(stack: cdk.Stack, constructProps?: waf.CfnWebACLProps) {
   const myBucket = new s3.Bucket(stack, 'myBucket', {
@@ -79,7 +79,8 @@ test('Test default deployment', () => {
   expect(construct.webacl !== null);
   expect(construct.cloudFrontWebDistribution !== null);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     Rules: [
       {
         Name: "AWS-AWSManagedRulesBotControlRuleSet",
@@ -234,7 +235,8 @@ test('Test user provided acl props', () => {
 
   deployConstruct(stack, webaclProps);
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: false,
       MetricName: "webACL",
@@ -308,7 +310,8 @@ test('Test existing web ACL', () => {
     existingCloudFrontWebDistribution: testCloudfrontDistribution
   });
 
-  expect(stack).toHaveResource("AWS::WAFv2::WebACL", {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: true,
       MetricName: "webACL",
@@ -316,5 +319,5 @@ test('Test existing web ACL', () => {
     }
   });
 
-  expect(stack).toCountResources("AWS::WAFv2::WebACL", 1);
+  template.resourceCountIs("AWS::WAFv2::WebACL", 1);
 });

--- a/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-api-gateway-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-api-gateway-helper.test.ts
@@ -45,7 +45,7 @@ test('test cloudfront for Api Gateway with user provided logging bucket', () => 
   });
 
   CloudFrontDistributionForApiGateway(stack, _api, cfdProps);
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -169,7 +169,7 @@ test('test cloudfront for Api Gateway override properties', () => {
 
   CloudFrontDistributionForApiGateway(stack, _api, props);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -280,7 +280,7 @@ test('test override cloudfront add custom cloudfront function', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -419,7 +419,7 @@ test('test override cloudfront replace custom lambda@edge', () => {
   },
   false);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",

--- a/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-mediastore-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-mediastore-helper.test.ts
@@ -32,7 +32,7 @@ test('CloudFront distribution for MediaStore with user provided log bucket', () 
   };
 
   CloudFrontDistributionForMediaStore(stack, mediaStoreContainer, cfProps);
-  Template.fromStack(stack).hasResourceProperties('AWS::CloudFront::Distribution', {
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -365,7 +365,7 @@ test('CloudFront distribution without HTTP security headers for MediaStore', () 
   const mediaStoreContainer = new mediastore.CfnContainer(stack, 'MediaStoreContainer', mediaStoreContainerProps);
 
   CloudFrontDistributionForMediaStore(stack, mediaStoreContainer, {}, false);
-  Template.fromStack(stack).hasResourceProperties('AWS::CloudFront::Distribution', {
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -453,7 +453,7 @@ test('CloudFront distribution for MediaStore override params', () => {
   };
 
   CloudFrontDistributionForMediaStore(stack, mediaStoreContainer, cfProps);
-  Template.fromStack(stack).hasResourceProperties('AWS::CloudFront::Distribution', {
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -529,7 +529,7 @@ test('test override cloudfront with custom cloudfront function', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [

--- a/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-s3-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-s3-helper.test.ts
@@ -26,7 +26,7 @@ test('check bucket policy metadata', () => {
   const stack = new Stack();
   const buildS3BucketResponse = buildS3Bucket(stack, {});
   CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket);
-  Template.fromStack(stack).hasResource('AWS::S3::BucketPolicy', {
+  template.hasResource('AWS::S3::BucketPolicy', {
     Metadata: {
       cfn_nag: {
         rules_to_suppress: [
@@ -44,7 +44,7 @@ test('check bucket metadata', () => {
   const stack = new Stack();
   const buildS3BucketResponse = buildS3Bucket(stack, {});
   CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket);
-  Template.fromStack(stack).hasResource('AWS::S3::Bucket', {
+  template.hasResource('AWS::S3::Bucket', {
     Metadata: {
       cfn_nag: {
         rules_to_suppress: [
@@ -63,7 +63,7 @@ test('test cloudfront check bucket policy', () => {
   const buildS3BucketResponse = buildS3Bucket(stack, {});
   CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::BucketPolicy", {
+  template.hasResourceProperties("AWS::S3::BucketPolicy", {
     PolicyDocument: {
       Statement: [
         {
@@ -138,7 +138,7 @@ test('test cloudfront with no security headers ', () => {
 
   CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket, {}, false);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -198,7 +198,7 @@ test('test cloudfront override cloudfront logging bucket ', () => {
 
   CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket, myprops);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -271,7 +271,7 @@ test('test cloudfront override properties', () => {
 
   CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket, props);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         AllowedMethods: [
@@ -365,7 +365,7 @@ test('test override cloudfront with custom cloudfront function', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -453,7 +453,7 @@ test('test override cloudfront replace custom lambda@edge', () => {
   },
   false);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       DefaultCacheBehavior: {
         CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -522,7 +522,7 @@ test('test cloudfront override cloudfront custom domain names ', () => {
 
   CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket, myprops);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::CloudFront::Distribution", {
+  template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {
       Aliases: [
         "mydomains"

--- a/source/patterns/@aws-solutions-constructs/core/test/cloudwatch-log-group-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/cloudwatch-log-group-helper.test.ts
@@ -26,7 +26,7 @@ test('override cw log group props with encryptionKey only', () => {
     encryptionKey: key
   });
 
-  Template.fromStack(stack).hasResource('AWS::Logs::LogGroup', {
+  template.hasResource('AWS::Logs::LogGroup', {
     Metadata: {
       cfn_nag: {
         rules_to_suppress: [
@@ -47,7 +47,7 @@ test('override cw log group props with retention period only', () => {
     retention: logs.RetentionDays.FIVE_DAYS
   });
 
-  Template.fromStack(stack).hasResource('AWS::Logs::LogGroup', {
+  template.hasResource('AWS::Logs::LogGroup', {
     Metadata: {
       cfn_nag: {
         rules_to_suppress: [

--- a/source/patterns/@aws-solutions-constructs/core/test/congnito-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/congnito-helper.test.ts
@@ -26,7 +26,7 @@ test('Test override for buildUserPool', () => {
 
   defaults.buildUserPool(stack, userpoolProps);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Cognito::UserPool', {
+  template.hasResourceProperties('AWS::Cognito::UserPool', {
     UsernameAttributes: [
       "email",
       "phone_number"
@@ -50,7 +50,7 @@ test('Test override for buildUserPoolClient', () => {
 
   defaults.buildUserPoolClient(stack, userpool, userpoolclientProps);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Cognito::UserPoolClient', {
+  template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
     UserPoolId: {
       Ref: "CognitoUserPool53E37E69"
     },
@@ -70,7 +70,7 @@ test('Test override for buildIdentityPool', () => {
     allowUnauthenticatedIdentities: true
   });
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Cognito::IdentityPool', {
+  template.hasResourceProperties('AWS::Cognito::IdentityPool', {
     AllowUnauthenticatedIdentities: true,
     CognitoIdentityProviders: [
       {

--- a/source/patterns/@aws-solutions-constructs/core/test/dynamo-table.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/dynamo-table.test.ts
@@ -36,7 +36,7 @@ test('test TableProps change billing mode', () => {
   const outProps = overrideProps(defaultProps, inProps);
   new dynamodb.Table(stack, 'test-dynamo-override', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     KeySchema: [
       {
         AttributeName: "id",
@@ -78,7 +78,7 @@ test('test TableProps override add sort key', () => {
   const outProps = overrideProps(defaultProps, inProps);
   new dynamodb.Table(stack, 'test-dynamo-override', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     KeySchema: [
       {
         AttributeName: "id",
@@ -122,7 +122,7 @@ test('test TableWithStreamProps override stream view type', () => {
   const outProps = overrideProps(defaultProps, inProps);
   new dynamodb.Table(stack, 'test-dynamo-override', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+  template.hasResourceProperties("AWS::DynamoDB::Table", {
     KeySchema: [
       {
         AttributeName: "id",

--- a/source/patterns/@aws-solutions-constructs/core/test/elasticache-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/elasticache-helper.test.ts
@@ -49,7 +49,7 @@ test("Test create cache with no client props", () => {
     cachePort: 11111,
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::ElastiCache::CacheCluster", {
+  template.hasResourceProperties("AWS::ElastiCache::CacheCluster", {
     Port: 11111,
     AZMode: 'cross-az',
     Engine: 'memcached',
@@ -74,7 +74,7 @@ test("Test create cache with client props", () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::ElastiCache::CacheCluster", {
+  template.hasResourceProperties("AWS::ElastiCache::CacheCluster", {
     Port: 12321,
     AZMode: 'single-az',
     Engine: 'memcached',

--- a/source/patterns/@aws-solutions-constructs/core/test/elasticsearch-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/elasticsearch-helper.test.ts
@@ -68,7 +68,7 @@ test('Test override SnapshotOptions for buildElasticSearch', () => {
   expect(buildElasticSearchResponse.domain).toBeDefined();
   expect(buildElasticSearchResponse.role).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     AccessPolicies: {
       Statement: [
         {
@@ -163,7 +163,7 @@ test('Test VPC with 1 AZ, Zone Awareness Disabled', () => {
   expect(buildElasticSearchResponse.domain).toBeDefined();
   expect(buildElasticSearchResponse.role).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     DomainName: "test-domain",
     ElasticsearchClusterConfig: {
       DedicatedMasterCount: 3,
@@ -186,7 +186,7 @@ test('Test VPC with 2 AZ, Zone Awareness Enabled', () => {
   expect(buildElasticSearchResponse.domain).toBeDefined();
   expect(buildElasticSearchResponse.role).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     DomainName: "test-domain",
     ElasticsearchClusterConfig: {
       DedicatedMasterCount: 3,
@@ -211,7 +211,7 @@ test('Test VPC with 3 AZ, Zone Awareness Enabled', () => {
   expect(buildElasticSearchResponse.domain).toBeDefined();
   expect(buildElasticSearchResponse.role).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     DomainName: "test-domain",
     ElasticsearchClusterConfig: {
       DedicatedMasterCount: 3,
@@ -248,7 +248,7 @@ test('Test deployment with an existing private VPC', () => {
   expect(buildElasticSearchResponse.domain).toBeDefined();
   expect(buildElasticSearchResponse.role).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     DomainName: "test-domain",
     ElasticsearchClusterConfig: {
       DedicatedMasterCount: 3,
@@ -295,7 +295,7 @@ test('Test override ES version for buildElasticSearch', () => {
   expect(response.domain).toBeDefined();
   expect(response.role).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     AccessPolicies: {
       Statement: [
         {
@@ -382,7 +382,7 @@ test('Test ES with lambdaRoleARN', () => {
   expect(buildElasticSearchResponse.domain).toBeDefined();
   expect(buildElasticSearchResponse.role).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+  template.hasResourceProperties('AWS::Elasticsearch::Domain', {
     AccessPolicies: {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/core/test/eventbridge-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/eventbridge-helper.test.ts
@@ -29,7 +29,7 @@ test('Test deployment with no properties', () => {
     }
   });
 
-  Template.fromStack(stack).resourceCountIs("AWS::EventBridge::EventBus", 0);
+  template.resourceCountIs("AWS::EventBridge::EventBus", 0);
 });
 
 // --------------------------------------------------------------
@@ -43,7 +43,7 @@ test('Test deployment with existing EventBus', () => {
     existingEventBusInterface: new events.EventBus(stack, `existing-event-bus`, { eventBusName: 'test-bus' })
   });
 
-  Template.fromStack(stack).resourceCountIs('AWS::Events::EventBus', 1);
+  template.resourceCountIs('AWS::Events::EventBus', 1);
 });
 
 // --------------------------------------------------------------
@@ -59,7 +59,7 @@ test('Test deployment with new EventBus with props', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Events::EventBus', {
+  template.hasResourceProperties('AWS::Events::EventBus', {
     Name: 'testneweventbus'
   });
 });

--- a/source/patterns/@aws-solutions-constructs/core/test/events-rule.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/events-rule.test.ts
@@ -38,7 +38,7 @@ test('test EventsRuleProps override ruleName and description', () => {
 
   new events.Rule(stack, 'Events', eventsRuleProps);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Events::Rule', {
+  template.hasResourceProperties('AWS::Events::Rule', {
     Description: "hello world",
     Name: "test",
     ScheduleExpression: "rate(5 minutes)",
@@ -78,7 +78,7 @@ test('test EventsRuleProps add more event targets', () => {
 
   new events.Rule(stack, 'Events', eventsRuleProps);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Events::Rule', {
+  template.hasResourceProperties('AWS::Events::Rule', {
     ScheduleExpression: "rate(5 minutes)",
     State: "ENABLED",
     Targets: [

--- a/source/patterns/@aws-solutions-constructs/core/test/fargate-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/fargate-helper.test.ts
@@ -196,7 +196,7 @@ test('Test with custom task definition', () => {
     }
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     ContainerDefinitions: [
       {
         Image: {
@@ -229,7 +229,7 @@ test('Test with custom container definition', () => {
     { cpu: 256, memoryLimitMiB: 512  }
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::ECS::TaskDefinition", {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
     Cpu: '256',
     Memory: '512'
   });
@@ -248,7 +248,7 @@ test('Test with custom cluster props', () => {
     undefined,
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::ECS::Cluster", {
+  template.hasResourceProperties("AWS::ECS::Cluster", {
     ClusterName: clusterName,
   });
 });
@@ -269,7 +269,7 @@ test('Test with custom Fargate Service props', () => {
     { serviceName  }
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::ECS::Service", {
+  template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName,
   });
 });
@@ -298,7 +298,7 @@ test('Test with custom security group', () => {
     { securityGroups: [ customSg ]  }
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+  template.hasResourceProperties("AWS::EC2::SecurityGroup", {
     GroupDescription: groupDescription,
   });
 

--- a/source/patterns/@aws-solutions-constructs/core/test/glue-job-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/glue-job-helper.test.ts
@@ -53,7 +53,7 @@ test('Test deployment with role creation', () => {
 
   expect(glueJob.bucket).toBeDefined();
   expect(glueJob.bucket).toBeInstanceOf(Bucket);
-  Template.fromStack(stack).hasResource('AWS::Glue::Job', {
+  template.hasResource('AWS::Glue::Job', {
     Type: "AWS::Glue::Job",
     Properties: {
       Command: {
@@ -115,7 +115,7 @@ test('Create a Glue Job outside the construct', () => {
 
   expect(glueJob.bucket).not.toBeDefined();
   expect(glueJob.loggingBucket).not.toBeDefined();
-  Template.fromStack(stack).hasResource('AWS::Glue::Job', {
+  template.hasResource('AWS::Glue::Job', {
     Type: "AWS::Glue::Job",
     Properties: {
       AllocatedCapacity: 2,
@@ -305,7 +305,7 @@ test('Test deployment with role creation', () => {
       comment: ""
     }], 'kinesis', {STREAM_NAME: 'testStream'})
   });
-  Template.fromStack(stack).hasResource('AWS::IAM::Role', {
+  template.hasResource('AWS::IAM::Role', {
     Type: "AWS::IAM::Role",
     Properties: {
       AssumeRolePolicyDocument: {
@@ -359,7 +359,7 @@ test('Test deployment with role creation', () => {
       comment: ""
     }], 'kinesis', {STREAM_NAME: 'testStream'})
   });
-  Template.fromStack(stack).hasResource('AWS::S3::Bucket', {
+  template.hasResource('AWS::S3::Bucket', {
     Type: 'AWS::S3::Bucket',
     Properties: {
       BucketEncryption: {

--- a/source/patterns/@aws-solutions-constructs/core/test/glue-table-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/glue-table-helper.test.ts
@@ -55,7 +55,7 @@ test('create default CfnTable with default props', () => {
     }
   });
 
-  Template.fromStack(stack).hasResource('AWS::Glue::Table', {
+  template.hasResource('AWS::Glue::Table', {
     Type: "AWS::Glue::Table",
     Properties: {
       CatalogId: "fakecatalogfortest",

--- a/source/patterns/@aws-solutions-constructs/core/test/iot-rule.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/iot-rule.test.ts
@@ -41,7 +41,7 @@ test('test TopicRuleProps override sql and description', () => {
 
   new iot.CfnTopicRule(stack, 'IotTopic', outProps);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::IoT::TopicRule', {
+  template.hasResourceProperties('AWS::IoT::TopicRule', {
     TopicRulePayload: {
       Actions: [
         {
@@ -80,7 +80,7 @@ test('test TopicRuleProps override actions', () => {
 
   new iot.CfnTopicRule(stack, 'IotTopic', outProps);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::IoT::TopicRule', {
+  template.hasResourceProperties('AWS::IoT::TopicRule', {
     TopicRulePayload: {
       Actions: [
         {

--- a/source/patterns/@aws-solutions-constructs/core/test/kinesis-analytics.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/kinesis-analytics.test.ts
@@ -44,7 +44,7 @@ test("test kinesisanalytics override inputProperty", () => {
 
   new kinesisanalytics.CfnApplication(stack, "KinesisAnalytics", outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::KinesisAnalytics::Application", {
+  template.hasResourceProperties("AWS::KinesisAnalytics::Application", {
     Inputs: [
       {
         InputSchema: {
@@ -94,7 +94,7 @@ test("Test default implementation", () => {
 
   defaults.buildKinesisAnalyticsApp(stack, kinesisProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::KinesisAnalytics::Application", {
+  template.hasResourceProperties("AWS::KinesisAnalytics::Application", {
     Inputs: [{
       InputSchema: {
         RecordColumns: [{

--- a/source/patterns/@aws-solutions-constructs/core/test/kinesis-firehose-s3-defaults.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/kinesis-firehose-s3-defaults.test.ts
@@ -37,7 +37,7 @@ test('test kinesisanalytics override buffer conditions', () => {
 
   new kinesisfirehose.CfnDeliveryStream(stack, 'KinesisFirehose', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::KinesisFirehose::DeliveryStream", {
+  template.hasResourceProperties("AWS::KinesisFirehose::DeliveryStream", {
     ExtendedS3DestinationConfiguration: {
       BucketARN: "bucket_arn",
       BufferingHints: {

--- a/source/patterns/@aws-solutions-constructs/core/test/kinesis-streams-defaults.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/kinesis-streams-defaults.test.ts
@@ -30,7 +30,7 @@ test('test kinesisstream override RetentionPeriodHours', () => {
 
   new kinesis.Stream(stack, 'KinesisStream', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::Kinesis::Stream", {
+  template.hasResourceProperties("AWS::Kinesis::Stream", {
     RetentionPeriodHours: 48
   });
 });

--- a/source/patterns/@aws-solutions-constructs/core/test/kinesis-streams-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/kinesis-streams-helper.test.ts
@@ -26,7 +26,7 @@ test('Test minimal deployment with no properties', () => {
   // Helper declaration
   defaults.buildKinesisStream(stack, {});
 
-  Template.fromStack(stack).hasResource('AWS::Kinesis::Stream', {
+  template.hasResource('AWS::Kinesis::Stream', {
     Type: "AWS::Kinesis::Stream",
     Properties: {
       StreamEncryption: {
@@ -85,7 +85,7 @@ test('Test deployment w/ existing stream', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Kinesis::Stream', {
+  template.hasResourceProperties('AWS::Kinesis::Stream', {
     ShardCount: 2,
     RetentionPeriodHours: 72
   });

--- a/source/patterns/@aws-solutions-constructs/core/test/kms-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/kms-helper.test.ts
@@ -25,7 +25,7 @@ test('Test minimal deployment with no properties', () => {
   // Helper declaration
   defaults.buildEncryptionKey(stack);
 
-  Template.fromStack(stack).hasResource('AWS::KMS::Key', {
+  template.hasResource('AWS::KMS::Key', {
     Type: "AWS::KMS::Key",
     Properties: {
       EnableKeyRotation: true
@@ -44,7 +44,7 @@ test('Test minimal deployment with custom properties', () => {
     enableKeyRotation: false
   });
 
-  Template.fromStack(stack).hasResource('AWS::KMS::Key', {
+  template.hasResource('AWS::KMS::Key', {
     Type: "AWS::KMS::Key",
     Properties: {
       EnableKeyRotation: false

--- a/source/patterns/@aws-solutions-constructs/core/test/lambda-event-source.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/lambda-event-source.test.ts
@@ -141,7 +141,7 @@ test('test sqsDlqQueueProps override', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "hello-world",
     VisibilityTimeout: 50
   });

--- a/source/patterns/@aws-solutions-constructs/core/test/lambda-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/lambda-helper.test.ts
@@ -30,7 +30,7 @@ test("test FunctionProps override code and runtime", () => {
 
   defaults.deployLambdaFunction(stack, inProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": ["LambdaFunctionServiceRole0C4CDE0B", "Arn"],
@@ -51,7 +51,7 @@ test("test FunctionProps override timeout", () => {
 
   defaults.deployLambdaFunction(stack, inProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": ["LambdaFunctionServiceRole0C4CDE0B", "Arn"],
@@ -72,7 +72,7 @@ test("test FunctionProps for environment variable when runtime = NODEJS", () => 
 
   defaults.deployLambdaFunction(stack, inProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": ["LambdaFunctionServiceRole0C4CDE0B", "Arn"],
@@ -97,7 +97,7 @@ test("test FunctionProps when runtime = PYTHON", () => {
 
   defaults.deployLambdaFunction(stack, inProps);
 
-  Template.fromStack(stack).hasResourceProperties(
+  template.hasResourceProperties(
     "AWS::Lambda::Function",
     {
       Handler: "index.handler",
@@ -125,7 +125,7 @@ test("test buildLambdaFunction with deploy = true", () => {
     lambdaFunctionProps: inProps,
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": ["LambdaFunctionServiceRole0C4CDE0B", "Arn"],
@@ -164,7 +164,7 @@ test("test buildLambdaFunction with FunctionProps", () => {
 
   defaults.deployLambdaFunction(stack, inProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": ["LambdaFunctionServiceRole0C4CDE0B", "Arn"],
@@ -195,7 +195,7 @@ test("test buildLambdaFunction with Tracing Disabled", () => {
 
   defaults.deployLambdaFunction(stack, inProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+  template.hasResourceProperties("AWS::Lambda::Function", {
     Handler: "index.handler",
     Role: {
       "Fn::GetAtt": ["LambdaFunctionServiceRole0C4CDE0B", "Arn"],
@@ -218,7 +218,7 @@ test("test buildLambdaFunction when Lambda properties includes a VPC", () => {
 
   defaults.deployLambdaFunction(stack, lambdaFunctionProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {
@@ -379,7 +379,7 @@ test('Test environment variable for NodeJS 14.x', () => {
   defaults.deployLambdaFunction(stack, inProps);
 
   // Assertion
-  Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
     Role: {
       'Fn::GetAtt': ['LambdaFunctionServiceRole0C4CDE0B', 'Arn']
@@ -406,7 +406,7 @@ test('Test minimum deployment with an existing VPC as a vpc parameter in deployL
   defaults.deployLambdaFunction(stack, inProps, undefined, fakeVpc);
 
   // Assertion
-  Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     VpcConfig: {
       SecurityGroupIds: [
         {
@@ -460,7 +460,7 @@ test('test buildLambdaFunction with lambdaFunctionProps default id', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Role: {
       'Fn::GetAtt': ['LambdaFunctionServiceRole0C4CDE0B', 'Arn'],
     },
@@ -479,7 +479,7 @@ test('test buildLambdaFunction with lambdaFunctionProps custom id', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+  template.hasResourceProperties('AWS::Lambda::Function', {
     Role: {
       'Fn::GetAtt': ['MyTestFunctionServiceRole37517223', 'Arn'],
     },

--- a/source/patterns/@aws-solutions-constructs/core/test/mediastore-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/mediastore-helper.test.ts
@@ -28,7 +28,7 @@ test('MediaStore container override params', () => {
   };
 
   MediaStoreContainer(stack, mediaStoreContainerProps);
-  Template.fromStack(stack).hasResourceProperties('AWS::MediaStore::Container', {
+  template.hasResourceProperties('AWS::MediaStore::Container', {
     AccessLoggingEnabled: true,
     CorsPolicy: [
       {

--- a/source/patterns/@aws-solutions-constructs/core/test/opensearch-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/opensearch-helper.test.ts
@@ -61,7 +61,7 @@ test('Test override SnapshotOptions for buildOpenSearch', () => {
 
   expect(buildOpenSearchResponse.domain).toBeDefined();
   expect(buildOpenSearchResponse.role).toBeDefined();
-  Template.fromStack(stack).hasResourceProperties('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     AccessPolicies: {
       Statement: [
         {
@@ -151,7 +151,7 @@ test('Test VPC with 1 AZ, Zone Awareness Disabled', () => {
     }
   }, undefined, vpc);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     DomainName: "test-domain",
     ClusterConfig: {
       DedicatedMasterCount: 3,
@@ -173,7 +173,7 @@ test('Test VPC with 2 AZ, Zone Awareness Enabled', () => {
 
   expect(buildOpenSearchResponse.domain).toBeDefined();
   expect(buildOpenSearchResponse.role).toBeDefined();
-  Template.fromStack(stack).hasResourceProperties('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     DomainName: "test-domain",
     ClusterConfig: {
       DedicatedMasterCount: 3,
@@ -193,7 +193,7 @@ test('Test VPC with 3 AZ, Zone Awareness Enabled', () => {
 
   buildTestOpenSearchDomain(stack, 'test-domain', {}, undefined, vpc);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     DomainName: "test-domain",
     ClusterConfig: {
       DedicatedMasterCount: 3,
@@ -225,7 +225,7 @@ test('Test deployment with an existing private VPC', () => {
 
   buildTestOpenSearchDomain(stack, 'test-domain', {}, undefined, vpc);
 
-  Template.fromStack(stack).hasResourceProperties('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     DomainName: "test-domain",
     ClusterConfig: {
       DedicatedMasterCount: 3,
@@ -265,7 +265,7 @@ test('Test engine version override for buildOpenSearch', () => {
     engineVersion: 'OpenSearch_1.0'
   });
 
-  Template.fromStack(stack).hasResourceProperties('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     AccessPolicies: {
       Statement: [
         {
@@ -349,7 +349,7 @@ test('Test deployment with lambdaRoleARN', () => {
 
   expect(buildOpenSearchResponse.domain).toBeDefined();
   expect(buildOpenSearchResponse.role).toBeDefined();
-  Template.fromStack(stack).hasResourceProperties('AWS::OpenSearchService::Domain', {
+  template.hasResourceProperties('AWS::OpenSearchService::Domain', {
     AccessPolicies: {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/core/test/s3-bucket-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/s3-bucket-helper.test.ts
@@ -435,7 +435,7 @@ test('test s3Bucket removalPolicy override', () => {
     },
   }, 'test-bucket');
 
-  Template.fromStack(stack).hasResource("AWS::S3::Bucket", {
+  template.hasResource("AWS::S3::Bucket", {
     Type: 'AWS::S3::Bucket',
     Properties: {
       AccessControl: "LogDeliveryWrite"

--- a/source/patterns/@aws-solutions-constructs/core/test/s3-bucket.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/s3-bucket.test.ts
@@ -30,7 +30,7 @@ test('test s3Bucket override versioningConfiguration', () => {
   const outProps = overrideProps(defaultProps, inProps);
   new s3.Bucket(stack, 'test-s3-verioning', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketEncryption: {
       ServerSideEncryptionConfiguration: [
         {
@@ -61,7 +61,7 @@ test('test s3Bucket override bucketEncryption', () => {
   const outProps = overrideProps(defaultProps, inProps);
   new s3.Bucket(stack, 'test-s3-encryption', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketEncryption: {
       ServerSideEncryptionConfiguration: [
         {
@@ -91,7 +91,7 @@ test('test s3Bucket override publicAccessBlockConfiguration', () => {
   const outProps = overrideProps(defaultProps, inProps);
   new s3.Bucket(stack, 'test-s3-publicAccessBlock', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     PublicAccessBlockConfiguration: {
       BlockPublicAcls: true,
       IgnorePublicAcls: true
@@ -112,7 +112,7 @@ test('test s3Bucket add lifecycleConfiguration', () => {
   const outProps = overrideProps(defaultProps, inProps);
   new s3.Bucket(stack, 'test-s3-lifecycle', outProps);
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     LifecycleConfiguration: {
       Rules: [
         {
@@ -135,7 +135,7 @@ test('test s3Bucket override serverAccessLogsBucket', () => {
     bucketProps: myS3Props
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     LoggingConfiguration: {
       DestinationBucketName: {
         Ref: "MyS3LoggingBucket119BE896"
@@ -151,7 +151,7 @@ test('test createAlbLoggingBucket()', () => {
     bucketName: 'test-name'
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+  template.hasResourceProperties("AWS::S3::Bucket", {
     BucketName: 'test-name'
   });
 });
@@ -165,7 +165,7 @@ test('Test bucket policy that only accepts SSL requests only', () => {
     }
   }, 'test-bucket');
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::BucketPolicy", {
+  template.hasResourceProperties("AWS::S3::BucketPolicy", {
     PolicyDocument: {
       Statement: [
         {
@@ -265,7 +265,7 @@ test('Test enforcing SSL when bucketProps is not provided', () => {
 
   defaults.buildS3Bucket(stack, {}, 'test-bucket');
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::BucketPolicy", {
+  template.hasResourceProperties("AWS::S3::BucketPolicy", {
     PolicyDocument: {
       Statement: [
         {
@@ -318,7 +318,7 @@ test('Test enforcing SSL when bucketProps is provided and enforceSSL is not set'
     }
   }, 'test-bucket');
 
-  Template.fromStack(stack).hasResourceProperties("AWS::S3::BucketPolicy", {
+  template.hasResourceProperties("AWS::S3::BucketPolicy", {
     PolicyDocument: {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/core/test/sagemaker-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/sagemaker-helper.test.ts
@@ -74,7 +74,7 @@ test('Test deployment w/ existing VPC', () => {
   expect(buildSagemakerNotebookResponse.vpc).not.toBeDefined();
   expect(buildSagemakerNotebookResponse.securityGroup).not.toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties('AWS::SageMaker::NotebookInstance', {
+  template.hasResourceProperties('AWS::SageMaker::NotebookInstance', {
     DirectInternetAccess: 'Disabled',
     SecurityGroupIds: ['sg-deadbeef'],
     SubnetId: 'subnet-deadbeef',
@@ -96,7 +96,7 @@ test('Test deployment w/ override', () => {
       kmsKeyId: key.keyArn,
     },
   });
-  Template.fromStack(stack).hasResourceProperties('AWS::SageMaker::NotebookInstance', {
+  template.hasResourceProperties('AWS::SageMaker::NotebookInstance', {
     DirectInternetAccess: 'Disabled',
     InstanceType: 'ml.c4.2xlarge',
     KmsKeyId: {

--- a/source/patterns/@aws-solutions-constructs/core/test/secretsmanager-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/secretsmanager-helper.test.ts
@@ -27,7 +27,7 @@ test('Test minimal deployment with no properties', () => {
   // Helper declaration
   defaults.buildSecretsManagerSecret(stack, 'secret', {});
 
-  Template.fromStack(stack).hasResource('AWS::SecretsManager::Secret', {
+  template.hasResource('AWS::SecretsManager::Secret', {
     Type: 'AWS::SecretsManager::Secret',
     UpdateReplacePolicy: 'Retain',
     DeletionPolicy: 'Retain'
@@ -47,7 +47,7 @@ test('Test deployment with custom properties', () => {
     removalPolicy: RemovalPolicy.DESTROY,
   });
   // Assertion 1
-  Template.fromStack(stack).hasResource('AWS::SecretsManager::Secret', {
+  template.hasResource('AWS::SecretsManager::Secret', {
     Type: 'AWS::SecretsManager::Secret',
     UpdateReplacePolicy: 'Delete',
     DeletionPolicy: 'Delete',

--- a/source/patterns/@aws-solutions-constructs/core/test/security-group-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/security-group-helper.test.ts
@@ -37,7 +37,7 @@ test("Test minimal deployment with no properties", () => {
     []
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+  template.hasResourceProperties("AWS::EC2::SecurityGroup", {
     SecurityGroupEgress: [
       {
         CidrIp: "0.0.0.0/0",
@@ -66,7 +66,7 @@ test("Test deployment with ingress rules", () => {
     []
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+  template.hasResourceProperties("AWS::EC2::SecurityGroup", {
     SecurityGroupIngress: [
       {
         CidrIp: "1.1.1.1/16",
@@ -100,7 +100,7 @@ test("Test deployment with egress rule", () => {
     ]
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+  template.hasResourceProperties("AWS::EC2::SecurityGroup", {
     SecurityGroupEgress: [
       {
         CidrIp: "1.1.1.1/16",
@@ -135,7 +135,7 @@ test("Test self referencing security group", () => {
     testPort,
   );
 
-  Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+  template.hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
     IpProtocol: "TCP",
     FromPort: testPort,
     ToPort: testPort,

--- a/source/patterns/@aws-solutions-constructs/core/test/sns-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/sns-helper.test.ts
@@ -30,7 +30,7 @@ test('Test deployment with no properties using AWS Managed KMS Key', () => {
 
   expect(buildTopicResponse.topic).toBeDefined();
   expect(buildTopicResponse.key).toBeDefined();
-  Template.fromStack(stack).hasResourceProperties("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::Join": [
         "",
@@ -98,7 +98,7 @@ test('Test deployment w/ imported encryption key', () => {
   expect(buildTopicResponse.topic).toBeDefined();
   expect(buildTopicResponse.key).toBeDefined();
 
-  Template.fromStack(stack).hasResourceProperties("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -116,7 +116,7 @@ test('enableEncryptionWithCustomerManagedKey flag is ignored when encryptionKey 
     encryptionKey: defaults.buildEncryptionKey(stack)
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -135,7 +135,7 @@ test('enableEncryptionWithCustomerManagedKey flag is ignored when topicProps.mas
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::SNS::Topic", {
+  template.hasResourceProperties("AWS::SNS::Topic", {
     KmsMasterKeyId: {
       "Fn::GetAtt": [
         "EncryptionKey1B843E66",
@@ -179,7 +179,7 @@ test('encryptionProps are set correctly on the SNS Topic', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::KMS::Key", {
+  template.hasResourceProperties("AWS::KMS::Key", {
     Description: description
   });
 });

--- a/source/patterns/@aws-solutions-constructs/core/test/sqs-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/sqs-helper.test.ts
@@ -67,7 +67,7 @@ test('Test deployment without imported encryption key', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: "existing-queue",
     KmsMasterKeyId: "alias/aws/sqs"
   });
@@ -106,14 +106,14 @@ test('Test DLQ when existing Queue Provided', () => {
   const returnedQueue = defaults.buildDeadLetterQueue(stack, buildDlqProps);
 
   expect(returnedQueue).toBeUndefined();
-  Template.fromStack(stack).resourceCountIs("AWS::SQS::Queue", 1);
+  template.resourceCountIs("AWS::SQS::Queue", 1);
 });
 
 test('Test DLQ with all defaults', () => {
   const stack = new Stack();
 
   buildDeadLetterQueue(stack, {});
-  Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     KmsMasterKeyId: "alias/aws/sqs"
   });
 });
@@ -127,7 +127,7 @@ test("Test DLQ with a provided properties", () => {
       queueName: testQueueName,
     },
   });
-  Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: testQueueName,
   });
   expect(returnedQueue).toBeDefined();
@@ -155,7 +155,7 @@ test('Test returning an existing Queue', () => {
     existingQueueObj: existingQueue
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     QueueName: testQueueName,
   });
   expect(existingQueue.queueName).toEqual(buildQueueResponse.queue.queueName);
@@ -171,7 +171,7 @@ test('Test creating a queue with a DLQ', () => {
     deadLetterQueue: dlqInterface
   });
 
-  Template.fromStack(stack).resourceCountIs("AWS::SQS::Queue", 2);
+  template.resourceCountIs("AWS::SQS::Queue", 2);
   expect(buildQueueResponse.queue).toBeDefined();
   expect(buildQueueResponse.queue.deadLetterQueue).toBeDefined();
 });
@@ -185,7 +185,7 @@ test('Test creating a FIFO queue', () => {
     }
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+  template.hasResourceProperties("AWS::SQS::Queue", {
     FifoQueue: true
   });
   expect(buildQueueResponse.queue.fifo).toBe(true);

--- a/source/patterns/@aws-solutions-constructs/core/test/ssm-string-parameter-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/ssm-string-parameter-helper.test.ts
@@ -25,7 +25,7 @@ test('Test minimal deployment with required properties', () => {
   const parameterValue = "test-val";
   defaults.buildSsmStringParameter(stack, 'parameterName', {stringValue: parameterValue});
 
-  Template.fromStack(stack).hasResourceProperties('AWS::SSM::Parameter', {
+  template.hasResourceProperties('AWS::SSM::Parameter', {
     Type: 'String',
     Value: parameterValue
   });

--- a/source/patterns/@aws-solutions-constructs/core/test/step-function-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/step-function-helper.test.ts
@@ -91,7 +91,7 @@ test('Check default Cloudwatch permissions', () => {
   // Assertion
   expect(buildStateMachineResponse.stateMachine).toBeDefined();
   expect(buildStateMachineResponse.stateMachine).toBeDefined();
-  Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+  template.hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
         {

--- a/source/patterns/@aws-solutions-constructs/core/test/vpc-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/vpc-helper.test.ts
@@ -54,7 +54,7 @@ test('Test deployment w/ user provided custom properties', () => {
       ipAddresses: ec2.IpAddresses.cidr('172.168.0.0/19'),
     },
   });
-  Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     CidrBlock: '172.168.0.0/19',
     EnableDnsHostnames: false,
     EnableDnsSupport: false,
@@ -76,7 +76,7 @@ test('Test deployment w/ construct provided custom properties', () => {
       ipAddresses: ec2.IpAddresses.cidr('172.168.0.0/19'),
     },
   });
-  Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     CidrBlock: '172.168.0.0/19',
     EnableDnsHostnames: true,
     EnableDnsSupport: true,
@@ -103,7 +103,7 @@ test('Test deployment w/ construct and user provided custom properties', () => {
       ipAddresses: ec2.IpAddresses.cidr('172.168.0.0/19'),
     },
   });
-  Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPC', {
+  template.hasResourceProperties('AWS::EC2::VPC', {
     CidrBlock: '172.168.0.0/19',
     EnableDnsHostnames: false,
     EnableDnsSupport: false,
@@ -202,7 +202,7 @@ test('Test adding Interface Endpoint', () => {
   AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.SNS);
 
   // Assertion
-  Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+  template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Interface',
   });
 });
@@ -221,7 +221,7 @@ test('Test adding SAGEMAKER_RUNTIME Interface Endpoint', () => {
   AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.SAGEMAKER_RUNTIME);
 
   // Assertion
-  Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+  template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Interface',
   });
 });
@@ -241,7 +241,7 @@ test('Test adding a second Endpoint of same service', () => {
   AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.SNS);
 
   // Assertion
-  Template.fromStack(stack).resourceCountIs('AWS::EC2::VPCEndpoint', 1);
+  template.resourceCountIs('AWS::EC2::VPCEndpoint', 1);
 });
 
 // --------------------------------------------------------------
@@ -276,7 +276,7 @@ test('Test adding Events Interface Endpoint', () => {
   AddAwsServiceEndpoint(stack, testVpc, ServiceEndpointTypes.EVENTS);
 
   // Assertion
-  Template.fromStack(stack).hasResourceProperties('AWS::EC2::VPCEndpoint', {
+  template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
     VpcEndpointType: 'Interface',
   });
 });

--- a/source/patterns/@aws-solutions-constructs/core/test/waf-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/waf-helper.test.ts
@@ -196,7 +196,7 @@ test('Test deployment w/ user provided custom properties', () => {
     webaclProps: props
   });
 
-  Template.fromStack(stack).hasResourceProperties("AWS::WAFv2::WebACL", {
+  template.hasResourceProperties("AWS::WAFv2::WebACL", {
     Scope: "CLOUDFRONT",
     VisibilityConfig: {
       CloudWatchMetricsEnabled: false,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove the deprecated @aws-cdk/assert completely

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.