### PR TITLE
fix(s3-bucket-helper): do not remove lifecycle rules from log buckets

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/README.md
@@ -87,6 +87,7 @@ new EventbridgeToKinesisFirehoseToS3(this, "test-eventbridge-firehose-s3",
 |loggingBucketProps?|[`s3.BucketProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.BucketProps.html)|Optional user provided props to override the default props for the S3 Logging Bucket.|
 |logS3AccessLogs?| boolean|Whether to turn on Access Logging for the S3 bucket. Creates an S3 bucket with associated storage costs for the logs. Enabling Access Logging is a best practice. default - true|
 
+NOTE: `existingLoggingBucketObj` has been deprecated - to specify an existing Log Bucket, use  bucketProps.serverAccessLogsBucket
 ## Pattern Properties
 
 | **Name**     | **Type**        | **Description** |

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/test/integ.existingLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/test/integ.existingLoggingBucket.expected.json
@@ -1,0 +1,714 @@
+{
+  "Resources": {
+    "scrapBucketB11863B7": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W51",
+              "reason": "This S3 bucket is created for unit/ integration testing purposes only and not part of       the actual construct implementation"
+            },
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is created for unit/ integration testing purposes only and not part of       the actual construct implementation"
+            },
+            {
+              "id": "W41",
+              "reason": "This S3 bucket is created for unit/ integration testing purposes only and not part of       the actual construct"
+            }
+          ]
+        }
+      }
+    },
+    "scrapBucketPolicy189B0607": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "scrapBucketB11863B7"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "scrapBucketB11863B7",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "scrapBucketB11863B7",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "scrapBucketB11863B7",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "scrapBucketAutoDeleteObjectsCustomResourceFFFC3275": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "scrapBucketB11863B7"
+        }
+      },
+      "DependsOn": [
+        "scrapBucketPolicy189B0607"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          }
+        ]
+      }
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+          },
+          "S3Key": "350185a1069fa20a23a583e20c77f6844218bd73097902362dc94f1a108f5d89.zip"
+        },
+        "Timeout": 900,
+        "MemorySize": 128,
+        "Handler": "__entrypoint__.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs16.x",
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "Lambda function for auto-deleting objects in ",
+              {
+                "Ref": "scrapBucketB11863B7"
+              },
+              " S3 bucket."
+            ]
+          ]
+        }
+      },
+      "DependsOn": [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
+      ],
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W58",
+              "reason": "CDK generated custom resource"
+            },
+            {
+              "id": "W89",
+              "reason": "CDK generated custom resource"
+            },
+            {
+              "id": "W92",
+              "reason": "CDK generated custom resource"
+            }
+          ]
+        }
+      }
+    },
+    "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "NoncurrentVersionTransitions": [
+                {
+                  "StorageClass": "GLACIER",
+                  "TransitionInDays": 90
+                }
+              ],
+              "Status": "Enabled"
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "scrapBucketB11863B7"
+          }
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testkinesisfirehoses3KinesisFirehoseToS3S3BucketPolicy46BDB29D": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "testkinesisfirehoses3KinesisFirehoseToS3firehoseloggroupDDB24FE5": {
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W86",
+              "reason": "Retention period for CloudWatchLogs LogGroups are set to 'Never Expire' to preserve customer data indefinitely"
+            },
+            {
+              "id": "W84",
+              "reason": "By default CloudWatchLogs LogGroups data is encrypted using the CloudWatch server-side encryption keys (AWS Managed Keys)"
+            }
+          ]
+        }
+      }
+    },
+    "testkinesisfirehoses3KinesisFirehoseToS3firehoseloggroupfirehoselogstreamEC0EA660": {
+      "Type": "AWS::Logs::LogStream",
+      "Properties": {
+        "LogGroupName": {
+          "Ref": "testkinesisfirehoses3KinesisFirehoseToS3firehoseloggroupDDB24FE5"
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehoseRole18870C08": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "firehose.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehosePolicyD6A1BC51": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:PutObject"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "logs:PutLogEvents",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":logs:",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":log-group:",
+                    {
+                      "Ref": "testkinesisfirehoses3KinesisFirehoseToS3firehoseloggroupDDB24FE5"
+                    },
+                    ":log-stream:",
+                    {
+                      "Ref": "testkinesisfirehoses3KinesisFirehoseToS3firehoseloggroupfirehoselogstreamEC0EA660"
+                    }
+                  ]
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehosePolicyD6A1BC51",
+        "Roles": [
+          {
+            "Ref": "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehoseRole18870C08"
+          }
+        ]
+      }
+    },
+    "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehoseEB65C83D": {
+      "Type": "AWS::KinesisFirehose::DeliveryStream",
+      "Properties": {
+        "DeliveryStreamEncryptionConfigurationInput": {
+          "KeyType": "AWS_OWNED_CMK"
+        },
+        "DeliveryStreamName": "KinesisFirehoseexistingLoggingBuoses3KinesisFirehoseToS3375399AD",
+        "ExtendedS3DestinationConfiguration": {
+          "BucketARN": {
+            "Fn::GetAtt": [
+              "testkinesisfirehoses3KinesisFirehoseToS3S3Bucket303877FF",
+              "Arn"
+            ]
+          },
+          "BufferingHints": {
+            "IntervalInSeconds": 300,
+            "SizeInMBs": 5
+          },
+          "CloudWatchLoggingOptions": {
+            "Enabled": true,
+            "LogGroupName": {
+              "Ref": "testkinesisfirehoses3KinesisFirehoseToS3firehoseloggroupDDB24FE5"
+            },
+            "LogStreamName": {
+              "Ref": "testkinesisfirehoses3KinesisFirehoseToS3firehoseloggroupfirehoselogstreamEC0EA660"
+            }
+          },
+          "CompressionFormat": "GZIP",
+          "EncryptionConfiguration": {
+            "KMSEncryptionConfig": {
+              "AWSKMSKeyARN": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":kms:",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":alias/aws/s3"
+                  ]
+                ]
+              }
+            }
+          },
+          "RoleARN": {
+            "Fn::GetAtt": [
+              "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehoseRole18870C08",
+              "Arn"
+            ]
+          }
+        }
+      }
+    },
+    "testkinesisfirehoses3EventsRuleInvokeKinesisFirehoseRole0D8588E2": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Description": "Events Rule To Kinesis Firehose Role"
+      }
+    },
+    "testkinesisfirehoses3EventsRuleInvokeKinesisFirehosePolicy88CA86C4": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "firehose:PutRecord",
+                "firehose:PutRecordBatch"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehoseEB65C83D",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "testkinesisfirehoses3EventsRuleInvokeKinesisFirehosePolicy88CA86C4",
+        "Roles": [
+          {
+            "Ref": "testkinesisfirehoses3EventsRuleInvokeKinesisFirehoseRole0D8588E2"
+          }
+        ]
+      }
+    },
+    "testkinesisfirehoses3EventsRule05D717D1": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "ScheduleExpression": "rate(5 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "testkinesisfirehoses3KinesisFirehoseToS3KinesisFirehoseEB65C83D",
+                "Arn"
+              ]
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "testkinesisfirehoses3EventsRuleInvokeKinesisFirehoseRole0D8588E2",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Mappings": {
+    "DefaultCrNodeVersionMap": {
+      "af-south-1": {
+        "value": "nodejs16.x"
+      },
+      "ap-east-1": {
+        "value": "nodejs16.x"
+      },
+      "ap-northeast-1": {
+        "value": "nodejs16.x"
+      },
+      "ap-northeast-2": {
+        "value": "nodejs16.x"
+      },
+      "ap-northeast-3": {
+        "value": "nodejs16.x"
+      },
+      "ap-south-1": {
+        "value": "nodejs16.x"
+      },
+      "ap-south-2": {
+        "value": "nodejs16.x"
+      },
+      "ap-southeast-1": {
+        "value": "nodejs16.x"
+      },
+      "ap-southeast-2": {
+        "value": "nodejs16.x"
+      },
+      "ap-southeast-3": {
+        "value": "nodejs16.x"
+      },
+      "ca-central-1": {
+        "value": "nodejs16.x"
+      },
+      "cn-north-1": {
+        "value": "nodejs16.x"
+      },
+      "cn-northwest-1": {
+        "value": "nodejs16.x"
+      },
+      "eu-central-1": {
+        "value": "nodejs16.x"
+      },
+      "eu-central-2": {
+        "value": "nodejs16.x"
+      },
+      "eu-north-1": {
+        "value": "nodejs16.x"
+      },
+      "eu-south-1": {
+        "value": "nodejs16.x"
+      },
+      "eu-south-2": {
+        "value": "nodejs16.x"
+      },
+      "eu-west-1": {
+        "value": "nodejs16.x"
+      },
+      "eu-west-2": {
+        "value": "nodejs16.x"
+      },
+      "eu-west-3": {
+        "value": "nodejs16.x"
+      },
+      "me-central-1": {
+        "value": "nodejs16.x"
+      },
+      "me-south-1": {
+        "value": "nodejs16.x"
+      },
+      "sa-east-1": {
+        "value": "nodejs16.x"
+      },
+      "us-east-1": {
+        "value": "nodejs16.x"
+      },
+      "us-east-2": {
+        "value": "nodejs16.x"
+      },
+      "us-gov-east-1": {
+        "value": "nodejs16.x"
+      },
+      "us-gov-west-1": {
+        "value": "nodejs16.x"
+      },
+      "us-iso-east-1": {
+        "value": "nodejs14.x"
+      },
+      "us-iso-west-1": {
+        "value": "nodejs14.x"
+      },
+      "us-isob-east-1": {
+        "value": "nodejs14.x"
+      },
+      "us-west-1": {
+        "value": "nodejs16.x"
+      },
+      "us-west-2": {
+        "value": "nodejs16.x"
+      }
+    }
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+    }
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                  ],
+                  {
+                    "Ref": "BootstrapVersion"
+                  }
+                ]
+              }
+            ]
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+        }
+      ]
+    }
+  }
+}

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/test/integ.existingLoggingBucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/test/integ.existingLoggingBucket.ts
@@ -1,0 +1,43 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+/// !cdk-integ *
+import { App, Stack, RemovalPolicy, Duration } from "aws-cdk-lib";
+import { EventbridgeToKinesisFirehoseToS3 } from "../lib";
+import { generateIntegStackName } from '@aws-solutions-constructs/core';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as defaults from '@aws-solutions-constructs/core';
+
+const app = new App();
+
+// Empty arguments
+const stack = new Stack(app, generateIntegStackName(__filename));
+stack.node.setContext("@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy", true);
+
+const logBucket = defaults.CreateScrapBucket(stack);
+
+new EventbridgeToKinesisFirehoseToS3(stack, 'test-kinesisfirehose-s3', {
+  eventRuleProps: {
+    schedule: events.Schedule.rate(Duration.minutes(5))
+  },
+  bucketProps: {
+    removalPolicy: RemovalPolicy.DESTROY,
+    serverAccessLogsBucket: logBucket,
+  },
+  logGroupProps: {
+    removalPolicy: RemovalPolicy.DESTROY
+  }
+});
+
+defaults.suppressAutoDeleteHandlerWarnings(stack);
+app.synth();

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
@@ -66,9 +66,6 @@ export function createLoggingBucket(scope: Construct,
   // Extract the CfnBucket from the loggingBucket
   const loggingBucketResource = loggingBucket.node.findChild('Resource') as s3.CfnBucket;
 
-  // Remove the default LifecycleConfiguration for the Logging Bucket
-  loggingBucketResource.addPropertyDeletionOverride('LifecycleConfiguration.Rules');
-
   let _reason = "This S3 bucket is used as the access logging bucket for another bucket";
 
   if (bucketId === 'CloudfrontLoggingBucket') {

--- a/source/patterns/@aws-solutions-constructs/core/test/s3-bucket-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/s3-bucket-helper.test.ts
@@ -460,3 +460,23 @@ test('s3 bucket with logging turned off', () => {
     }
   });
 });
+
+test('Confirm Log Bucket lifecycle rules persist',  () => {
+  const stack = new Stack();
+
+  defaults.buildS3Bucket(stack, {
+    loggingBucketProps: {
+      lifecycleRules: [
+        {
+          expiration: Duration.days(365),
+        }],
+    }
+  });
+
+  const template = Template.fromStack(stack);
+  template.hasResource("AWS::S3::Bucket", {
+    Properties: {
+      LifecycleConfiguration: {}
+    }
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*
#965 


*Description of changes:*
Delete line that removed lifecycle rules
Test that and that an existingLogBucket can be sent to aws-eventbridge-kinesisfirehose-s3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.