### PR TITLE
feat(cloudfront constructs): add s3 access logging to cloudfront access log buckets by default

### DIFF
--- a/deployment/v2/refresh-multiple-tests.sh
+++ b/deployment/v2/refresh-multiple-tests.sh
@@ -19,9 +19,78 @@
 #   a sleep 10 command before the end of the loop to keep from overwhelming CloudFormation
 
 export constructs="
-  aws-cloudfront-apigateway-lambda
-  aws-cloudfront-mediastore
-  aws-wafwebacl-cloudfront
+aws-alb-fargate
+aws-alb-lambda
+aws-apigateway-dynamodb
+aws-apigateway-iot
+aws-apigateway-kinesisstreams
+aws-apigateway-lambda
+aws-apigateway-sagemakerendpoint
+aws-apigateway-sqs
+aws-cloudfront-apigateway
+aws-cloudfront-apigateway-lambda
+aws-cloudfront-mediastore
+aws-cloudfront-s3
+aws-cognito-apigateway-lambda
+aws-dynamodbstreams-lambda
+aws-dynamodbstreams-lambda-elasticsearch-kibana
+aws-eventbridge-kinesisfirehose-s3
+aws-eventbridge-kinesisstreams
+aws-eventbridge-lambda
+aws-eventbridge-sns
+aws-eventbridge-sqs
+aws-eventbridge-stepfunctions
+aws-fargate-dynamodb
+aws-fargate-eventbridge
+aws-fargate-kinesisfirehose
+aws-fargate-kinesisstreams
+aws-fargate-opensearch
+aws-fargate-s3
+aws-fargate-secretsmanager
+aws-fargate-sns
+aws-fargate-sqs
+aws-fargate-ssmstringparameter
+aws-fargate-stepfunctions
+aws-iot-kinesisfirehose-s3
+aws-iot-kinesisstreams
+aws-iot-lambda
+aws-iot-lambda-dynamodb
+aws-iot-s3
+aws-iot-sqs
+aws-kinesisfirehose-s3
+aws-kinesisstreams-gluejob
+aws-kinesisstreams-kinesisfirehose-s3
+aws-kinesisstreams-lambda
+aws-lambda-dynamodb
+aws-lambda-elasticachememcached
+aws-lambda-elasticsearch-kibana
+aws-lambda-eventbridge
+aws-lambda-kendra
+aws-lambda-kinesisfirehose
+aws-lambda-kinesisstreams
+aws-lambda-opensearch
+aws-lambda-s3
+aws-lambda-sagemakerendpoint
+aws-lambda-secretsmanager
+aws-lambda-sns
+aws-lambda-sqs
+aws-lambda-sqs-lambda
+aws-lambda-ssmstringparameter
+aws-lambda-stepfunctions
+aws-openapigateway-lambda
+aws-route53-alb
+aws-route53-apigateway
+aws-s3-lambda
+aws-s3-sns
+aws-s3-sqs
+aws-s3-stepfunctions
+aws-sns-lambda
+aws-sns-sqs
+aws-sqs-lambda
+aws-wafwebacl-alb
+aws-wafwebacl-apigateway
+aws-wafwebacl-appsync
+aws-wafwebacl-cloudfront
 "
 
 deployment_dir=$(cd $(dirname $0) && pwd)

--- a/deployment/v2/refresh-multiple-tests.sh
+++ b/deployment/v2/refresh-multiple-tests.sh
@@ -19,82 +19,14 @@
 #   a sleep 10 command before the end of the loop to keep from overwhelming CloudFormation
 
 export constructs="
-  aws-alb-fargate
-  aws-alb-lambda
-  aws-apigateway-dynamodb
-  aws-apigateway-iot
-  aws-apigateway-kinesisstreams
-  aws-apigateway-lambda
-  aws-apigateway-sagemakerendpoint
-  aws-apigateway-sqs
-  aws-cloudfront-apigateway
   aws-cloudfront-apigateway-lambda
   aws-cloudfront-mediastore
-  aws-cloudfront-s3
-  aws-cognito-apigateway-lambda
-  aws-dynamodbstreams-lambda
-  aws-dynamodbstreams-lambda-elasticsearch-kibana
-  aws-eventbridge-kinesisfirehose-s3
-  aws-eventbridge-kinesisstreams
-  aws-eventbridge-lambda
-  aws-eventbridge-sns
-  aws-eventbridge-sqs
-  aws-eventbridge-stepfunctions
-  aws-fargate-dynamodb
-  aws-fargate-eventbridge
-  aws-fargate-kinesisfirehose
-  aws-fargate-kinesisstreams
-  aws-fargate-opensearch
-  aws-fargate-s3
-  aws-fargate-secretsmanager
-  aws-fargate-sns
-  aws-fargate-sqs
-  aws-fargate-ssmstringparameter
-  aws-fargate-stepfunctions
-  aws-iot-kinesisfirehose-s3
-  aws-iot-kinesisstreams
-  aws-iot-lambda
-  aws-iot-lambda-dynamodb
-  aws-iot-s3
-  aws-iot-sqs
-  aws-kinesisfirehose-s3
-  aws-kinesisstreams-gluejob
-  aws-kinesisstreams-kinesisfirehose-s3
-  aws-kinesisstreams-lambda
-  aws-lambda-dynamodb
-  aws-lambda-elasticachememcached
-  aws-lambda-elasticsearch-kibana
-  aws-lambda-eventbridge
-  aws-lambda-kendra
-  aws-lambda-kinesisfirehose
-  aws-lambda-kinesisstreams
-  aws-lambda-opensearch
-  aws-lambda-s3
-  aws-lambda-sagemakerendpoint
-  aws-lambda-secretsmanager
-  aws-lambda-sns
-  aws-lambda-sqs
-  aws-lambda-sqs-lambda
-  aws-lambda-ssmstringparameter
-  aws-lambda-stepfunctions
-  aws-openapigateway-lambda
-  aws-route53-alb
-  aws-route53-apigateway
-  aws-s3-lambda
-  aws-s3-sns
-  aws-s3-sqs
-  aws-s3-stepfunctions
-  aws-sns-lambda
-  aws-sns-sqs
-  aws-sqs-lambda
-  aws-wafwebacl-alb
-  aws-wafwebacl-apigateway
-  aws-wafwebacl-appsync
   aws-wafwebacl-cloudfront
 "
 
-constructs_root_dir=$(cd $(dirname $0) && pwd)
-source_dir="$constructs_root_dir/source"
+deployment_dir=$(cd $(dirname $0) && pwd)
+constructs_root_dir="$deployment_dir/../.."
+source_dir="$deployment_dir/../../source"
 
 echo "============================================================================================="
 echo "aligning versions and updating package.json for CDK v2..."

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/lib/index.ts
@@ -107,6 +107,10 @@ export class CloudFrontToApiGatewayToLambda extends Construct {
     defaults.CheckLambdaProps(props);
     // CheckCloudFrontProps() is called by internal aws-cloudfront-apigateway construct
 
+    // All our tests are based upon this behavior being on, so we're setting
+    // context here rather than assuming the client will set it
+    this.node.setContext("@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy", true);
+
     this.lambdaFunction = defaults.buildLambdaFunction(this, {
       existingLambdaObj: props.existingLambdaObj,
       lambdaFunctionProps: props.lambdaFunctionProps

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.expected.json
@@ -598,10 +598,9 @@
         "Name": "SetHttpSecurityHeadersc860b559e82562b55d86431c32566a0eb839407df7"
       }
     },
-    "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucket2E8E3DC2": {
+    "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -635,17 +634,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicyC05E1C71": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucket2E8E3DC2",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResource296BC002": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A"
+        }
+      },
+      "DependsOn": [
+        "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicyC05E1C71"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucket2E8E3DC2": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketPolicy416A95E3": {
       "Type": "AWS::S3::BucketPolicy",
@@ -910,7 +1084,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucket2E8E3DC2"
+                "Ref": "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog48BE423A"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.expected.json
@@ -634,7 +634,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "cfapigwlambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicyC05E1C71": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.expected.json
@@ -598,10 +598,9 @@
         "Name": "SetHttpSecurityHeadersc87d9e55c0a6a55f893f95e9a700c7ce19634229d0"
       }
     },
-    "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421": {
+    "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -635,17 +634,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicy521355D8": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResource2395E2A2": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57"
+        }
+      },
+      "DependsOn": [
+        "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicy521355D8"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketPolicy4A551B79": {
       "Type": "AWS::S3::BucketPolicy",
@@ -910,7 +1084,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucket7F467421"
+                "Ref": "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog347EED57"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.expected.json
@@ -634,7 +634,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfrontapigatewaylambdaCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicy521355D8": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.expected.json
@@ -595,7 +595,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicy53DB42E0": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.expected.json
@@ -559,10 +559,9 @@
         "Name": "SetHttpSecurityHeadersc826c2a6a3ffe209aed33765f37752084820de0d3b"
       }
     },
-    "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucket3A71B9E0": {
+    "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -596,17 +595,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicy53DB42E0": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucket3A71B9E0",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResource33279C95": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9"
+        }
+      },
+      "DependsOn": [
+        "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLogPolicy53DB42E0"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucket3A71B9E0": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketPolicyC3092436": {
       "Type": "AWS::S3::BucketPolicy",
@@ -949,7 +1123,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucket3A71B9E0"
+                "Ref": "cfapilambdaoverrideCloudFrontToApiGatewayCloudfrontLoggingBucketAccessLog9CEB5CD9"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/lib/index.ts
@@ -79,6 +79,11 @@ export class CloudFrontToApiGateway extends Construct {
    */
   constructor(scope: Construct, id: string, props: CloudFrontToApiGatewayProps) {
     super(scope, id);
+
+    // All our tests are based upon this behavior being on, so we're setting
+    // context here rather than assuming the client will set it
+    this.node.setContext("@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy", true);
+
     defaults.CheckCloudFrontProps(props);
 
     this.apiGateway = props.existingApiGatewayObj;

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-customCloudfrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-customCloudfrontLoggingBucket.expected.json
@@ -679,7 +679,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "cfapigwCloudfrontLoggingBucketAccessLogPolicyDB63EA7B": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-customCloudfrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-customCloudfrontLoggingBucket.expected.json
@@ -643,10 +643,9 @@
         "Name": "SetHttpSecurityHeadersc8cc607f355edae7717ef60e6468962d623a2d5ea9"
       }
     },
-    "cfapigwCloudfrontLoggingBucket79FE4195": {
+    "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -680,17 +679,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "cfapigwCloudfrontLoggingBucketAccessLogPolicyDB63EA7B": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "cfapigwCloudfrontLoggingBucket79FE4195",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "cfapigwCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResource861BCB32": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754"
+        }
+      },
+      "DependsOn": [
+        "cfapigwCloudfrontLoggingBucketAccessLogPolicyDB63EA7B"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "cfapigwCloudfrontLoggingBucket79FE4195": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "cfapigwCloudfrontLoggingBucketPolicyF5181F4F": {
       "Type": "AWS::S3::BucketPolicy",
@@ -955,7 +1129,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "cfapigwCloudfrontLoggingBucket79FE4195"
+                "Ref": "cfapigwCloudfrontLoggingBucketAccessLog6DDE9754"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-no-arguments.expected.json
@@ -643,10 +643,9 @@
         "Name": "SetHttpSecurityHeadersc8b8093f33c7dec7c3b269919bb775882671d92f95"
       }
     },
-    "testcloudfrontapigatewayCloudfrontLoggingBucket9811F6E8": {
+    "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -680,17 +679,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLogPolicy1110B389": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfrontapigatewayCloudfrontLoggingBucket9811F6E8",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceCAC0A05B": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB"
+        }
+      },
+      "DependsOn": [
+        "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLogPolicy1110B389"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontapigatewayCloudfrontLoggingBucket9811F6E8": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfrontapigatewayCloudfrontLoggingBucketPolicyAA14EB71": {
       "Type": "AWS::S3::BucketPolicy",
@@ -955,7 +1129,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "testcloudfrontapigatewayCloudfrontLoggingBucket9811F6E8"
+                "Ref": "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLog4D9DC9FB"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-no-arguments.expected.json
@@ -679,7 +679,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfrontapigatewayCloudfrontLoggingBucketAccessLogPolicy1110B389": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/lib/index.ts
@@ -87,6 +87,11 @@ export class CloudFrontToMediaStore extends Construct {
    */
   constructor(scope: Construct, id: string, props: CloudFrontToMediaStoreProps) {
     super(scope, id);
+
+    // All our tests are based upon this behavior being on, so we're setting
+    // context here rather than assuming the client will set it
+    this.node.setContext("@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy", true);
+
     defaults.CheckMediaStoreProps(props);
     defaults.CheckCloudFrontProps(props);
 

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-customCloudFrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-customCloudFrontLoggingBucket.expected.json
@@ -118,7 +118,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicyB512EE2A": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-customCloudFrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-customCloudFrontLoggingBucket.expected.json
@@ -82,10 +82,9 @@
       },
       "DeletionPolicy": "Retain"
     },
-    "cloudfrontmediastoreCloudfrontLoggingBucketE54A8D50": {
+    "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -119,17 +118,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicyB512EE2A": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "cloudfrontmediastoreCloudfrontLoggingBucketE54A8D50",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResource5D7907AB": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56"
+        }
+      },
+      "DependsOn": [
+        "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicyB512EE2A"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "cloudfrontmediastoreCloudfrontLoggingBucketE54A8D50": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "cloudfrontmediastoreCloudfrontLoggingBucketPolicyBB2766C9": {
       "Type": "AWS::S3::BucketPolicy",
@@ -436,7 +610,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "cloudfrontmediastoreCloudfrontLoggingBucketE54A8D50"
+                "Ref": "cloudfrontmediastoreCloudfrontLoggingBucketAccessLogB829BA56"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-default.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-default.expected.json
@@ -118,7 +118,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-default.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-default.expected.json
@@ -82,10 +82,9 @@
       },
       "DeletionPolicy": "Retain"
     },
-    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -119,17 +118,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceAE9C7ABE": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        }
+      },
+      "DependsOn": [
+        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketPolicyF3B44DFD": {
       "Type": "AWS::S3::BucketPolicy",
@@ -436,7 +610,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A"
+                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-existingContainer.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-existingContainer.expected.json
@@ -43,7 +43,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-existingContainer.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-existingContainer.expected.json
@@ -7,10 +7,9 @@
         "ContainerName": "MyExistingMediaStoreContainer"
       }
     },
-    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -44,17 +43,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceAE9C7ABE": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        }
+      },
+      "DependsOn": [
+        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketPolicyF3B44DFD": {
       "Type": "AWS::S3::BucketPolicy",
@@ -353,7 +527,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A"
+                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-overrideProperties.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-overrideProperties.expected.json
@@ -46,10 +46,9 @@
       },
       "DeletionPolicy": "Retain"
     },
-    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -83,17 +82,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceAE9C7ABE": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        }
+      },
+      "DependsOn": [
+        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketPolicyF3B44DFD": {
       "Type": "AWS::S3::BucketPolicy",
@@ -395,7 +569,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A"
+                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-overrideProperties.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-overrideProperties.expected.json
@@ -82,7 +82,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withSecurityHeaderBehavior.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withSecurityHeaderBehavior.expected.json
@@ -82,10 +82,9 @@
       },
       "DeletionPolicy": "Retain"
     },
-    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -113,17 +112,128 @@
         }
       },
       "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Retain"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketPolicyF3B44DFD": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withSecurityHeaderBehavior.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withSecurityHeaderBehavior.expected.json
@@ -112,7 +112,17 @@
         }
       },
       "UpdateReplacePolicy": "Retain",
-      "DeletionPolicy": "Retain"
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withoutHttpSecurityHeaders.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withoutHttpSecurityHeaders.expected.json
@@ -82,10 +82,9 @@
       },
       "DeletionPolicy": "Retain"
     },
-    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -119,17 +118,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceAE9C7ABE": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+        }
+      },
+      "DependsOn": [
+        "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketPolicyF3B44DFD": {
       "Type": "AWS::S3::BucketPolicy",
@@ -413,7 +587,7 @@
             [
               "Lambda function for auto-deleting objects in ",
               {
-                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketA3A51E6A"
+                "Ref": "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLog907A8116"
               },
               " S3 bucket."
             ]

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withoutHttpSecurityHeaders.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/test/integ.cftmed-withoutHttpSecurityHeaders.expected.json
@@ -118,7 +118,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfrontmediastoreCloudfrontLoggingBucketAccessLogPolicy7B05AE89": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-headers.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-headers.expected.json
@@ -453,7 +453,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-headers.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-headers.expected.json
@@ -417,10 +417,9 @@
         "Name": "SetHttpSecurityHeadersc8da5865185980f6eb00e7dd351786a8b49cd2929e"
       }
     },
-    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -454,17 +453,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfronts3CloudfrontLoggingBucket985C0FE8",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceE16E063D": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        }
+      },
+      "DependsOn": [
+        "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfronts3CloudfrontLoggingBucketPolicyDF55851B": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-originPath.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-originPath.expected.json
@@ -385,10 +385,9 @@
         "Name": "SetHttpSecurityHeadersc8966f7b24c95d47868a69c8831fbd3ccac3fa3d70"
       }
     },
-    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -422,17 +421,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfronts3CloudfrontLoggingBucket985C0FE8",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceE16E063D": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        }
+      },
+      "DependsOn": [
+        "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfronts3CloudfrontLoggingBucketPolicyDF55851B": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-originPath.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-originPath.expected.json
@@ -421,7 +421,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customLoggingBuckets.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customLoggingBuckets.expected.json
@@ -397,10 +397,9 @@
         "Name": "SetHttpSecurityHeadersc844fcbc00f82925aea73bcda195f6b5551bdcf3d4"
       }
     },
-    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -447,17 +446,205 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfronts3CloudfrontLoggingBucket985C0FE8",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceE16E063D": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        }
+      },
+      "DependsOn": [
+        "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "Status": "Enabled",
+              "Transitions": [
+                {
+                  "StorageClass": "GLACIER",
+                  "TransitionInDays": 7
+                }
+              ]
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfronts3CloudfrontLoggingBucketPolicyDF55851B": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customLoggingBuckets.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customLoggingBuckets.expected.json
@@ -446,7 +446,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-existing-bucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-existing-bucket.expected.json
@@ -461,10 +461,9 @@
         "Name": "SetHttpSecurityHeadersc8321a2c9fa54d380831d390bfbd7aff27f99fd427"
       }
     },
-    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -498,17 +497,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfronts3CloudfrontLoggingBucket985C0FE8",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceE16E063D": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        }
+      },
+      "DependsOn": [
+        "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfronts3CloudfrontLoggingBucketPolicyDF55851B": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-existing-bucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-existing-bucket.expected.json
@@ -497,7 +497,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-arguments.expected.json
@@ -395,10 +395,9 @@
         "Name": "SetHttpSecurityHeadersc88b3e0fe5ebfb7f401b410752c35f74a3678d5cb1"
       }
     },
-    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -432,17 +431,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfronts3CloudfrontLoggingBucket985C0FE8",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfronts3CloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResourceE16E063D": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+        }
+      },
+      "DependsOn": [
+        "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3CloudfrontLoggingBucket985C0FE8": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfronts3CloudfrontLoggingBucketAccessLog2E738D58"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfronts3CloudfrontLoggingBucketPolicyDF55851B": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-arguments.expected.json
@@ -431,7 +431,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfronts3CloudfrontLoggingBucketAccessLogPolicy526F2E14": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-security-headers.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-security-headers.expected.json
@@ -409,7 +409,17 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W35",
+              "reason": "This S3 bucket is used as the access logging bucket for another bucket"
+            }
+          ]
+        }
+      }
     },
     "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogPolicy3DF5F522": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-security-headers.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-security-headers.expected.json
@@ -373,10 +373,9 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "testcloudfronts3nosecurityheadersCloudfrontLoggingBucket92A5E2A5": {
+    "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {
@@ -410,17 +409,192 @@
         }
       },
       "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogPolicy3DF5F522": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1"
+        },
+        "PolicyDocument": {
+          "Statement": [
             {
-              "id": "W35",
-              "reason": "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn"
+                  ]
+                }
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "testcloudfronts3nosecurityheadersCloudfrontLoggingBucket92A5E2A5",
+                      "Arn"
+                    ]
+                  }
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         }
       }
+    },
+    "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogAutoDeleteObjectsCustomResource20738403": {
+      "Type": "Custom::S3AutoDeleteObjects",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn"
+          ]
+        },
+        "BucketName": {
+          "Ref": "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1"
+        }
+      },
+      "DependsOn": [
+        "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogPolicy3DF5F522"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "testcloudfronts3nosecurityheadersCloudfrontLoggingBucket92A5E2A5": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketAccessLogA3FF51B1"
+          }
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true"
+          }
+        ],
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "testcloudfronts3nosecurityheadersCloudfrontLoggingBucketPolicy7D709982": {
       "Type": "AWS::S3::BucketPolicy",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -329,7 +329,7 @@ test('Cloudfront logging bucket error when providing existing log bucket and log
   expect(app).toThrowError();
 });
 
-test('s3 bucket with one content bucket and no logging bucket', () => {
+test('s3 bucket with one content bucket and no access logging of CONTENT bucket', () => {
   const stack = new cdk.Stack();
 
   const construct = new CloudFrontToS3(stack, 'cloudfront-s3', {
@@ -340,7 +340,9 @@ test('s3 bucket with one content bucket and no logging bucket', () => {
   });
 
   const template = Template.fromStack(stack);
-  template.resourceCountIs("AWS::S3::Bucket", 2);
+  // Content bucket+Cloudfront Logs bucket+
+  // Access Log bucket for Cloudfront Logs bucket = 3 buckets
+  template.resourceCountIs("AWS::S3::Bucket", 3);
   expect(construct.s3LoggingBucket).toEqual(undefined);
 });
 

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/lib/index.ts
@@ -59,6 +59,10 @@ export class WafwebaclToCloudFront extends Construct {
     super(scope, id);
     defaults.CheckWafWebAclProps(props);
 
+    // All our tests are based upon this behavior being on, so we're setting
+    // context here rather than assuming the client will set it
+    this.node.setContext("@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy", true);
+
     // Build the Web ACL
     this.webacl = defaults.buildWebacl(this, 'CLOUDFRONT', {
       existingWebaclObj: props.existingWebaclObj,

--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
@@ -27,7 +27,7 @@ import {
   DefaultCloudFrontDistributionForMediaStoreProps
 } from './cloudfront-distribution-defaults';
 import { addCfnSuppressRules, consolidateProps } from './utils';
-import { createLoggingBucket } from './s3-bucket-helper';
+import { createCloudFrontLoggingBucket } from './s3-bucket-helper';
 import { DefaultS3Props } from './s3-bucket-defaults';
 // Note: To ensure CDKv2 compatibility, keep the import statement for Construct separate
 import { Construct } from 'constructs';
@@ -250,7 +250,7 @@ function getLoggingBucket(
   } else if (userSuppliedLogBucket) {
     bucketResult = userSuppliedLogBucket;
   } else {
-    bucketResult = createLoggingBucket(
+    bucketResult = createCloudFrontLoggingBucket(
       scope,
       'CloudfrontLoggingBucket',
       consolidateProps(DefaultS3Props(), cloudFrontLoggingBucketProps, { objectOwnership: s3.ObjectOwnership.OBJECT_WRITER }));

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
@@ -97,6 +97,12 @@ export function createCloudFrontLoggingBucket(scope: Construct,
   const combinedBucketProps = consolidateProps(DefaultS3Props(), loggingBucketProps);
 
   const accessLogBucket: s3.Bucket = new s3.Bucket(scope, `${bucketId}AccessLog`, combinedBucketProps); // NOSONAR
+  addCfnSuppressRules(accessLogBucket, [
+    {
+      id: 'W35',
+      reason: "This S3 bucket is used as the access logging bucket for another bucket"
+    }
+  ]);
 
   // Create the Logging Bucket
   // NOSONAR  (typescript:S6281)

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-bucket-helper.ts
@@ -52,7 +52,7 @@ export interface BuildS3BucketProps {
 /**
  * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
  */
-export function createLoggingBucket(scope: Construct,
+export function createS3AccessLoggingBucket(scope: Construct,
   bucketId: string,
   loggingBucketProps: s3.BucketProps): s3.Bucket {
 
@@ -75,23 +75,46 @@ export function createLoggingBucket(scope: Construct,
   // Verified by unit test 's3 bucket with default props'
   const loggingBucket: s3.Bucket = new s3.Bucket(scope, bucketId, combinedBucketProps); // NOSONAR
 
-  // Extract the CfnBucket from the loggingBucket
-  const loggingBucketResource = loggingBucket.node.findChild('Resource') as s3.CfnBucket;
-
-  let _reason = "This S3 bucket is used as the access logging bucket for another bucket";
-
-  if (bucketId === 'CloudfrontLoggingBucket') {
-    _reason = "This S3 bucket is used as the access logging bucket for CloudFront Distribution";
-  }
-
-  addCfnSuppressRules(loggingBucketResource, [
+  addCfnSuppressRules(loggingBucket, [
     {
       id: 'W35',
-      reason: _reason
+      reason: "This S3 bucket is used as the access logging bucket for another bucket"
     }
   ]);
 
   return loggingBucket;
+}
+
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ */
+export function createCloudFrontLoggingBucket(scope: Construct,
+  bucketId: string,
+  loggingBucketProps: s3.BucketProps): s3.Bucket {
+
+  // Introduce the default props since we can't be certain the caller used them and
+  // they are important best practices
+  const combinedBucketProps = consolidateProps(DefaultS3Props(), loggingBucketProps);
+
+  const accessLogBucket: s3.Bucket = new s3.Bucket(scope, `${bucketId}AccessLog`, combinedBucketProps); // NOSONAR
+
+  // Create the Logging Bucket
+  // NOSONAR  (typescript:S6281)
+  // Block Public Access is set by DefaultS3Props, but Sonarqube can't detect it
+  // It is verified by 's3 bucket with default props' in the unit tests
+  // NOSONAR (typescript:S6245)
+  // Encryption is turned on in the default properties that Sonarqube doesn't see
+  // Verified by unit test 's3 bucket with default props'
+  // NOSONAR (typescript:S6249)
+  // enforceSSL  is turned on in the default properties that Sonarqube doesn't see
+  // Verified by unit test 's3 bucket with default props'
+  // NOSONAR (typescript:typescript:S6249)
+  // versioning is turned on in the default properties that Sonarqube doesn't see
+  // Verified by unit test 's3 bucket with default props'
+  const cloudfrontLogBucketProps = overrideProps(combinedBucketProps, { serverAccessLogsBucket: accessLogBucket });
+  const cloudfrontLogBucket: s3.Bucket = new s3.Bucket(scope, bucketId, cloudfrontLogBucketProps); // NOSONAR
+
+  return cloudfrontLogBucket;
 }
 
 /**
@@ -173,7 +196,7 @@ export function buildS3Bucket(scope: Construct,
       loggingBucketProps = overrideProps(loggingBucketProps, { removalPolicy: props.bucketProps.removalPolicy });
     }
 
-    loggingBucket = createLoggingBucket(scope, loggingBucketId, loggingBucketProps);
+    loggingBucket = createS3AccessLoggingBucket(scope, loggingBucketId, loggingBucketProps);
   } else if (props.bucketProps?.serverAccessLogsBucket) {
     loggingBucket = props.bucketProps?.serverAccessLogsBucket as s3.Bucket;
   }

--- a/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-s3-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/cloudfront-distribution-s3-helper.test.ts
@@ -42,25 +42,6 @@ test('check bucket policy metadata', () => {
   });
 });
 
-test('check bucket metadata', () => {
-  const stack = new Stack();
-  const buildS3BucketResponse = buildS3Bucket(stack, {});
-  CloudFrontDistributionForS3(stack, buildS3BucketResponse.bucket);
-  const template = Template.fromStack(stack);
-  template.hasResource('AWS::S3::Bucket', {
-    Metadata: {
-      cfn_nag: {
-        rules_to_suppress: [
-          {
-            id: "W35",
-            reason: "This S3 bucket is used as the access logging bucket for CloudFront Distribution"
-          }
-        ]
-      }
-    }
-  });
-});
-
 test('test cloudfront check bucket policy', () => {
   const stack = new Stack();
   const buildS3BucketResponse = buildS3Bucket(stack, {});


### PR DESCRIPTION
*Issue #, if available:*
Addresses Issue #1041 

*Description of changes:*
Adds s3 access logging to the CloudFront log buckets by default

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.