### PR TITLE
fix(aws-kinesisfirehose-s3): Fix type of `kinesisFirehoseProps` prop.

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/lib/index.ts
@@ -49,7 +49,17 @@ export interface KinesisFirehoseToS3Props {
    *
    * @default - Default props are used
    */
-  readonly kinesisFirehoseProps?: kinesisfirehose.CfnDeliveryStreamProps | any;
+  readonly kinesisFirehoseProps?: Omit<
+    kinesisfirehose.CfnDeliveryStreamProps,
+    "extendedS3DestinationConfiguration"
+  > & {
+    extendedS3DestinationConfiguration:
+    | Omit<
+      kinesisfirehose.CfnDeliveryStream.ExtendedS3DestinationConfigurationProperty,
+      "bucketArn" | "roleArn"
+    >
+    | cdk.IResolvable;
+  };
   /**
    * Optional user provided props to override the default props for the CloudWatchLogs LogGroup.
    *


### PR DESCRIPTION
In [V1.64.0](https://github.com/awslabs/aws-solutions-constructs/commit/b7b24d4a56ab7695880e4542c0e1461333b4ab9c#diff-d001ee629f77cd31f70092c6a11b57d71a139db26f057f3fba662b605ebc4196) the type of the `kinesisFirehoseProps` prop was adjusted from `kinesisfirehose.CfnDeliveryStreamProps` to `kinesisfirehose.CfnDeliveryStreamProps | any`. I assume this was to prevent a type error around `bucketArn` and `roleArn` being required in `kinesisfirehose.CfnDeliveryStreamProps`, but not within the prop (since the construct handles setting these).

This was a lazy solution that meant developers haven't been able to benefit from the autocompletion of the type. The type has been corrected in this PR so that people can get autocomplete on the properties again.

The type admittedly isn't the prettiest, but does work and is the best way I could find to achieve the correct type.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._