### PR TITLE
fix(aws-apigateway-sqs): Remove /message path when delete method is not allowed

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/lib/index.ts
@@ -241,9 +241,6 @@ export class ApiGatewayToSqs extends Construct {
       assumedBy: new iam.ServicePrincipal('apigateway.amazonaws.com')
     });
 
-    // Setup the API Gateway resource
-    const apiGatewayResource = this.apiGateway.root.addResource('message');
-
     // Create
     const createRequestTemplate = props.createRequestTemplate ?? this.defaultCreateRequestTemplate;
     if (props.allowCreateOperation && props.allowCreateOperation === true) {
@@ -281,6 +278,7 @@ export class ApiGatewayToSqs extends Construct {
     // Delete
     const deleteRequestTemplate = props.deleteRequestTemplate ?? this.defaultDeleteRequestTemplate;
     if (props.allowDeleteOperation && props.allowDeleteOperation === true) {
+      const apiGatewayResource = this.apiGateway.root.addResource('message');
       this.addActionToPolicy("sqs:DeleteMessage");
       defaults.addProxyMethodToApiResource({
         service: "sqs",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/apigateway-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/apigateway-sqs.test.ts
@@ -185,9 +185,8 @@ test('Test deployment for allow delete operation', () => {
   const template = Template.fromStack(stack);
   template.hasResourceProperties('AWS::ApiGateway::Resource', {
     PathPart: "message"
-  })
+  });
 });
-
 
 test('Test deployment with existing queue object', () => {
   const stack = new Stack();

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/apigateway-sqs.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/apigateway-sqs.test.ts
@@ -163,6 +163,32 @@ test('Test deployment for override ApiGateway deleteRequestTemplate', () => {
   });
 });
 
+test('Test deployment for disallow delete operation', () => {
+  const stack = new Stack();
+
+  new ApiGatewayToSqs(stack, 'api-gateway-sqs', {
+    allowDeleteOperation: false
+  });
+  const template = Template.fromStack(stack);
+  const resources = template.findResources('AWS::ApiGateway::Resource', {
+    PathPart: "message"
+  });
+  expect(Object.keys(resources).length).toBe(0);
+});
+
+test('Test deployment for allow delete operation', () => {
+  const stack = new Stack();
+
+  new ApiGatewayToSqs(stack, 'api-gateway-sqs', {
+    allowDeleteOperation: true
+  });
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::ApiGateway::Resource', {
+    PathPart: "message"
+  })
+});
+
+
 test('Test deployment with existing queue object', () => {
   const stack = new Stack();
 

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-additional-request-templates.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-additional-request-templates.expected.json
@@ -198,7 +198,7 @@
         "Name": "RestApi"
       }
     },
-    "testapigatewaysqsdefaultRestApiDeploymentFB9688F5aa398c65c945d66dd485b50d59cc7a25": {
+    "testapigatewaysqsdefaultRestApiDeploymentFB9688F5ba8a42d07caa9db068377b2cabf4da74": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -208,7 +208,6 @@
       },
       "DependsOn": [
         "testapigatewaysqsdefaultRestApiGET733E6394",
-        "testapigatewaysqsdefaultRestApimessage41073D7F",
         "testapigatewaysqsdefaultRestApiPOSTD8ACD1CB"
       ],
       "Metadata": {
@@ -235,7 +234,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "testapigatewaysqsdefaultRestApiDeploymentFB9688F5aa398c65c945d66dd485b50d59cc7a25"
+          "Ref": "testapigatewaysqsdefaultRestApiDeploymentFB9688F5ba8a42d07caa9db068377b2cabf4da74"
         },
         "MethodSettings": [
           {
@@ -250,21 +249,6 @@
         },
         "StageName": "prod",
         "TracingEnabled": true
-      }
-    },
-    "testapigatewaysqsdefaultRestApimessage41073D7F": {
-      "Type": "AWS::ApiGateway::Resource",
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "testapigatewaysqsdefaultRestApi554243C3",
-            "RootResourceId"
-          ]
-        },
-        "PathPart": "message",
-        "RestApiId": {
-          "Ref": "testapigatewaysqsdefaultRestApi554243C3"
-        }
       }
     },
     "testapigatewaysqsdefaultRestApiPOSTD8ACD1CB": {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-apigateway-sqs-crud.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-apigateway-sqs-crud.expected.json
@@ -198,7 +198,7 @@
         "Name": "RestApi"
       }
     },
-    "testapigatewaysqsRestApiDeploymentCA19D3723284170350125cf6cf25e30c33a57efd": {
+    "testapigatewaysqsRestApiDeploymentCA19D37261367bad52ebfa5cbc65d48442b36029": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -236,7 +236,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "testapigatewaysqsRestApiDeploymentCA19D3723284170350125cf6cf25e30c33a57efd"
+          "Ref": "testapigatewaysqsRestApiDeploymentCA19D37261367bad52ebfa5cbc65d48442b36029"
         },
         "MethodSettings": [
           {
@@ -251,103 +251,6 @@
         },
         "StageName": "prod",
         "TracingEnabled": true
-      }
-    },
-    "testapigatewaysqsRestApimessage6D62B7B0": {
-      "Type": "AWS::ApiGateway::Resource",
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "testapigatewaysqsRestApi557C7EDC",
-            "RootResourceId"
-          ]
-        },
-        "PathPart": "message",
-        "RestApiId": {
-          "Ref": "testapigatewaysqsRestApi557C7EDC"
-        }
-      }
-    },
-    "testapigatewaysqsRestApimessageDELETE2D4539B7": {
-      "Type": "AWS::ApiGateway::Method",
-      "Properties": {
-        "AuthorizationType": "AWS_IAM",
-        "HttpMethod": "DELETE",
-        "Integration": {
-          "Credentials": {
-            "Fn::GetAtt": [
-              "testapigatewaysqsapigatewayrole07110CD6",
-              "Arn"
-            ]
-          },
-          "IntegrationHttpMethod": "POST",
-          "IntegrationResponses": [
-            {
-              "StatusCode": "200"
-            },
-            {
-              "ResponseTemplates": {
-                "text/html": "Error"
-              },
-              "SelectionPattern": "500",
-              "StatusCode": "500"
-            }
-          ],
-          "PassthroughBehavior": "NEVER",
-          "RequestParameters": {
-            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'"
-          },
-          "RequestTemplates": {
-            "application/json": "Action=DeleteMessage&ReceiptHandle=$util.urlEncode($input.params('receiptHandle'))"
-          },
-          "Type": "AWS",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition"
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region"
-                },
-                ":sqs:path/",
-                {
-                  "Ref": "AWS::AccountId"
-                },
-                "/",
-                {
-                  "Fn::GetAtt": [
-                    "testapigatewaysqsqueue8EDC3CAF",
-                    "QueueName"
-                  ]
-                }
-              ]
-            ]
-          }
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Content-Type": true
-            },
-            "StatusCode": "200"
-          },
-          {
-            "ResponseParameters": {
-              "method.response.header.Content-Type": true
-            },
-            "StatusCode": "500"
-          }
-        ],
-        "ResourceId": {
-          "Ref": "testapigatewaysqsRestApimessage6D62B7B0"
-        },
-        "RestApiId": {
-          "Ref": "testapigatewaysqsRestApi557C7EDC"
-        }
       }
     },
     "testapigatewaysqsRestApiPOST26D15DBA": {
@@ -514,6 +417,103 @@
             "testapigatewaysqsRestApi557C7EDC",
             "RootResourceId"
           ]
+        },
+        "RestApiId": {
+          "Ref": "testapigatewaysqsRestApi557C7EDC"
+        }
+      }
+    },
+    "testapigatewaysqsRestApimessage6D62B7B0": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "testapigatewaysqsRestApi557C7EDC",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "message",
+        "RestApiId": {
+          "Ref": "testapigatewaysqsRestApi557C7EDC"
+        }
+      }
+    },
+    "testapigatewaysqsRestApimessageDELETE2D4539B7": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "DELETE",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "testapigatewaysqsapigatewayrole07110CD6",
+              "Arn"
+            ]
+          },
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": [
+            {
+              "StatusCode": "200"
+            },
+            {
+              "ResponseTemplates": {
+                "text/html": "Error"
+              },
+              "SelectionPattern": "500",
+              "StatusCode": "500"
+            }
+          ],
+          "PassthroughBehavior": "NEVER",
+          "RequestParameters": {
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'"
+          },
+          "RequestTemplates": {
+            "application/json": "Action=DeleteMessage&ReceiptHandle=$util.urlEncode($input.params('receiptHandle'))"
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":sqs:path/",
+                {
+                  "Ref": "AWS::AccountId"
+                },
+                "/",
+                {
+                  "Fn::GetAtt": [
+                    "testapigatewaysqsqueue8EDC3CAF",
+                    "QueueName"
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Content-Type": true
+            },
+            "StatusCode": "200"
+          },
+          {
+            "ResponseParameters": {
+              "method.response.header.Content-Type": true
+            },
+            "StatusCode": "500"
+          }
+        ],
+        "ResourceId": {
+          "Ref": "testapigatewaysqsRestApimessage6D62B7B0"
         },
         "RestApiId": {
           "Ref": "testapigatewaysqsRestApi557C7EDC"

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-custom-integration-responses.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-custom-integration-responses.expected.json
@@ -198,7 +198,7 @@
         "Name": "RestApi"
       }
     },
-    "testapigatewaysqsintegrationresponsesRestApiDeployment9749223507b4327bc896117bc13d1c395d6fa5e7": {
+    "testapigatewaysqsintegrationresponsesRestApiDeployment9749223547b7cf1e61211d0a1959e7fc8dd7abd0": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -207,8 +207,7 @@
         }
       },
       "DependsOn": [
-        "testapigatewaysqsintegrationresponsesRestApiGETD105D1F1",
-        "testapigatewaysqsintegrationresponsesRestApimessageC29A9FEB"
+        "testapigatewaysqsintegrationresponsesRestApiGETD105D1F1"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -234,7 +233,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "testapigatewaysqsintegrationresponsesRestApiDeployment9749223507b4327bc896117bc13d1c395d6fa5e7"
+          "Ref": "testapigatewaysqsintegrationresponsesRestApiDeployment9749223547b7cf1e61211d0a1959e7fc8dd7abd0"
         },
         "MethodSettings": [
           {
@@ -249,21 +248,6 @@
         },
         "StageName": "prod",
         "TracingEnabled": true
-      }
-    },
-    "testapigatewaysqsintegrationresponsesRestApimessageC29A9FEB": {
-      "Type": "AWS::ApiGateway::Resource",
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "testapigatewaysqsintegrationresponsesRestApi3BE7E402",
-            "RootResourceId"
-          ]
-        },
-        "PathPart": "message",
-        "RestApiId": {
-          "Ref": "testapigatewaysqsintegrationresponsesRestApi3BE7E402"
-        }
       }
     },
     "testapigatewaysqsintegrationresponsesRestApiGETD105D1F1": {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-existing-queue.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-existing-queue.expected.json
@@ -110,7 +110,7 @@
         "Name": "RestApi"
       }
     },
-    "testapigatewaysqsexistingqueueRestApiDeploymentA3CB681F40a3b61200f0070439f29a9d27e30e73": {
+    "testapigatewaysqsexistingqueueRestApiDeploymentA3CB681Fb34af53058b656b91c9af037460db593": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -119,8 +119,7 @@
         }
       },
       "DependsOn": [
-        "testapigatewaysqsexistingqueueRestApiGET860786F8",
-        "testapigatewaysqsexistingqueueRestApimessageDF0AE465"
+        "testapigatewaysqsexistingqueueRestApiGET860786F8"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -146,7 +145,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "testapigatewaysqsexistingqueueRestApiDeploymentA3CB681F40a3b61200f0070439f29a9d27e30e73"
+          "Ref": "testapigatewaysqsexistingqueueRestApiDeploymentA3CB681Fb34af53058b656b91c9af037460db593"
         },
         "MethodSettings": [
           {
@@ -161,21 +160,6 @@
         },
         "StageName": "prod",
         "TracingEnabled": true
-      }
-    },
-    "testapigatewaysqsexistingqueueRestApimessageDF0AE465": {
-      "Type": "AWS::ApiGateway::Resource",
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "testapigatewaysqsexistingqueueRestApi2E025EF5",
-            "RootResourceId"
-          ]
-        },
-        "PathPart": "message",
-        "RestApiId": {
-          "Ref": "testapigatewaysqsexistingqueueRestApi2E025EF5"
-        }
       }
     },
     "testapigatewaysqsexistingqueueRestApiGET860786F8": {

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/test/integ.apisqs-no-arguments.expected.json
@@ -198,7 +198,7 @@
         "Name": "RestApi"
       }
     },
-    "testapigatewaysqsdefaultRestApiDeploymentFB9688F5638eca4a0d71dff702d4b2c6b1d1e2df": {
+    "testapigatewaysqsdefaultRestApiDeploymentFB9688F5fb9a1a72439389c4d385b8e23725ff77": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -207,8 +207,7 @@
         }
       },
       "DependsOn": [
-        "testapigatewaysqsdefaultRestApiGET733E6394",
-        "testapigatewaysqsdefaultRestApimessage41073D7F"
+        "testapigatewaysqsdefaultRestApiGET733E6394"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -234,7 +233,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "testapigatewaysqsdefaultRestApiDeploymentFB9688F5638eca4a0d71dff702d4b2c6b1d1e2df"
+          "Ref": "testapigatewaysqsdefaultRestApiDeploymentFB9688F5fb9a1a72439389c4d385b8e23725ff77"
         },
         "MethodSettings": [
           {
@@ -249,21 +248,6 @@
         },
         "StageName": "prod",
         "TracingEnabled": true
-      }
-    },
-    "testapigatewaysqsdefaultRestApimessage41073D7F": {
-      "Type": "AWS::ApiGateway::Resource",
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "testapigatewaysqsdefaultRestApi554243C3",
-            "RootResourceId"
-          ]
-        },
-        "PathPart": "message",
-        "RestApiId": {
-          "Ref": "testapigatewaysqsdefaultRestApi554243C3"
-        }
       }
     },
     "testapigatewaysqsdefaultRestApiGET733E6394": {


### PR DESCRIPTION
*Issue #, if available:*
- #1029

*Description of changes:*

- Prevent the creation of the /message path when the DELETE method is not used, as this path is only utilized by the DELETE method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.