### PR TITLE
fix(aws-alb-fargate): change container used to launch integ tests

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.expected.json
@@ -651,7 +651,6 @@
           "Ref": "Vpc8378EB38"
         },
         "ResourceType": "VPC",
-        "TrafficType": "ALL",
         "DeliverLogsPermissionArn": {
           "Fn::GetAtt": [
             "VpcFlowLogIAMRole6A475D41",
@@ -667,7 +666,8 @@
             "Key": "Name",
             "Value": "all-existing-private-http/Vpc"
           }
-        ]
+        ],
+        "TrafficType": "ALL"
       }
     },
     "VpcECRAPI9A3B6A2B": {
@@ -913,7 +913,7 @@
         "ContainerDefinitions": [
           {
             "Essential": true,
-            "Image": "nginx",
+            "Image": "public.ecr.aws/m7z7i5e4/integration-test-image:latest",
             "MemoryReservation": 512,
             "Name": "test-container",
             "PortMappings": [

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
@@ -17,6 +17,7 @@ import { AlbToFargate, AlbToFargateProps } from "../lib";
 import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
+// import * as ecr from 'aws-cdk-lib/aws-ecr';
 import { CfnSecurityGroup } from "aws-cdk-lib/aws-ec2";
 
 // Setup
@@ -26,7 +27,10 @@ const stack = new Stack(app, defaults.generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for private HTTPS API with existing VPC, LoadBalancer and Service';
 
-const image = ecs.ContainerImage.fromRegistry('nginx');
+// const repo = ecr.Repository.fromRepositoryName(stack, 'integ', 'integration-test')
+
+// const image = new ecs.EcrImage(repo, 'latest');
+const image = ecs.ContainerImage.fromRegistry('public.ecr.aws/m7z7i5e4/integration-test-image:latest');
 
 const testExistingVpc = defaults.getTestVpc(stack);
 

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
@@ -27,9 +27,7 @@ const stack = new Stack(app, defaults.generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for private HTTPS API with existing VPC, LoadBalancer and Service';
 
-// const repo = ecr.Repository.fromRepositoryName(stack, 'integ', 'integration-test')
-
-// const image = new ecs.EcrImage(repo, 'latest');
+// This is a minimal web server in our account that passes health checks
 const image = ecs.ContainerImage.fromRegistry('public.ecr.aws/m7z7i5e4/integration-test-image:latest');
 
 const testExistingVpc = defaults.getTestVpc(stack);

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-existing-private-http.ts
@@ -17,7 +17,6 @@ import { AlbToFargate, AlbToFargateProps } from "../lib";
 import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as defaults from '@aws-solutions-constructs/core';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
-// import * as ecr from 'aws-cdk-lib/aws-ecr';
 import { CfnSecurityGroup } from "aws-cdk-lib/aws-ec2";
 
 // Setup

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.expected.json
@@ -682,7 +682,6 @@
           "Ref": "Vpc8378EB38"
         },
         "ResourceType": "VPC",
-        "TrafficType": "ALL",
         "DeliverLogsPermissionArn": {
           "Fn::GetAtt": [
             "VpcFlowLogIAMRole6A475D41",
@@ -698,7 +697,8 @@
             "Key": "Name",
             "Value": "all-new-public-http/Vpc"
           }
-        ]
+        ],
+        "TrafficType": "ALL"
       }
     },
     "VpcECRAPI9A3B6A2B": {
@@ -1186,7 +1186,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
           },
-          "S3Key": "e57c1acaa363d7d2b81736776007a7091bc73dff4aeb8135627c4511a51e7dca.zip"
+          "S3Key": "40aa87cdf43c4095cec18bc443965f22ab2f8c1ace47e482a0ba4e35d83b0cc9.zip"
         },
         "Timeout": 900,
         "MemorySize": 128,
@@ -1375,7 +1375,7 @@
         "ContainerDefinitions": [
           {
             "Essential": true,
-            "Image": "nginx",
+            "Image": "public.ecr.aws/m7z7i5e4/integration-test-image:latest",
             "MemoryReservation": 512,
             "Name": "test-construct-container",
             "PortMappings": [

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.ts
@@ -26,6 +26,7 @@ const stack = new Stack(app, generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for public HTTP API with new VPC, LoadBalancer and Service';
 
+// This is a minimal web server in our account that passes health checks
 const image = ecs.ContainerImage.fromRegistry('public.ecr.aws/m7z7i5e4/integration-test-image:latest');
 
 const testProps: AlbToFargateProps = {

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-public-http.ts
@@ -26,7 +26,7 @@ const stack = new Stack(app, generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for public HTTP API with new VPC, LoadBalancer and Service';
 
-const image = ecs.ContainerImage.fromRegistry('nginx');
+const image = ecs.ContainerImage.fromRegistry('public.ecr.aws/m7z7i5e4/integration-test-image:latest');
 
 const testProps: AlbToFargateProps = {
   publicApi: true,

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.expected.json
@@ -53,10 +53,10 @@
             }
           }
         ],
+        "Priority": 10,
         "ListenerArn": {
           "Ref": "testconstructtestconstructlistener484444F1"
-        },
-        "Priority": 10
+        }
       }
     },
     "Vpc8378EB38": {
@@ -709,7 +709,6 @@
           "Ref": "Vpc8378EB38"
         },
         "ResourceType": "VPC",
-        "TrafficType": "ALL",
         "DeliverLogsPermissionArn": {
           "Fn::GetAtt": [
             "VpcFlowLogIAMRole6A475D41",
@@ -725,7 +724,8 @@
             "Key": "Name",
             "Value": "all-new-two-targets/Vpc"
           }
-        ]
+        ],
+        "TrafficType": "ALL"
       }
     },
     "VpcECRAPI9A3B6A2B": {
@@ -1213,7 +1213,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
           },
-          "S3Key": "e57c1acaa363d7d2b81736776007a7091bc73dff4aeb8135627c4511a51e7dca.zip"
+          "S3Key": "40aa87cdf43c4095cec18bc443965f22ab2f8c1ace47e482a0ba4e35d83b0cc9.zip"
         },
         "Timeout": 900,
         "MemorySize": 128,
@@ -1402,7 +1402,7 @@
         "ContainerDefinitions": [
           {
             "Essential": true,
-            "Image": "nginx",
+            "Image": "public.ecr.aws/m7z7i5e4/integration-test-image:latest",
             "MemoryReservation": 512,
             "Name": "test-construct-container",
             "PortMappings": [

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.ts
@@ -26,6 +26,7 @@ const stack = new Stack(app, defaults.generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for public HTTP API with new VPC, LoadBalancer and Service and 2 targets';
 
+// This is a minimal web server in our account that passes health checks
 const image = ecs.ContainerImage.fromRegistry('public.ecr.aws/m7z7i5e4/integration-test-image:latest');
 
 const testProps: AlbToFargateProps = {

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/integ.all-new-two-targets.ts
@@ -26,7 +26,7 @@ const stack = new Stack(app, defaults.generateIntegStackName(__filename), {
 });
 stack.templateOptions.description = 'Integration Test for public HTTP API with new VPC, LoadBalancer and Service and 2 targets';
 
-const image = ecs.ContainerImage.fromRegistry('nginx');
+const image = ecs.ContainerImage.fromRegistry('public.ecr.aws/m7z7i5e4/integration-test-image:latest');
 
 const testProps: AlbToFargateProps = {
   publicApi: true,


### PR DESCRIPTION
*Issue #, if available:*
#961 

*Description of changes:*
These integration tests now use a minimal container available publicly in our account so they pass a health check and the integ stack launches when being refreshed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.