### PR TITLE
fix(aws-eventbridge-sns): long sns topic names break eventbridge bindings

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/lib/index.ts
@@ -15,6 +15,7 @@ import * as sns from 'aws-cdk-lib/aws-sns';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as defaults from '@aws-solutions-constructs/core';
+import * as cdk from 'aws-cdk-lib';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from 'constructs';
 import { overrideProps } from '@aws-solutions-constructs/core';
@@ -107,10 +108,22 @@ export class EventbridgeToSns extends Construct {
 
       this.snsTopic = buildTopicResponse.topic;
       this.encryptionKey = buildTopicResponse.key;
+
       // Setup the event rule target as sns topic.
+
+      // The CDK generally avoids resource names that are too long, but in this case the maximum SNS topic name is 256 characters and the maximum
+      // binding id is 64 characters, so a long SNS topic name (driven by Stack id, Construct id, etc.) breaks upon launch. Because of this, we take
+      // control of the physical name ourselves.
+      const maxBindingIdLength = 64;
+      const nameParts: string[] = [
+        cdk.Stack.of(scope).stackName, // Name of the stack
+        id,                            // Construct ID
+      ];
+      const generatedTopicName = defaults.generatePhysicalName("", nameParts, maxBindingIdLength);
+
       const topicEventTarget: events.IRuleTarget = {
         bind: () => ({
-          id: this.snsTopic.topicName,
+          id: generatedTopicName,
           arn: this.snsTopic.topicArn
         })
       };

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
@@ -141,7 +141,7 @@ test('check if the event rule has permission/policy in place in sns for it to be
   );
 });
 
-test.only('check events rule properties', () => {
+test('check events rule properties', () => {
   const stack = new cdk.Stack();
   deployNewStack(stack);
 

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/eventbridge-sns-topic.test.ts
@@ -141,7 +141,7 @@ test('check if the event rule has permission/policy in place in sns for it to be
   );
 });
 
-test('check events rule properties', () => {
+test.only('check events rule properties', () => {
   const stack = new cdk.Stack();
   deployNewStack(stack);
 
@@ -155,9 +155,24 @@ test('check events rule properties', () => {
           Ref: "testSnsTopic42942701"
         },
         Id: {
-          "Fn::GetAtt": [
-            "testSnsTopic42942701",
-            "TopicName"
+          "Fn::Join": [
+            "",
+            [
+              "Defaulttest-",
+              {
+                "Fn::Select": [
+                  2,
+                  {
+                    "Fn::Split": [
+                      "/",
+                      {
+                        Ref: "AWS::StackId"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           ]
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.exist-bus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.exist-bus.expected.json
@@ -9,6 +9,7 @@
     "testconstructEncryptionKey6153B053": {
       "Type": "AWS::KMS::Key",
       "Properties": {
+        "EnableKeyRotation": true,
         "KeyPolicy": {
           "Statement": [
             {
@@ -49,8 +50,7 @@
             }
           ],
           "Version": "2012-10-17"
-        },
-        "EnableKeyRotation": true
+        }
       },
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
@@ -179,9 +179,24 @@
               "Ref": "testconstructSnsTopic44188529"
             },
             "Id": {
-              "Fn::GetAtt": [
-                "testconstructSnsTopic44188529",
-                "TopicName"
+              "Fn::Join": [
+                "",
+                [
+                  "exist-bustest-construct-",
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "AWS::StackId"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               ]
             }
           }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.long-stack-name.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.long-stack-name.expected.json
@@ -158,7 +158,7 @@
     "testconstructEventsRule145DBA20": {
       "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(5 minutes)",
+        "ScheduleExpression": "rate(1 minute)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -169,7 +169,197 @@
               "Fn::Join": [
                 "",
                 [
-                  "no-argtest-construct-",
+                  "longstacknametest-construct-",
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "AWS::StackId"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "secondconstructEncryptionKey6A63A25A": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "EnableKeyRotation": true,
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "secondconstructSnsTopicCE75056B": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "KmsMasterKeyId": {
+          "Fn::GetAtt": [
+            "secondconstructEncryptionKey6A63A25A",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "secondconstructSnsTopicPolicyD6D4DA55": {
+      "Type": "AWS::SNS::TopicPolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "SNS:Publish",
+                "SNS:RemovePermission",
+                "SNS:SetTopicAttributes",
+                "SNS:DeleteTopic",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:GetTopicAttributes",
+                "SNS:Receive",
+                "SNS:AddPermission",
+                "SNS:Subscribe"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "AWS:SourceOwner": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": {
+                "Ref": "secondconstructSnsTopicCE75056B"
+              },
+              "Sid": "TopicOwnerOnlyAccess"
+            },
+            {
+              "Action": [
+                "SNS:Publish",
+                "SNS:RemovePermission",
+                "SNS:SetTopicAttributes",
+                "SNS:DeleteTopic",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:GetTopicAttributes",
+                "SNS:Receive",
+                "SNS:AddPermission",
+                "SNS:Subscribe"
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Ref": "secondconstructSnsTopicCE75056B"
+              },
+              "Sid": "HttpsOnly"
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Resource": {
+                "Ref": "secondconstructSnsTopicCE75056B"
+              },
+              "Sid": "2"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Topics": [
+          {
+            "Ref": "secondconstructSnsTopicCE75056B"
+          }
+        ]
+      }
+    },
+    "secondconstructEventsRuleFA5C1CE6": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "secondconstructSnsTopicCE75056B"
+            },
+            "Id": {
+              "Fn::Join": [
+                "",
+                [
+                  "longstacknamecond-construct-",
                   {
                     "Fn::Select": [
                       2,

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.long-stack-name.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.long-stack-name.ts
@@ -1,0 +1,32 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { Duration } from 'aws-cdk-lib';
+import { EventbridgeToSns, EventbridgeToSnsProps } from '../lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import { App, Stack } from 'aws-cdk-lib';
+import { generateIntegStackName } from '@aws-solutions-constructs/core';
+
+const app = new App();
+const stack = new Stack(app, generateIntegStackName(__filename) + 'ThisIsTheLongestNameForAStackItMustBeGreaterThanSixtyFourCharactersLongAndThisShouldJustAboutDoItNoItMustBeABitLonger');
+
+const props: EventbridgeToSnsProps = {
+  eventRuleProps: {
+    schedule: events.Schedule.rate(Duration.minutes(1))
+  }
+};
+
+new EventbridgeToSns(stack, 'test-construct', props);
+new EventbridgeToSns(stack, 'second-construct', props);
+
+app.synth();

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.new-bus.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.new-bus.expected.json
@@ -3,6 +3,7 @@
     "testconstructEncryptionKey6153B053": {
       "Type": "AWS::KMS::Key",
       "Properties": {
+        "EnableKeyRotation": true,
         "KeyPolicy": {
           "Statement": [
             {
@@ -43,8 +44,7 @@
             }
           ],
           "Version": "2012-10-17"
-        },
-        "EnableKeyRotation": true
+        }
       },
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
@@ -179,9 +179,24 @@
               "Ref": "testconstructSnsTopic44188529"
             },
             "Id": {
-              "Fn::GetAtt": [
-                "testconstructSnsTopic44188529",
-                "TopicName"
+              "Fn::Join": [
+                "",
+                [
+                  "new-bustest-construct-",
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "AWS::StackId"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               ]
             }
           }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.second-long-stack-name.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.second-long-stack-name.expected.json
@@ -158,7 +158,7 @@
     "testconstructEventsRule145DBA20": {
       "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(5 minutes)",
+        "ScheduleExpression": "rate(1 minute)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -169,7 +169,197 @@
               "Fn::Join": [
                 "",
                 [
-                  "no-argtest-construct-",
+                  "secondlongstatest-construct-",
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "AWS::StackId"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "secondconstructEncryptionKey6A63A25A": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "EnableKeyRotation": true,
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "secondconstructSnsTopicCE75056B": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "KmsMasterKeyId": {
+          "Fn::GetAtt": [
+            "secondconstructEncryptionKey6A63A25A",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "secondconstructSnsTopicPolicyD6D4DA55": {
+      "Type": "AWS::SNS::TopicPolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "SNS:Publish",
+                "SNS:RemovePermission",
+                "SNS:SetTopicAttributes",
+                "SNS:DeleteTopic",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:GetTopicAttributes",
+                "SNS:Receive",
+                "SNS:AddPermission",
+                "SNS:Subscribe"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "AWS:SourceOwner": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": {
+                "Ref": "secondconstructSnsTopicCE75056B"
+              },
+              "Sid": "TopicOwnerOnlyAccess"
+            },
+            {
+              "Action": [
+                "SNS:Publish",
+                "SNS:RemovePermission",
+                "SNS:SetTopicAttributes",
+                "SNS:DeleteTopic",
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:GetTopicAttributes",
+                "SNS:Receive",
+                "SNS:AddPermission",
+                "SNS:Subscribe"
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Ref": "secondconstructSnsTopicCE75056B"
+              },
+              "Sid": "HttpsOnly"
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Resource": {
+                "Ref": "secondconstructSnsTopicCE75056B"
+              },
+              "Sid": "2"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Topics": [
+          {
+            "Ref": "secondconstructSnsTopicCE75056B"
+          }
+        ]
+      }
+    },
+    "secondconstructEventsRuleFA5C1CE6": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "secondconstructSnsTopicCE75056B"
+            },
+            "Id": {
+              "Fn::Join": [
+                "",
+                [
+                  "secondlongstacond-construct-",
                   {
                     "Fn::Select": [
                       2,

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.second-long-stack-name.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/test/integ.second-long-stack-name.ts
@@ -1,0 +1,38 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+// In order to confirm that we avoid name collisions on the event binding with both multiple constructs and multiple stacks,
+// launch two stacks with two constructs at the same time using
+//  cdk-integ integ.second-long-stack-name.js integ.long-stack-name.js --no-clean
+// and confirm that all topics are publishing messages.
+
+import { Duration } from 'aws-cdk-lib';
+import { EventbridgeToSns, EventbridgeToSnsProps } from '../lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import { App, Stack } from 'aws-cdk-lib';
+import { generateIntegStackName } from '@aws-solutions-constructs/core';
+
+const app = new App();
+
+const stackTwo = new Stack(app, generateIntegStackName(__filename) + 'ThisIsTheLongestNameForAStackItMustBeGreaterThanSixtyFourCharactersLongAndThisShouldJustAboutDoItNoItMustBeABitLessShort');
+
+const propsTwo: EventbridgeToSnsProps = {
+  eventRuleProps: {
+    schedule: events.Schedule.rate(Duration.minutes(1))
+  }
+};
+
+new EventbridgeToSns(stackTwo, 'test-construct', propsTwo);
+new EventbridgeToSns(stackTwo, 'second-construct', propsTwo);
+
+app.synth();


### PR DESCRIPTION
*Issue #, if available:*
Closes #1015 

*Description of changes:*
Explicitly set the physical name of the Event/Topic binding

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.