### PR TITLE
chore(cdk-integ): update CDK to 2.71.0

### DIFF
--- a/source/tools/cdk-integ-tools/package.json
+++ b/source/tools/cdk-integ-tools/package.json
@@ -32,13 +32,12 @@
     "@types/node": "18.11.9",
     "tslint": "^5.20.1",
     "typescript": "~3.9.10",
-    "aws-cdk-lib": "2.67.0",
+    "aws-cdk-lib": "2.71.0",
     "constructs": "^10.0.0"
   },
   "dependencies": {
-    "@aws-cdk/cloudformation-diff": "2.67.0",
-    "@aws-cdk/assert": "2.67.0",
-    "aws-cdk": "2.67.0",
+    "@aws-cdk/cloudformation-diff": "2.71.0",
+    "aws-cdk": "2.71.0",
     "fs-extra": "^9.0.1",
     "yargs": "^16.1.1",
     "deepmerge": "^4.0.0"
@@ -55,7 +54,7 @@
     "node": ">= 10.3.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.67.0",
+    "aws-cdk-lib": "^2.71.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION

*Description of changes:*
The build environment always get the latest CLI, which had become incompatible with the version of the CDK in the cdk-integ package.json file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.