### PR TITLE
chore(sonarqube): address more code smells

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -69,6 +69,7 @@ sonar.javascript.lcov.reportPaths= \
     source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-lambda-kendra/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/coverage/lcov.info, \
@@ -80,6 +81,7 @@ sonar.javascript.lcov.reportPaths= \
     source/patterns/@aws-solutions-constructs/aws-lambda-sqs/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/coverage/lcov.info, \
+    source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-route53-alb/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-route53-apigateway/coverage/lcov.info, \
     source/patterns/@aws-solutions-constructs/aws-s3-lambda/coverage/lcov.info, \

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
@@ -198,18 +198,15 @@ export class ApiGatewayToSqs extends Construct {
     super(scope, id);
     defaults.CheckProps(props);
 
-    if ((props.createRequestTemplate || props.additionalCreateRequestTemplates || props.createIntegrationResponses)
-        && props.allowCreateOperation !== true) {
+    if (this.CheckCreateRequestProps(props)) {
       throw new Error(`The 'allowCreateOperation' property must be set to true when setting any of the following: ` +
         `'createRequestTemplate', 'additionalCreateRequestTemplates', 'createIntegrationResponses'`);
     }
-    if ((props.readRequestTemplate || props.additionalReadRequestTemplates || props.readIntegrationResponses)
-        && props.allowReadOperation === false) {
+    if (this.CheckReadRequestProps(props)) {
       throw new Error(`The 'allowReadOperation' property must be set to true or undefined when setting any of the following: ` +
         `'readRequestTemplate', 'additionalReadRequestTemplates', 'readIntegrationResponses'`);
     }
-    if ((props.deleteRequestTemplate || props.additionalDeleteRequestTemplates || props.deleteIntegrationResponses)
-        && props.allowDeleteOperation !== true) {
+    if (this.CheckDeleteRequestProps(props)) {
       throw new Error(`The 'allowDeleteOperation' property must be set to true when setting any of the following: ` +
       `'deleteRequestTemplate', 'additionalDeleteRequestTemplates', 'deleteIntegrationResponses'`);
     }
@@ -297,6 +294,28 @@ export class ApiGatewayToSqs extends Construct {
         integrationResponses: props.deleteIntegrationResponses
       });
     }
+  }
+  private CheckReadRequestProps(props: ApiGatewayToSqsProps): boolean {
+    if ((props.readRequestTemplate || props.additionalReadRequestTemplates || props.readIntegrationResponses)
+        && props.allowReadOperation === false) {
+      return true;
+    }
+    return false;
+  }
+  private CheckDeleteRequestProps(props: ApiGatewayToSqsProps): boolean {
+    if ((props.deleteRequestTemplate || props.additionalDeleteRequestTemplates || props.deleteIntegrationResponses)
+        && props.allowDeleteOperation !== true)  {
+      return true;
+    }
+    return false;
+  }
+
+  private CheckCreateRequestProps(props: ApiGatewayToSqsProps): boolean {
+    if ((props.createRequestTemplate || props.additionalCreateRequestTemplates || props.createIntegrationResponses)
+        && props.allowCreateOperation !== true) {
+      return true;
+    }
+    return false;
   }
 
   private addActionToPolicy(action: string) {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/lib/index.ts
@@ -239,10 +239,14 @@ export class FargateToS3 extends Construct {
     }
 
     // Add environment variables
-    const bucketArnEnvironmentVariableName = props.bucketArnEnvironmentVariableName || 'S3_BUCKET_ARN';
+    const bucketArnEnvironmentVariableName = this.SetStringWithDefault(props.bucketArnEnvironmentVariableName, 'S3_BUCKET_ARN');
     this.container.addEnvironment(bucketArnEnvironmentVariableName, this.s3BucketInterface.bucketArn);
-    const bucketEnvironmentVariableName = props.bucketEnvironmentVariableName || 'S3_BUCKET_NAME';
+    const bucketEnvironmentVariableName = this.SetStringWithDefault(props.bucketEnvironmentVariableName, 'S3_BUCKET_NAME');
     this.container.addEnvironment(bucketEnvironmentVariableName, this.s3BucketInterface.bucketName);
 
+  }
+
+  private SetStringWithDefault(value: string | undefined, defaultValue: string) {
+    return value || defaultValue;
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/lib/index.ts
@@ -174,28 +174,7 @@ export class KinesisstreamsToGluejob extends Construct {
     this.node.setContext("@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy", true);
 
     defaults.CheckProps(props);
-
-    // custom props check
-    if (props.existingGlueJob && props.glueJobProps) {
-      throw Error("Either existingGlueJob instance or glueJobProps should be set, but found both");
-    }
-
-    if (!props.existingGlueJob) {
-      if (!props.glueJobProps.command.scriptLocation && !props.etlCodeAsset) {
-        throw Error('Either one of CfnJob.JobCommandProperty.scriptLocation or KinesisstreamsToGluejobProps.etlCodeAsset has ' +
-        'to be provided. If the ETL Job code file exists in a local filesystem, please set ' +
-        'KinesisstreamsToGluejobProps.etlCodeAsset. If the ETL Job is available in an S3 bucket, set the ' +
-        'CfnJob.JobCommandProperty.scriptLocation property');
-      }
-
-      if (!props.etlCodeAsset) {
-        const s3Url: string = props.glueJobProps.command.scriptLocation;
-        const found = s3Url.match(/^s3:\/\/\S+\/\S+/g);
-        if (!(found && found.length > 0 && found[0].length === s3Url.length)) {
-          throw Error("Invalid S3 URL provided");
-        }
-      }
-    }
+    defaults.CheckGlueProps(props);
 
     this.kinesisStream = defaults.buildKinesisStream(this, {
       existingStreamObj: props.existingStreamObj,
@@ -203,10 +182,6 @@ export class KinesisstreamsToGluejob extends Construct {
     });
 
     this.database = props.existingDatabase !== undefined ? props.existingDatabase : defaults.createGlueDatabase(scope, props.databaseProps);
-
-    if (props.fieldSchema === undefined && props.existingTable === undefined && props.tableProps === undefined) {
-      throw Error("Either fieldSchema or table property has to be set, both cannot be optional");
-    }
 
     if (props.existingTable !== undefined) {
       this.table = props.existingTable;

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/test/lambda-kendra.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/test/lambda-kendra.test.ts
@@ -20,7 +20,7 @@ import * as cdk from "aws-cdk-lib";
 import { Template } from 'aws-cdk-lib/assertions';
 import * as defaults from '@aws-solutions-constructs/core';
 
-test.only('Launch with minimal code and check  structure', () => {
+test('Launch with minimal code and check  structure', () => {
   const stack = new cdk.Stack();
   const testFunctionName = 'test-function-name24334';
   const testBucketName = 'test-bucket-name12344';

--- a/source/patterns/@aws-solutions-constructs/core/test/glue-job-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/glue-job-helper.test.ts
@@ -19,9 +19,6 @@ import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { RemovalPolicy, Stack } from "aws-cdk-lib";
 import * as defaults from '..';
 
-// --------------------------------------------------------------
-// Test deployment with role creation
-// --------------------------------------------------------------
 test('Test deployment with role creation', () => {
   // Stack
   const stack = new Stack();
@@ -75,9 +72,6 @@ test('Test deployment with role creation', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Pass an existing Glue Job
-// --------------------------------------------------------------
 test('Create a Glue Job outside the construct', () => {
   // Stack
   const stack = new Stack();
@@ -138,9 +132,6 @@ test('Create a Glue Job outside the construct', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Provide additional parameters other than default ones
-// --------------------------------------------------------------
 test('Test custom deployment properties', () => {
   // Stack
   const stack = new Stack();
@@ -252,9 +243,6 @@ test('Test custom deployment properties', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Do not supply parameters and error out
-// --------------------------------------------------------------
 test('Do no supply glueJobProps or existingCfnJob and error out', () => {
   const stack = new Stack();
   try {
@@ -275,10 +263,7 @@ test('Do no supply glueJobProps or existingCfnJob and error out', () => {
   }
 });
 
-// --------------------------------------------------------------
-// Allow the construct to create the job role required
-// --------------------------------------------------------------
-test('Test deployment with role creation', () => {
+test('llow the construct to create the job role required', () => {
   // Stack
   const stack = new Stack();
   const jobID = 'glueetl';
@@ -323,10 +308,7 @@ test('Test deployment with role creation', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Test deployment when output location is provided
-// --------------------------------------------------------------
-test('Test deployment with role creation', () => {
+test('Test deployment when output location is provided', () => {
   // Stack
   const stack = new Stack();
   const jobID = 'glueetl';
@@ -376,49 +358,6 @@ test('Test deployment with role creation', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Test deployment when script location not provided - throw error
-// --------------------------------------------------------------
-test('Test deployment with role creation', () => {
-  // Stack
-  const stack = new Stack();
-  const jobID = 'glueetl';
-
-  const cfnJobProps = {
-    command: {
-      name: jobID,
-      pythonVersion: '3'
-    }
-  };
-
-  const database = defaults.createGlueDatabase(stack);
-  try {
-    defaults.buildGlueJob(stack, {
-      glueJobProps: cfnJobProps,
-      outputDataStore: {
-        datastoreType: defaults.SinkStoreType.S3,
-        existingS3OutputBucket: new Bucket(stack, 'OutputBucket', {
-          versioned: false
-        })
-      },
-      database,
-      table: defaults.createGlueTable(stack, database, undefined, [{
-        name: "id",
-        type: "int",
-        comment: ""
-      }], 'kinesis', {STREAM_NAME: 'testStream'})
-    });
-  } catch (error) {
-    expect(error).toBeInstanceOf(Error);
-    expect(error.message).toEqual('Either one of CfnJob.JobCommandProperty.scriptLocation or KinesisstreamsToGluejobProps.etlCodeAsset ' +
-    'has to be provided. If the ETL Job code file exists in a local filesystem, please set KinesisstreamsToGluejobProps.etlCodeAsset. ' +
-    'If the ETL Job is available in an S3 bucket, set the CfnJob.JobCommandProperty.scriptLocation property');
-  }
-});
-
-// --------------------------------------------------------------
-// Dont pass Job Command attributes and it should throw an error
-// --------------------------------------------------------------
 test('Test for incorrect Job Command property', () => {
   const stack = new Stack();
   try {
@@ -489,9 +428,6 @@ test('GlueJob configuration with glueVersion 2.0 should not support maxCapacity 
   }
 });
 
-// --------------------------------------------------------------
-// Fail if setting maxCapacity and WorkerType/ NumberOfWorkers
-// --------------------------------------------------------------
 test('Cannot use maxCapacity and WorkerType, so error out', () => {
   const stack = new Stack();
   try {


### PR DESCRIPTION
Start the process of isolating the tests of props for each service utilized in a construct (break up input-validation.sh)