### PR TITLE
chore(aws-cdk/assert): remove all references to aws-cdk/assert

### DIFF
--- a/deployment/v2/align-version.js
+++ b/deployment/v2/align-version.js
@@ -14,8 +14,6 @@ const awsCdkLibVersion = '2.68.0';
 const constructsVersion = '10.0.0';
 const MODULE_EXEMPTIONS = new Set([
   '@aws-cdk/cloudformation-diff',
-  '@aws-cdk/assert',
-  '@aws-cdk/assert/jest',
   'aws-cdk'
 ]);
 

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-ecs": "0.0.0",
     "@aws-cdk/aws-ecr": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-lambda": "0.0.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
@@ -14,7 +14,6 @@
 // Imports
 import { Stack } from "aws-cdk-lib";
 import { ApiGatewayToDynamoDB, ApiGatewayToDynamoDBProps } from "../lib";
-import "@aws-cdk/assert/jest";
 import * as ddb from "aws-cdk-lib/aws-dynamodb";
 import * as api from "aws-cdk-lib/aws-apigateway";
 import { Template } from "aws-cdk-lib/assertions";

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
@@ -66,7 +66,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.27"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
@@ -68,7 +68,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
@@ -65,7 +65,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-dynamodb": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-ecs": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
@@ -57,7 +57,6 @@
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-ecs": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/awsopensearchservice": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-s3": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-secretsmanager": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-sns": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-sqs": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-ssm": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@aws-cdk/aws-cloudwatch": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/package.json
@@ -65,7 +65,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
@@ -65,7 +65,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
@@ -67,7 +67,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
@@ -65,7 +65,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/test/lambda-elasticachememcached.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/test/lambda-elasticachememcached.test.ts
@@ -12,7 +12,6 @@
  */
 
 // Imports
-import "@aws-cdk/assert/jest";
 import * as defaults from "@aws-solutions-constructs/core";
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
@@ -64,8 +64,7 @@
       "constructs": "^3.2.0"
     },
     "devDependencies": {
-      "@aws-cdk/assert": "0.0.0",
-      "@types/jest": "^27.4.0",
+        "@types/jest": "^27.4.0",
       "@types/node": "^10.3.0"
     },
     "jest": {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^24.0.23",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
@@ -61,7 +61,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^24.0.23",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "eslint-plugin-import": "^2.22.0"

--- a/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^26.0.22",
     "@types/node": "^10.3.0",
     "prettier": "^2.5.1"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
@@ -68,7 +68,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
@@ -62,7 +62,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
@@ -64,7 +64,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
@@ -56,7 +56,6 @@
     "@aws-solutions-constructs/core": "0.0.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
@@ -63,7 +63,6 @@
     "constructs": "^3.2.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "0.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0"
   },

--- a/source/patterns/@aws-solutions-constructs/core/lib/security-group-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/security-group-helper.ts
@@ -16,7 +16,6 @@
  *  or removed outside of a major release. We recommend against calling them directly from client code.
  */
 
-// import { countResources } from "@aws-cdk/assert";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { addCfnSuppressRules } from './utils';


### PR DESCRIPTION
*Description of changes:*

References to @aws-cdk/assert were replaced in package.json files by `align-version.sh revert`. This PR removes them again and cleans up a couple issues that their presence hid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.