### PR TITLE
chore(all): replace incorrect property checks in unit tests

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/test/apigateway-dynamodb.test.ts
@@ -23,11 +23,11 @@ test("check properties", () => {
   const apiGatewayToDynamoDBProps: ApiGatewayToDynamoDBProps = {};
   const construct = new ApiGatewayToDynamoDB( stack, "test-api-gateway-dynamodb-default", apiGatewayToDynamoDBProps);
 
-  expect(construct.dynamoTable !== null);
-  expect(construct.apiGateway !== null);
-  expect(construct.apiGatewayRole !== null);
-  expect(construct.apiGatewayCloudWatchRole !== null);
-  expect(construct.apiGatewayLogGroup !== null);
+  expect(construct.dynamoTable).toBeDefined();
+  expect(construct.apiGateway).toBeDefined();
+  expect(construct.apiGatewayRole).toBeDefined();
+  expect(construct.apiGatewayCloudWatchRole).toBeDefined();
+  expect(construct.apiGatewayLogGroup).toBeDefined();
 });
 
 test("check allow CRUD operations", () => {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/apigateway-kinesisstreams.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/test/apigateway-kinesisstreams.test.ts
@@ -21,12 +21,12 @@ test('Test construct properties', () => {
   const stack = new Stack();
   const pattern = new ApiGatewayToKinesisStreams(stack, 'api-gateway-kinesis', {});
 
-  expect(pattern.apiGateway !== null);
-  expect(pattern.apiGatewayRole !== null);
-  expect(pattern.apiGatewayCloudWatchRole !== null);
-  expect(pattern.apiGatewayLogGroup !== null);
-  expect(pattern.kinesisStream !== null);
-  expect(pattern.cloudwatchAlarms !== null);
+  expect(pattern.apiGateway).toBeDefined();
+  expect(pattern.apiGatewayRole).toBeDefined();
+  expect(pattern.apiGatewayCloudWatchRole).toBeDefined();
+  expect(pattern.apiGatewayLogGroup).toBeDefined();
+  expect(pattern.kinesisStream).toBeDefined();
+  expect(pattern.cloudwatchAlarms).toBeDefined();
 });
 
 test('Test deployment w/ overwritten properties', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/test.apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/test/test.apigateway-lambda.test.ts
@@ -72,11 +72,11 @@ test('Test properties', () => {
   };
   const app = new ApiGatewayToLambda(stack, 'test-apigateway-lambda', props);
   // Assertion 1
-  expect(app.lambdaFunction !== null);
+  expect(app.lambdaFunction).toBeDefined();
   // Assertion 2
-  expect(app.apiGateway !== null);
-  expect(app.apiGatewayCloudWatchRole !== null);
-  expect(app.apiGatewayLogGroup !== null);
+  expect(app.apiGateway).toBeDefined();
+  expect(app.apiGatewayCloudWatchRole).toBeDefined();
+  expect(app.apiGatewayLogGroup).toBeDefined();
 });
 
 test('Error on lambdaFunctionProps=undefined', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/apigateway-sagemakerendpoint.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/test/apigateway-sagemakerendpoint.test.ts
@@ -25,10 +25,10 @@ test('Test construct properties', () => {
     requestMappingTemplate: 'my-request-vtl-template'
   });
 
-  expect(pattern.apiGateway !== null);
-  expect(pattern.apiGatewayRole !== null);
-  expect(pattern.apiGatewayCloudWatchRole !== null);
-  expect(pattern.apiGatewayLogGroup !== null);
+  expect(pattern.apiGateway).toBeDefined();
+  expect(pattern.apiGatewayRole).toBeDefined();
+  expect(pattern.apiGatewayCloudWatchRole).toBeDefined();
+  expect(pattern.apiGatewayLogGroup).toBeDefined();
 });
 
 test('Test deployment w/ overwritten properties', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/apigateway-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/apigateway-sqs.test.ts
@@ -70,14 +70,14 @@ test('Test properties', () => {
     maxReceiveCount: 3
   });
     // Assertion 1
-  expect(pattern.apiGateway !== null);
+  expect(pattern.apiGateway).toBeDefined();
   // Assertion 2
-  expect(pattern.sqsQueue !== null);
+  expect(pattern.sqsQueue).toBeDefined();
   // Assertion 3
-  expect(pattern.apiGatewayRole !== null);
-  expect(pattern.apiGatewayCloudWatchRole !== null);
-  expect(pattern.apiGatewayLogGroup !== null);
-  expect(pattern.deadLetterQueue !== null);
+  expect(pattern.apiGatewayRole).toBeDefined();
+  expect(pattern.apiGatewayCloudWatchRole).toBeDefined();
+  expect(pattern.apiGatewayLogGroup).toBeDefined();
+  expect(pattern.deadLetterQueue).toBeDefined();
 });
 
 test('Test deployment ApiGateway AuthorizationType override', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/test.cloudfront-apigateway-lambda.test.ts
@@ -47,13 +47,13 @@ test('check properties', () => {
 
   const construct: CloudFrontToApiGatewayToLambda = deployNewFunc(stack);
 
-  expect(construct.cloudFrontWebDistribution !== null);
-  expect(construct.apiGateway !== null);
-  expect(construct.lambdaFunction !== null);
-  expect(construct.cloudFrontFunction !== null);
-  expect(construct.cloudFrontLoggingBucket !== null);
-  expect(construct.apiGatewayCloudWatchRole !== null);
-  expect(construct.apiGatewayLogGroup !== null);
+  expect(construct.cloudFrontWebDistribution).toBeDefined();
+  expect(construct.apiGateway).toBeDefined();
+  expect(construct.lambdaFunction).toBeDefined();
+  expect(construct.cloudFrontFunction).toBeDefined();
+  expect(construct.cloudFrontLoggingBucket).toBeDefined();
+  expect(construct.apiGatewayCloudWatchRole).toBeDefined();
+  expect(construct.apiGatewayLogGroup).toBeDefined();
 });
 
 test('check lambda function properties for deploy: true', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/test.cloudfront-apigateway.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/test.cloudfront-apigateway.test.ts
@@ -40,10 +40,10 @@ test('check getter methods', () => {
 
   const construct: CloudFrontToApiGateway = deploy(stack);
 
-  expect(construct.cloudFrontWebDistribution !== null);
-  expect(construct.apiGateway !== null);
-  expect(construct.cloudFrontFunction !== null);
-  expect(construct.cloudFrontLoggingBucket !== null);
+  expect(construct.cloudFrontWebDistribution).toBeDefined();
+  expect(construct.apiGateway).toBeDefined();
+  expect(construct.cloudFrontFunction).toBeDefined();
+  expect(construct.cloudFrontLoggingBucket).toBeDefined();
 });
 
 test('test cloudfront DomainName', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -143,8 +143,8 @@ test('check properties', () => {
 
   const construct: CloudFrontToS3 = deploy(stack);
 
-  expect(construct.cloudFrontWebDistribution !== null);
-  expect(construct.s3Bucket !== null);
+  expect(construct.cloudFrontWebDistribution).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
 });
 
 test("Confirm CheckS3Props is called", () => {
@@ -173,7 +173,7 @@ test("Test existingBucketObj", () => {
     existingBucketObj: s3.Bucket.fromBucketName(stack, 'mybucket', 'mybucket')
   });
   // Assertion
-  expect(construct.cloudFrontWebDistribution !== null);
+  expect(construct.cloudFrontWebDistribution).toBeDefined();
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::CloudFront::Distribution", {
     DistributionConfig: {

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/test.cognito-apigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/test.cognito-apigateway-lambda.test.ts
@@ -89,13 +89,13 @@ test('check properties', () => {
 
   const construct: CognitoToApiGatewayToLambda = deployNewFunc(stack);
 
-  expect(construct.userPool !== null);
-  expect(construct.userPoolClient !== null);
-  expect(construct.apiGateway !== null);
-  expect(construct.lambdaFunction !== null);
-  expect(construct.apiGatewayCloudWatchRole !== null);
-  expect(construct.apiGatewayLogGroup !== null);
-  expect(construct.apiGatewayAuthorizer !== null);
+  expect(construct.userPool).toBeDefined();
+  expect(construct.userPoolClient).toBeDefined();
+  expect(construct.apiGateway).toBeDefined();
+  expect(construct.lambdaFunction).toBeDefined();
+  expect(construct.apiGatewayCloudWatchRole).toBeDefined();
+  expect(construct.apiGatewayLogGroup).toBeDefined();
+  expect(construct.apiGatewayAuthorizer).toBeDefined();
 });
 
 test('override cognito cognitoUserPoolClientProps', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/dynamodbstreams-lambda-elasticsearch-kibana.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/dynamodbstreams-lambda-elasticsearch-kibana.test.ts
@@ -58,14 +58,14 @@ test('check properties', () => {
 
   const construct: DynamoDBStreamsToLambdaToElasticSearchAndKibana = deployNewFunc(stack);
 
-  expect(construct.lambdaFunction !== null);
-  expect(construct.dynamoTable !== null);
-  expect(construct.elasticsearchDomain !== null);
-  expect(construct.elasticsearchRole !== null);
-  expect(construct.identityPool !== null);
-  expect(construct.userPool !== null);
-  expect(construct.userPoolClient !== null);
-  expect(construct.cloudwatchAlarms !== null);
+  expect(construct.lambdaFunction).toBeDefined();
+  expect(construct.dynamoTable).toBeDefined();
+  expect(construct.elasticsearchDomain).toBeDefined();
+  expect(construct.elasticsearchRole).toBeDefined();
+  expect(construct.identityPool).toBeDefined();
+  expect(construct.userPool).toBeDefined();
+  expect(construct.userPoolClient).toBeDefined();
+  expect(construct.cloudwatchAlarms).toBeDefined();
 });
 
 test('check exception for Missing existingObj from props for deploy = false', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/test/eventbridge-kinesisfirehose-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/test/eventbridge-kinesisfirehose-s3.test.ts
@@ -33,13 +33,13 @@ test('Test properties', () => {
   const construct: EventbridgeToKinesisFirehoseToS3 = deployNewStack(stack);
 
   // Assertions
-  expect(construct.eventsRule !== null);
-  expect(construct.eventsRole !== null);
-  expect(construct.kinesisFirehose !== null);
-  expect(construct.kinesisFirehoseRole !== null);
-  expect(construct.kinesisFirehoseLogGroup !== null);
-  expect(construct.s3Bucket !== null);
-  expect(construct.s3LoggingBucket !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.eventsRole).toBeDefined();
+  expect(construct.kinesisFirehose).toBeDefined();
+  expect(construct.kinesisFirehoseRole).toBeDefined();
+  expect(construct.kinesisFirehoseLogGroup).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
+  expect(construct.s3LoggingBucket).toBeDefined();
 });
 
 test('Test default server side s3 bucket encryption', () => {
@@ -144,14 +144,14 @@ test('check eventbus property, snapshot & eventbus exists', () => {
   };
   const construct = new EventbridgeToKinesisFirehoseToS3(stack, 'test-eventbridge-kinesis-firehose-default-parameters', props);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.eventsRole !== null);
-  expect(construct.kinesisFirehose !== null);
-  expect(construct.kinesisFirehoseRole !== null);
-  expect(construct.kinesisFirehoseLogGroup !== null);
-  expect(construct.s3Bucket !== null);
-  expect(construct.s3LoggingBucket !== null);
-  expect(construct.eventBus !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.eventsRole).toBeDefined();
+  expect(construct.kinesisFirehose).toBeDefined();
+  expect(construct.kinesisFirehoseRole).toBeDefined();
+  expect(construct.kinesisFirehoseLogGroup).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
+  expect(construct.s3LoggingBucket).toBeDefined();
+  expect(construct.eventBus).toBeDefined();
   // Check whether eventbus exists
   const template = Template.fromStack(stack);
   template.resourceCountIs('AWS::Events::EventBus', 1);

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/test/eventbridge-kinesisstreams.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/test/eventbridge-kinesisstreams.test.ts
@@ -32,9 +32,9 @@ test('Test properties', () => {
   const construct: EventbridgeToKinesisStreams = deployNewStack(stack);
 
   // Assertions
-  expect(construct.eventsRule !== null);
-  expect(construct.kinesisStream !== null);
-  expect(construct.eventsRole !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.kinesisStream).toBeDefined();
+  expect(construct.eventsRole).toBeDefined();
 });
 
 test('Test default AWS managed encryption key property', () => {
@@ -91,10 +91,10 @@ test('check eventbus property, snapshot & eventbus exists', () => {
   };
   const construct = new EventbridgeToKinesisStreams(stack, 'test-eventbridge-kinesis-streams-default-parameters', props);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.kinesisStream !== null);
-  expect(construct.eventsRole !== null);
-  expect(construct.eventBus !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.kinesisStream).toBeDefined();
+  expect(construct.eventsRole).toBeDefined();
+  expect(construct.eventBus).toBeDefined();
   // Check whether eventbus exists
   const template = Template.fromStack(stack);
   template.resourceCountIs('AWS::Events::EventBus', 1);

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/test/eventbridge-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/test/eventbridge-lambda.test.ts
@@ -184,8 +184,8 @@ test('check properties', () => {
 
   const construct: EventbridgeToLambda = deployNewFunc(stack);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.lambdaFunction !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.lambdaFunction).toBeDefined();
 });
 
 test('check exception for Missing existingObj from props', () => {
@@ -209,9 +209,9 @@ test('check eventbus property, snapshot & eventbus exists', () => {
 
   const construct: EventbridgeToLambda = deployNewEventBus(stack);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.lambdaFunction !== null);
-  expect(construct.eventBus !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.lambdaFunction).toBeDefined();
+  expect(construct.eventBus).toBeDefined();
   // Check whether eventbus exists
   const template = Template.fromStack(stack);
   template.resourceCountIs('AWS::Events::EventBus', 1);

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
@@ -169,9 +169,9 @@ test('check properties', () => {
   const stack = new cdk.Stack();
   const construct: EventbridgeToSns = deployNewStack(stack);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.snsTopic !== null);
-  expect(construct.encryptionKey !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.snsTopic).toBeDefined();
+  expect(construct.encryptionKey).toBeDefined();
 });
 
 test('check the sns topic properties', () => {
@@ -224,10 +224,10 @@ test('check eventbus property, snapshot & eventbus exists', () => {
 
   const construct: EventbridgeToSns = deployStackWithNewEventBus(stack);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.snsTopic !== null);
-  expect(construct.encryptionKey !== null);
-  expect(construct.eventBus !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.snsTopic).toBeDefined();
+  expect(construct.encryptionKey).toBeDefined();
+  expect(construct.eventBus).toBeDefined();
 
   // Check whether eventbus exists
   const template = Template.fromStack(stack);

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/test/eventbridge-sqs-queue.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/test/eventbridge-sqs-queue.test.ts
@@ -278,21 +278,21 @@ test('check properties', () => {
   const stack = new cdk.Stack();
   const construct: EventbridgeToSqs = deployNewStack(stack);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.sqsQueue !== null);
-  expect(construct.encryptionKey !== null);
-  expect(construct.deadLetterQueue !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.sqsQueue).toBeDefined();
+  expect(construct.encryptionKey).toBeDefined();
+  expect(construct.deadLetterQueue).toBeDefined();
 });
 
 test('check eventbus property, snapshot & eventbus exists', () => {
   const stack = new cdk.Stack();
   const construct: EventbridgeToSqs = deployStackWithNewEventBus(stack);
 
-  expect(construct.eventsRule !== null);
-  expect(construct.sqsQueue !== null);
-  expect(construct.encryptionKey !== null);
-  expect(construct.deadLetterQueue !== null);
-  expect(construct.eventBus !== null);
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.sqsQueue).toBeDefined();
+  expect(construct.encryptionKey).toBeDefined();
+  expect(construct.deadLetterQueue).toBeDefined();
+  expect(construct.eventBus).toBeDefined();
 
   // Check whether eventbus exists
   const template = Template.fromStack(stack);

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/eventbridge-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/eventbridge-stepfunctions.test.ts
@@ -106,10 +106,10 @@ test('check properties', () => {
 
   const construct: EventbridgeToStepfunctions = deployNewStateMachine(stack);
 
-  expect(construct.cloudwatchAlarms !== null);
-  expect(construct.stateMachine !== null);
-  expect(construct.eventsRule !== null);
-  expect(construct.stateMachineLogGroup !== null);
+  expect(construct.cloudwatchAlarms).toBeDefined();
+  expect(construct.stateMachine).toBeDefined();
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.stateMachineLogGroup).toBeDefined();
 });
 
 test('check properties with no CW Alarms', () => {
@@ -128,10 +128,10 @@ test('check properties with no CW Alarms', () => {
 
   const construct: EventbridgeToStepfunctions =  new EventbridgeToStepfunctions(stack, 'test-eventbridge-stepfunctions', props);
 
-  expect(construct.cloudwatchAlarms === null);
-  expect(construct.stateMachine !== null);
-  expect(construct.eventsRule !== null);
-  expect(construct.stateMachineLogGroup !== null);
+  expect(construct.cloudwatchAlarms).not.toBeDefined();
+  expect(construct.stateMachine).toBeDefined();
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.stateMachineLogGroup).toBeDefined();
 });
 
 test('check eventbus property, snapshot & eventbus exists', () => {
@@ -139,11 +139,11 @@ test('check eventbus property, snapshot & eventbus exists', () => {
 
   const construct: EventbridgeToStepfunctions = deployNewStateMachineAndEventBus(stack);
 
-  expect(construct.cloudwatchAlarms !== null);
-  expect(construct.stateMachine !== null);
-  expect(construct.eventsRule !== null);
-  expect(construct.stateMachineLogGroup !== null);
-  expect(construct.eventBus !== null);
+  expect(construct.cloudwatchAlarms).toBeDefined();
+  expect(construct.stateMachine).toBeDefined();
+  expect(construct.eventsRule).toBeDefined();
+  expect(construct.stateMachineLogGroup).toBeDefined();
+  expect(construct.eventBus).toBeDefined();
 
   // Check whether eventbus exists
   const template = Template.fromStack(stack);

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/test/fargate-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/test/fargate-dynamodb.test.ts
@@ -46,11 +46,11 @@ test('New service/new table, public API, new VPC', () => {
     tablePermissions: 'ReadWrite'
   });
 
-  expect(construct.vpc !== null);
-  expect(construct.service !== null);
-  expect(construct.container !== null);
-  expect(construct.dynamoTable !== null);
-  expect(construct.dynamoTableInterface !== null);
+  expect(construct.vpc).toBeDefined();
+  expect(construct.service).toBeDefined();
+  expect(construct.container).toBeDefined();
+  expect(construct.dynamoTable).toBeDefined();
+  expect(construct.dynamoTableInterface).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::ECS::Service", {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/test/aws-fargate-kinesisfirehose.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/test/aws-fargate-kinesisfirehose.test.ts
@@ -39,10 +39,10 @@ test('New service/new bucket, public API, new VPC', () => {
     existingKinesisFirehose: destination.kinesisFirehose
   });
 
-  expect(construct.vpc !== null);
-  expect(construct.service !== null);
-  expect(construct.container !== null);
-  expect(construct.kinesisFirehose !== null);
+  expect(construct.vpc).toBeDefined();
+  expect(construct.service).toBeDefined();
+  expect(construct.container).toBeDefined();
+  expect(construct.kinesisFirehose).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::ECS::Service", {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/fargate-opensearch.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/test/fargate-opensearch.test.ts
@@ -71,15 +71,15 @@ test('Check construct properties', () => {
 
   const construct = deployStackWithNewResources(stack, publicApi);
 
-  expect(construct.vpc !== null);
-  expect(construct.service !== null);
-  expect(construct.container !== null);
-  expect(construct.userPool !== null);
-  expect(construct.userPoolClient !== null);
-  expect(construct.identityPool !== null);
-  expect(construct.openSearchDomain !== null);
-  expect(construct.openSearchRole !== null);
-  expect(construct.cloudWatchAlarms !== null);
+  expect(construct.vpc).toBeDefined();
+  expect(construct.service).toBeDefined();
+  expect(construct.container).toBeDefined();
+  expect(construct.userPool).toBeDefined();
+  expect(construct.userPoolClient).toBeDefined();
+  expect(construct.identityPool).toBeDefined();
+  expect(construct.openSearchDomain).toBeDefined();
+  expect(construct.openSearchRole).toBeDefined();
+  expect(construct.cloudWatchAlarms).toBeDefined();
 });
 
 test('Test cognito dashboard role IAM policy', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/test/fargate-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/test/fargate-s3.test.ts
@@ -42,11 +42,11 @@ test('New service/new bucket, public API, new VPC', () => {
     bucketPermissions: ['Delete', 'Read', 'Write']
   });
 
-  expect(construct.vpc !== null);
-  expect(construct.service !== null);
-  expect(construct.container !== null);
-  expect(construct.s3Bucket !== null);
-  expect(construct.s3BucketInterface !== null);
+  expect(construct.vpc).toBeDefined();
+  expect(construct.service).toBeDefined();
+  expect(construct.container).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
+  expect(construct.s3BucketInterface).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::ECS::Service", {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/test/fargate-secretsmanager.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/test/fargate-secretsmanager.test.ts
@@ -45,10 +45,10 @@ test('New service/new secret, public API, new VPC', () => {
     },
   });
 
-  expect(construct.vpc !== null);
-  expect(construct.service !== null);
-  expect(construct.container !== null);
-  expect(construct.secret !== null);
+  expect(construct.vpc).toBeDefined();
+  expect(construct.service).toBeDefined();
+  expect(construct.container).toBeDefined();
+  expect(construct.secret).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::ECS::Service", {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/test/fargate-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/test/fargate-sqs.test.ts
@@ -58,11 +58,11 @@ test('New service/new queue, dlq, public API, new VPC', () => {
     PlatformVersion: ecs.FargatePlatformVersion.LATEST,
   });
 
-  expect(construct.vpc !== null);
-  expect(construct.service !== null);
-  expect(construct.container !== null);
-  expect(construct.sqsQueue !== null);
-  expect(construct.deadLetterQueue !== null);
+  expect(construct.vpc).toBeDefined();
+  expect(construct.service).toBeDefined();
+  expect(construct.container).toBeDefined();
+  expect(construct.sqsQueue).toBeDefined();
+  expect(construct.deadLetterQueue).toBeDefined();
 
   template.hasResourceProperties("AWS::ECS::Service", {
     ServiceName: serviceName

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/test/fargate-ssmstringparameter.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/test/fargate-ssmstringparameter.test.ts
@@ -47,10 +47,10 @@ test('New service/new parameter store, public API, new VPC', () => {
     },
   });
 
-  expect(construct.vpc !== null);
-  expect(construct.service !== null);
-  expect(construct.container !== null);
-  expect(construct.stringParameter !== null);
+  expect(construct.vpc).toBeDefined();
+  expect(construct.service).toBeDefined();
+  expect(construct.container).toBeDefined();
+  expect(construct.stringParameter).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::ECS::Service", {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/test/test.iot-kinesisfirehose-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/test/test.iot-kinesisfirehose-s3.test.ts
@@ -120,13 +120,13 @@ test('check properties', () => {
 
   const construct: IotToKinesisFirehoseToS3 = deploy(stack);
 
-  expect(construct.iotTopicRule !== null);
-  expect(construct.kinesisFirehose !== null);
-  expect(construct.s3Bucket !== null);
-  expect(construct.iotActionsRole !== null);
-  expect(construct.kinesisFirehoseRole !== null);
-  expect(construct.kinesisFirehoseLogGroup !== null);
-  expect(construct.s3LoggingBucket !== null);
+  expect(construct.iotTopicRule).toBeDefined();
+  expect(construct.kinesisFirehose).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
+  expect(construct.iotActionsRole).toBeDefined();
+  expect(construct.kinesisFirehoseRole).toBeDefined();
+  expect(construct.kinesisFirehoseLogGroup).toBeDefined();
+  expect(construct.s3LoggingBucket).toBeDefined();
 });
 
 test("Confirm CheckS3Props is being called", () => {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/test/iot-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/test/iot-lambda.test.ts
@@ -271,8 +271,8 @@ test('check properties', () => {
 
   const construct: IotToLambda = deployNewFunc(stack);
 
-  expect(construct.iotTopicRule !== null);
-  expect(construct.lambdaFunction !== null);
+  expect(construct.iotTopicRule).toBeDefined();
+  expect(construct.lambdaFunction).toBeDefined();
 });
 
 test('check exception for Missing existingObj from props for deploy = false', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/test/kinesisfirehose-s3-and-kinesisanalytics.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3-and-kinesisanalytics/test/kinesisfirehose-s3-and-kinesisanalytics.test.ts
@@ -47,12 +47,12 @@ test('Test properties', () => {
   };
   const app = new KinesisFirehoseToAnalyticsAndS3(stack, 'test-kinesis-firehose-kinesis-analytics', props);
   // Assertions
-  expect(app.kinesisAnalytics !== null);
-  expect(app.kinesisFirehose !== null);
-  expect(app.kinesisFirehoseRole !== null);
-  expect(app.kinesisFirehoseLogGroup !== null);
-  expect(app.s3Bucket !== null);
-  expect(app.s3LoggingBucket !== null);
+  expect(app.kinesisAnalytics).toBeDefined();
+  expect(app.kinesisFirehose).toBeDefined();
+  expect(app.kinesisFirehoseRole).toBeDefined();
+  expect(app.kinesisFirehoseLogGroup).toBeDefined();
+  expect(app.s3Bucket).toBeDefined();
+  expect(app.s3LoggingBucket).toBeDefined();
 });
 
 // --------------------------------------------------------------

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/kinesisstreams-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/test/kinesisstreams-lambda.test.ts
@@ -30,11 +30,11 @@ test('Test properties', () => {
   };
   const app = new KinesisStreamsToLambda(stack, 'test-kinesis-streams-lambda', props);
   // Assertion 1
-  expect(app.lambdaFunction !== null);
+  expect(app.lambdaFunction).toBeDefined();
   // Assertion 2
-  expect(app.kinesisStream !== null);
+  expect(app.kinesisStream).toBeDefined();
   // Assertion 3
-  expect(app.cloudwatchAlarms !== null);
+  expect(app.cloudwatchAlarms).toBeDefined();
 });
 
 test('Test existing resources', () => {
@@ -108,11 +108,11 @@ test('Test properties with no CW Alarms', () => {
   };
   const app = new KinesisStreamsToLambda(stack, 'test-kinesis-streams-lambda', props);
   // Assertion 1
-  expect(app.lambdaFunction !== null);
+  expect(app.lambdaFunction).toBeDefined();
   // Assertion 2
-  expect(app.kinesisStream !== null);
+  expect(app.kinesisStream).toBeDefined();
   // Assertion 3
-  expect(app.cloudwatchAlarms === null);
+  expect(app.cloudwatchAlarms).not.toBeDefined();
 });
 
 test('Confirm call to CheckLambdaProps', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/test/lambda-dynamodb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/test/lambda-dynamodb.test.ts
@@ -275,8 +275,8 @@ test('check properties', () => {
 
   const construct: LambdaToDynamoDB = deployNewFunc(stack);
 
-  expect(construct.lambdaFunction !== null);
-  expect(construct.dynamoTable !== null);
+  expect(construct.lambdaFunction).toBeDefined();
+  expect(construct.dynamoTable).toBeDefined();
 });
 
 test('check exception for Missing existingObj from props', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/test/aws-lambda-kinesisfirehose.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/test/aws-lambda-kinesisfirehose.test.ts
@@ -108,7 +108,7 @@ test('Test that new VPC is created', () => {
     }
   });
 
-  expect(construct.vpc !== null);
+  expect(construct.vpc).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::EC2::VPC", {
@@ -148,7 +148,7 @@ test('Test that existing VPC is used', () => {
     existingVpc: myVpc
   });
 
-  expect(construct.vpc !== null);
+  expect(construct.vpc).toBeDefined();
 
   // Make sure we didn't deploy a new one anyway
   const template = Template.fromStack(stack);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/test/lambda-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/test/lambda-s3.test.ts
@@ -34,11 +34,11 @@ test('Test the properties', () => {
   });
     // Assertion 1
   const func = pattern.lambdaFunction;
-  expect(func !== null);
+  expect(func).toBeDefined();
   // Assertion 2
   const bucket = pattern.s3Bucket;
-  expect(bucket !== null);
-  expect(pattern.s3LoggingBucket !== null);
+  expect(bucket).toBeDefined();
+  expect(pattern.s3LoggingBucket).toBeDefined();
 });
 
 test('Test the bucketProps override', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/test/s3-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/test/s3-lambda.test.ts
@@ -38,9 +38,9 @@ test('check properties', () => {
 
   const construct: S3ToLambda = deployNewFunc(stack);
 
-  expect(construct.lambdaFunction !== null);
-  expect(construct.s3Bucket !== null);
-  expect(construct.s3LoggingBucket !== null);
+  expect(construct.lambdaFunction).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
+  expect(construct.s3LoggingBucket).toBeDefined();
 });
 
 test("Confirm CheckS3Props is being called", () => {

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sns/test/test.s3-sns.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sns/test/test.s3-sns.test.ts
@@ -24,11 +24,11 @@ test('All get methods return non-null objects', () => {
   const app = new S3ToSns(stack, 'test-s3-sns', {
 
   });
-  expect(app.snsTopic !== null);
-  expect(app.s3Bucket !== null);
-  expect(app.s3LoggingBucket !== null);
-  expect(app.encryptionKey !== null);
-  expect(app.s3BucketInterface !== null);
+  expect(app.snsTopic).toBeDefined();
+  expect(app.s3Bucket).toBeDefined();
+  expect(app.s3LoggingBucket).toBeDefined();
+  expect(app.encryptionKey).toBeDefined();
+  expect(app.s3BucketInterface).toBeDefined();
 });
 
 test('construct creates default event notification', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/test.s3-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/test/test.s3-sqs.test.ts
@@ -33,11 +33,11 @@ test('Test getter methods', () => {
   };
   const app = new S3ToSqs(stack, 'test-s3-sqs', props);
   // Assertion 1
-  expect(app.sqsQueue !== null);
+  expect(app.sqsQueue).toBeDefined();
   // Assertion 2
-  expect(app.deadLetterQueue !== null);
+  expect(app.deadLetterQueue).toBeDefined();
   // Assertion 3
-  expect(app.s3Bucket !== null);
+  expect(app.s3Bucket).toBeDefined();
 });
 
 test('Test deployment w/ existing queue', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/s3-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/s3-stepfunctions.test.ts
@@ -98,11 +98,11 @@ test('check properties', () => {
 
   const construct: S3ToStepfunctions = deployNewStateMachine(stack);
 
-  expect(construct.stateMachine !== null);
-  expect(construct.s3Bucket !== null);
-  expect(construct.cloudwatchAlarms !== null);
-  expect(construct.stateMachineLogGroup !== null);
-  expect(construct.s3LoggingBucket !== null);
+  expect(construct.stateMachine).toBeDefined();
+  expect(construct.s3Bucket).toBeDefined();
+  expect(construct.cloudwatchAlarms).toBeDefined();
+  expect(construct.stateMachineLogGroup).toBeDefined();
+  expect(construct.s3LoggingBucket).toBeDefined();
 });
 
 // --------------------------------------------------------------

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/sns-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/sns-lambda.test.ts
@@ -35,8 +35,8 @@ test('check properties', () => {
 
   const construct: SnsToLambda = deployNewFunc(stack);
 
-  expect(construct.lambdaFunction !== null);
-  expect(construct.snsTopic !== null);
+  expect(construct.lambdaFunction).toBeDefined();
+  expect(construct.snsTopic).toBeDefined();
 });
 
 test('override topicProps', () => {

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/sns-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/test/sns-sqs.test.ts
@@ -112,13 +112,13 @@ test('Test getter methods', () => {
   };
   const app = new SnsToSqs(stack, 'test-sns-sqs', props);
   // Assertion 1
-  expect(app.snsTopic !== null);
+  expect(app.snsTopic).toBeDefined();
   // Assertion 2
-  expect(app.encryptionKey !== null);
+  expect(app.encryptionKey).toBeDefined();
   // Assertion 3
-  expect(app.sqsQueue !== null);
+  expect(app.sqsQueue).toBeDefined();
   // Assertion 4
-  expect(app.deadLetterQueue !== null);
+  expect(app.deadLetterQueue).toBeDefined();
 });
 
 test('Test deployment w/ existing queue, and topic', () => {
@@ -136,7 +136,7 @@ test('Test deployment w/ existing queue, and topic', () => {
     existingQueueObj: queue
   });
   // Assertion 2
-  expect(app.snsTopic !== null);
+  expect(app.snsTopic).toBeDefined();
   // Assertion 3
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::SNS::Topic", {

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/test/test.sqs-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/test/test.sqs-lambda.test.ts
@@ -67,11 +67,11 @@ test('Test getter methods', () => {
   };
   const app = new SqsToLambda(stack, 'sqs-lambda', props);
   // Assertion 1
-  expect(app.lambdaFunction !== null);
+  expect(app.lambdaFunction).toBeDefined();
   // Assertion 2
-  expect(app.sqsQueue !== null);
+  expect(app.sqsQueue).toBeDefined();
   // Assertion 3
-  expect(app.deadLetterQueue !== null);
+  expect(app.deadLetterQueue).toBeDefined();
 });
 
 // --------------------------------------------------------------

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/test/test.wafwebacl-alb.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/test/test.wafwebacl-alb.test.ts
@@ -71,8 +71,8 @@ test('Test default deployment', () => {
   const stack = new cdk.Stack();
   const construct = deployConstruct(stack);
 
-  expect(construct.webacl !== null);
-  expect(construct.loadBalancer !== null);
+  expect(construct.webacl).toBeDefined();
+  expect(construct.loadBalancer).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::WAFv2::WebACL", {

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/test.wafwebacl-apigateway.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/test.wafwebacl-apigateway.test.ts
@@ -60,8 +60,8 @@ test('Test default deployment', () => {
   const stack = new cdk.Stack();
   const construct = deployConstruct(stack);
 
-  expect(construct.webacl !== null);
-  expect(construct.apiGateway !== null);
+  expect(construct.webacl).toBeDefined();
+  expect(construct.apiGateway).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::WAFv2::WebACL", {

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/test/test.wafwebacl-appsync.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/test/test.wafwebacl-appsync.test.ts
@@ -73,8 +73,8 @@ test("Test default deployment", () => {
   const stack = new cdk.Stack();
   const construct = deployConstruct(stack);
 
-  expect(construct.webacl !== null);
-  expect(construct.appsyncApi !== null);
+  expect(construct.webacl).toBeDefined();
+  expect(construct.appsyncApi).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::WAFv2::WebACL", {

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/test/test.wafwebacl-cloudfront.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/test/test.wafwebacl-cloudfront.test.ts
@@ -70,8 +70,8 @@ test('Test default deployment', () => {
   const stack = new cdk.Stack();
   const construct = deployConstruct(stack);
 
-  expect(construct.webacl !== null);
-  expect(construct.cloudFrontWebDistribution !== null);
+  expect(construct.webacl).toBeDefined();
+  expect(construct.cloudFrontWebDistribution).toBeDefined();
 
   const template = Template.fromStack(stack);
   template.hasResourceProperties("AWS::WAFv2::WebACL", {


### PR DESCRIPTION
replace

`expect(construct.value !== null)`

with 

`expect(construct.value).toBeDefined()`