### PR TITLE
fix(all constructs): use aws.partition where value could refer to govcloud

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/lib/index.ts
@@ -116,14 +116,14 @@ export class ApiGatewayToIot extends Construct {
             Action: [
               "iot:UpdateThingShadow"
             ],
-            Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/*`,
+            Resource: `arn:${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/*`,
             Effect: "Allow"
           },
           {
             Action: [
               "iot:Publish"
             ],
-            Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/*`,
+            Resource: `arn:${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/*`,
             Effect: "Allow"
           }
         ]

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.defaultParams.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.defaultParams.expected.json
@@ -28,7 +28,11 @@
                     "Fn::Join": [
                       "",
                       [
-                        "arn:aws:iot:",
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":iot:",
                         {
                           "Ref": "AWS::Region"
                         },
@@ -48,7 +52,11 @@
                     "Fn::Join": [
                       "",
                       [
-                        "arn:aws:iot:",
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":iot:",
                         {
                           "Ref": "AWS::Region"
                         },

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.ts
@@ -40,14 +40,14 @@ const policyJSON = {
       Action: [
         "iot:UpdateThingShadow"
       ],
-      Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/*`,
+      Resource: `arn:${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/*`,
       Effect: "Allow"
     },
     {
       Action: [
         "iot:Publish"
       ],
-      Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/*`,
+      Resource: `arn:${arn:${Aws.PARTITION}:Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/*`,
       Effect: "Allow"
     }
   ]

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.overrideParams.ts
@@ -40,14 +40,14 @@ const policyJSON = {
       Action: [
         "iot:UpdateThingShadow"
       ],
-      Resource: `arn:${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/*`,
+      Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/*`,
       Effect: "Allow"
     },
     {
       Action: [
         "iot:Publish"
       ],
-      Resource: `arn:${arn:${Aws.PARTITION}:Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/*`,
+      Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/*`,
       Effect: "Allow"
     }
   ]

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.override_auth_api_keys.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/integ.override_auth_api_keys.expected.json
@@ -28,7 +28,11 @@
                     "Fn::Join": [
                       "",
                       [
-                        "arn:aws:iot:",
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":iot:",
                         {
                           "Ref": "AWS::Region"
                         },
@@ -48,7 +52,11 @@
                     "Fn::Join": [
                       "",
                       [
-                        "arn:aws:iot:",
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":iot:",
                         {
                           "Ref": "AWS::Region"
                         },

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/test.apigateway-iot.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/test.apigateway-iot.test.ts
@@ -302,14 +302,14 @@ test('Test for overriden IAM Role', () => {
         Action: [
           "iot:UpdateThingShadow"
         ],
-        Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/mything1`,
+        Resource: `arn:$${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/mything1`,
         Effect: "Allow"
       },
       {
         Action: [
           "iot:Publish"
         ],
-        Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/topic-abc`,
+        Resource: `arn:${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/topic-abc`,
         Effect: "Allow"
       }
     ]

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/test.apigateway-iot.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/test/test.apigateway-iot.test.ts
@@ -72,7 +72,11 @@ test('Test for default IAM Role', () => {
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:iot:",
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition"
+                    },
+                    ":iot:",
                     {
                       Ref: "AWS::Region"
                     },
@@ -92,7 +96,11 @@ test('Test for default IAM Role', () => {
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:iot:",
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition"
+                    },
+                    ":iot:",
                     {
                       Ref: "AWS::Region"
                     },
@@ -302,14 +310,14 @@ test('Test for overriden IAM Role', () => {
         Action: [
           "iot:UpdateThingShadow"
         ],
-        Resource: `arn:$${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/mything1`,
+        Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:thing/mything1`,
         Effect: "Allow"
       },
       {
         Action: [
           "iot:Publish"
         ],
-        Resource: `arn:${cdk.Aws.PARTITION}:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/topic-abc`,
+        Resource: `arn:aws:iot:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:topic/topic-abc`,
         Effect: "Allow"
       }
     ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.overrideProperties.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.overrideProperties.ts
@@ -31,7 +31,7 @@ const mediaStoreContainerProps: mediastore.CfnContainerProps = {
       Effect: 'Allow',
       Principal: '*',
       Action: 'mediastore:*',
-      Resource: `arn:${Aws.PARTITION}:mediastore:${Aws.REGION}:${Aws.ACCOUNT_ID}:container/MyOwnMediaStoreContainer/*`,
+      Resource: `arn:aws:mediastore:${Aws.REGION}:${Aws.ACCOUNT_ID}:container/MyOwnMediaStoreContainer/*`,
       Condition: {
         Bool: { "aws:SecureTransport": "true" }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.overrideProperties.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.overrideProperties.ts
@@ -31,7 +31,7 @@ const mediaStoreContainerProps: mediastore.CfnContainerProps = {
       Effect: 'Allow',
       Principal: '*',
       Action: 'mediastore:*',
-      Resource: `arn:aws:mediastore:${Aws.REGION}:${Aws.ACCOUNT_ID}:container/MyOwnMediaStoreContainer/*`,
+      Resource: `arn:${Aws.PARTITION}:mediastore:${Aws.REGION}:${Aws.ACCOUNT_ID}:container/MyOwnMediaStoreContainer/*`,
       Condition: {
         Bool: { "aws:SecureTransport": "true" }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -228,7 +228,7 @@ test('test cloudfront disable cloudfront logging', () => {
 test('test cloudfront with custom domain names', () => {
   const stack = new cdk.Stack();
 
-  const certificate = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:aws:acm:us-east-1:123456789012:certificate/11112222-3333-1234-1234-123456789012');
+  const certificate = acm.Certificate.fromCertificateArn(stack, 'Cert', 'arn:${Aws.PARTITION}:acm:us-east-1:123456789012:certificate/11112222-3333-1234-1234-123456789012');
 
   const props: CloudFrontToS3Props = {
     cloudFrontDistributionProps: {

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.deploy-with-vpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.deploy-with-vpc.expected.json
@@ -494,7 +494,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -513,7 +517,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -581,8 +589,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.no-arguments.expected.json
@@ -424,7 +424,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -443,7 +447,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -511,8 +519,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/fargate-opensearch.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/fargate-opensearch.test.ts
@@ -119,7 +119,11 @@ test('Test cognito dashboard role IAM policy', () => {
               "Fn::Join": [
                 "",
                 [
-                  "arn:aws:cognito-identity:",
+                  "arn:",
+                  {
+                    Ref: "AWS::Partition"
+                  },
+                  ":cognito-identity:",
                   {
                     Ref: "AWS::Region"
                   },
@@ -138,7 +142,11 @@ test('Test cognito dashboard role IAM policy', () => {
               "Fn::Join": [
                 "",
                 [
-                  "arn:aws:es:",
+                  "arn:",
+                  {
+                    Ref: "AWS::Partition"
+                  },
+                  ":es:",
                   {
                     Ref: "AWS::Region"
                   },

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/integ.existing-resources.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/integ.existing-resources.expected.json
@@ -1241,7 +1241,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -1260,7 +1264,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -1320,8 +1328,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/integ.new-resources.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/integ.new-resources.expected.json
@@ -219,7 +219,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -238,7 +242,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -298,8 +306,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployFunctionWithClusterConfig.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployFunctionWithClusterConfig.expected.json
@@ -423,7 +423,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -442,7 +446,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -510,8 +518,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployFunctionWithExistingVpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployFunctionWithExistingVpc.expected.json
@@ -1097,7 +1097,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -1116,7 +1120,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -1184,8 +1192,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployFunctionWithVpcProps.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployFunctionWithVpcProps.expected.json
@@ -425,7 +425,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -444,7 +448,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -512,8 +520,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployToFiveZones.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.deployToFiveZones.expected.json
@@ -427,7 +427,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -446,7 +450,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -514,7 +522,11 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
                     {
                       "Ref": "AWS::Region"
                     },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.disabledZoneAwareness.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.disabledZoneAwareness.expected.json
@@ -419,7 +419,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -438,7 +442,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -506,7 +514,11 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
                     {
                       "Ref": "AWS::Region"
                     },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.domain-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.domain-arguments.expected.json
@@ -362,7 +362,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -381,7 +385,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -449,7 +457,11 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
                     {
                       "Ref": "AWS::Region"
                     },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.no-arguments.expected.json
@@ -362,7 +362,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -381,7 +385,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -449,7 +457,11 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
                     {
                       "Ref": "AWS::Region"
                     },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.cluster-config.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.cluster-config.expected.json
@@ -423,7 +423,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -442,7 +446,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -510,8 +518,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.disabled-zone-awareness.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.disabled-zone-awareness.expected.json
@@ -419,7 +419,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -438,7 +442,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -506,8 +514,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.domain-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.domain-arguments.expected.json
@@ -362,7 +362,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -381,7 +385,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -449,8 +457,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.existing-vpc.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.existing-vpc.expected.json
@@ -1097,7 +1097,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -1116,7 +1120,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -1184,8 +1192,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.no-arguments.expected.json
@@ -362,7 +362,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -381,7 +385,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -449,8 +457,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.vpc-props.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.vpc-props.expected.json
@@ -425,7 +425,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:cognito-identity:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":cognito-identity:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -444,7 +448,11 @@
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:es:",
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":es:",
                       {
                         "Ref": "AWS::Region"
                       },
@@ -512,8 +520,12 @@
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:es:",
+                    "arn:",
                     {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":es:",
+                  {
                       "Ref": "AWS::Region"
                     },
                     ":",

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-defaults.ts
@@ -64,7 +64,7 @@ export function DefaultCfnDomainProps(domainName: string, cognitoKibanaConfigure
             'es:ESHttp*'
           ],
           resources: [
-            `arn:aws:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}/*`
+            `arn:${cdk.Aws.PARTITION}:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}/*`
           ]
         })
       ]

--- a/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/elasticsearch-helper.ts
@@ -284,8 +284,8 @@ function createKibanaCognitoRole(
           ],
           resources: [
             userPool.userPoolArn,
-            `arn:aws:cognito-identity:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identitypool/${identitypool.ref}`,
-            `arn:aws:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}`,
+            `arn:${cdk.Aws.PARTITION}:cognito-identity:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identitypool/${identitypool.ref}`,
+            `arn:${cdk.Aws.PARTITION}:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}`,
           ],
         }),
         new iam.PolicyStatement({

--- a/source/patterns/@aws-solutions-constructs/core/lib/opensearch-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/opensearch-defaults.ts
@@ -67,7 +67,7 @@ export function DefaultOpenSearchCfnDomainProps(domainName: string, cognitoConfi
             'es:ESHttp*'
           ],
           resources: [
-            `arn:aws:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}/*`
+            `arn:${cdk.Aws.PARTITION}:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}/*`
           ]
         })
       ]

--- a/source/patterns/@aws-solutions-constructs/core/lib/opensearch-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/opensearch-helper.ts
@@ -282,8 +282,8 @@ function createDashboardCognitoRole(
           ],
           resources: [
             userPool.userPoolArn,
-            `arn:aws:cognito-identity:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identitypool/${identitypool.ref}`,
-            `arn:aws:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}`,
+            `arn:${cdk.Aws.PARTITION}:cognito-identity:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identitypool/${identitypool.ref}`,
+            `arn:${cdk.Aws.PARTITION}:es:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:domain/${domainName}`,
           ],
         }),
         new iam.PolicyStatement({

--- a/source/patterns/@aws-solutions-constructs/core/test/elasticsearch-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/elasticsearch-helper.test.ts
@@ -87,7 +87,11 @@ test('Test override SnapshotOptions for buildElasticSearch', () => {
             "Fn::Join": [
               "",
               [
-                "arn:aws:es:",
+                "arn:",
+                {
+                  Ref: "AWS::Partition"
+                },
+                ":es:",
                 {
                   Ref: "AWS::Region"
                 },
@@ -319,7 +323,11 @@ test('Test override ES version for buildElasticSearch', () => {
             "Fn::Join": [
               "",
               [
-                "arn:aws:es:",
+                "arn:",
+                {
+                  Ref: "AWS::Partition"
+                },
+                ":es:",
                 {
                   Ref: "AWS::Region"
                 },
@@ -410,7 +418,11 @@ test('Test ES with lambdaRoleARN', () => {
             "Fn::Join": [
               "",
               [
-                "arn:aws:es:",
+                "arn:",
+                {
+                  Ref: "AWS::Partition"
+                },
+                ":es:",
                 {
                   Ref: "AWS::Region"
                 },

--- a/source/patterns/@aws-solutions-constructs/core/test/opensearch-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/opensearch-helper.test.ts
@@ -79,7 +79,11 @@ test('Test override SnapshotOptions for buildOpenSearch', () => {
             "Fn::Join": [
               "",
               [
-                "arn:aws:es:",
+                "arn:",
+                {
+                  Ref: "AWS::Partition"
+                },
+                ":es:",
                 {
                   Ref: "AWS::Region"
                 },
@@ -283,7 +287,11 @@ test('Test engine version override for buildOpenSearch', () => {
             "Fn::Join": [
               "",
               [
-                "arn:aws:es:",
+                "arn:",
+                {
+                  Ref: "AWS::Partition"
+                },
+                ":es:",
                 {
                   Ref: "AWS::Region"
                 },
@@ -370,7 +378,11 @@ test('Test deployment with lambdaRoleARN', () => {
             "Fn::Join": [
               "",
               [
-                "arn:aws:es:",
+                "arn:",
+                {
+                  Ref: "AWS::Partition"
+                },
+                ":es:",
                 {
                   Ref: "AWS::Region"
                 },


### PR DESCRIPTION
*Issue #, if available:*
#903 

*Description of changes:*
arns use values other than aws in the second term for some regions, such as GovCloud

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.