### PR TITLE
API Gateway to Kinesis override properties -> @awslabs/aws-solutions-constructs/main

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/README.md
@@ -59,11 +59,14 @@ new ApiGatewayToKinesisStreams(this, "test-apigw-kinesis", new ApiGatewayToKines
 
 | **Name**     | **Type**        | **Description** |
 |:-------------|:----------------|-----------------|
+|appNamePrefix?|`string`|Optional prefix to insert in the resource path. Default is to not insert a prefix.|
 |apiGatewayProps?|[`api.RestApiProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApiProps.html)|Optional user-provided props to override the default props for the API Gateway.|
+|putRecordResourceName?|`string`|Override the default name for the `/record` resource|
 |putRecordRequestTemplate?|`string`|API Gateway request template for the PutRecord action. If not provided, a default one will be used.|
 |additionalPutRecordRequestTemplates?|`{ [contentType: string]: string; }`|Optional PutRecord Request Templates for content-types other than `application/json`. Use the `putRecordRequestTemplate` property to set the request template for the `application/json` content-type.|
 |putRecordRequestModel?|[`api.ModelOptions`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ModelOptions.html)|API Gateway request model for the PutRecord action. If not provided, a default one will be created.|
 |putRecordIntegrationResponses?|[`api.IntegrationResponses[]`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IntegrationResponse.html)|Optional, custom API Gateway Integration Response for the PutRecord action.|
+|putRecordsResourceName?|`string`|Override the default name for the `/records` resource.|
 |putRecordsRequestTemplate?|`string`|API Gateway request template for the PutRecords action. If not provided, a default one will be used.|
 |additionalPutRecordsRequestTemplates?|`{ [contentType: string]: string; }`|Optional PutRecords Request Templates for content-types other than `application/json`. Use the `putRecordsRequestTemplate` property to set the request template for the `application/json` content-type.|
 |putRecordsRequestModel?|[`api.ModelOptions`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ModelOptions.html)|

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/lib/index.ts
@@ -198,7 +198,7 @@ export class ApiGatewayToKinesisStreams extends Construct {
     });
 
     // PutRecords
-    const putRecordsResource = rootResource.addResource(props.putRecordsResourceName ?? 'records')
+    const putRecordsResource = rootResource.addResource(props.putRecordsResourceName ?? 'records');
     defaults.addProxyMethodToApiResource({
       service: 'kinesis',
       action: 'PutRecords',


### PR DESCRIPTION
This PR adds optional properties to the AWS API Gateway -> Kinesis Streams template to override default configurations (see README for details).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.