### PR TITLE
feat(aws-cloudfront-apigateway-lambda): require explicit authentication type

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/lib/index.ts
@@ -127,7 +127,13 @@ export class CloudFrontToApiGatewayToLambda extends Construct {
       lambdaFunctionProps: props.lambdaFunctionProps
     });
 
-    const regionalLambdaRestApiResponse = defaults.RegionalLambdaRestApi(this, this.lambdaFunction, props.apiGatewayProps, props.logGroupProps);
+    // We can't default to IAM authentication with a CloudFront distribution, so
+    // we'll instruct core to not use any default auth to avoid override warnings
+    const regionalLambdaRestApiResponse = defaults.RegionalLambdaRestApi(this,
+      this.lambdaFunction,
+      props.apiGatewayProps,
+      props.logGroupProps,
+      false);
     this.apiGateway = regionalLambdaRestApiResponse.api;
     this.apiGatewayCloudWatchRole = regionalLambdaRestApiResponse.role;
     this.apiGatewayLogGroup = regionalLambdaRestApiResponse.group;

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/lib/index.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/lib/index.ts
@@ -39,11 +39,14 @@ export interface CloudFrontToApiGatewayToLambdaProps {
    */
   readonly lambdaFunctionProps?: lambda.FunctionProps
   /**
-   * Optional user provided props to override the default props for the API Gateway.
+   * User provided props to override the default props for the API Gateway. As of release
+   * 2.48.0, clients must include this property with defaultMethodOptions: { authorizationType: string } specified.
+   * See Issue1043 in the github repo https://github.com/awslabs/aws-solutions-constructs/issues/1043
    *
-   * @default - Default props are used
+   * @default - defaultMethodOptions/authorizationType is required, for other, unspecified values the
+   * default props are used
    */
-  readonly apiGatewayProps?: api.LambdaRestApiProps | any
+  readonly apiGatewayProps: api.LambdaRestApiProps | any
   /**
    * Optional user provided props to override the default props
    *
@@ -106,6 +109,14 @@ export class CloudFrontToApiGatewayToLambda extends Construct {
     super(scope, id);
     defaults.CheckLambdaProps(props);
     // CheckCloudFrontProps() is called by internal aws-cloudfront-apigateway construct
+    if (!props.apiGatewayProps?.defaultMethodOptions?.authorizationType) {
+      defaults.printWarning('As of v2.48.0, apiGatewayProps.defaultMethodOptions.authorizationType is\
+      required. To update your instantiation call, add the following to your CloudFrontToApiGatewayToLambdaProps argument\
+      \n\napiGatewayProps: { defaultMethodOptions: { authorizationType: api.AuthorizationType.NONE }},\n\nSee Issue1043 for an explanation.');
+      throw new Error('As of v2.48.0, an explicit authorization type is required for CloudFront/API Gateway patterns');
+    } else if (props.apiGatewayProps.defaultMethodOptions.authorizationType === "AWS_IAM") {
+      throw new Error('Amazon API Gateway Rest APIs integrated with Amazon CloudFront do not support AWS_IAM authorization');
+    }
 
     // All our tests are based upon this behavior being on, so we're setting
     // context here rather than assuming the client will set it
@@ -120,22 +131,6 @@ export class CloudFrontToApiGatewayToLambda extends Construct {
     this.apiGateway = regionalLambdaRestApiResponse.api;
     this.apiGatewayCloudWatchRole = regionalLambdaRestApiResponse.role;
     this.apiGatewayLogGroup = regionalLambdaRestApiResponse.group;
-
-    this.apiGateway.methods.forEach((apiMethod) => {
-      // Override the API Gateway Authorization Type from AWS_IAM to NONE
-      const child = apiMethod.node.findChild('Resource') as api.CfnMethod;
-      if (child.authorizationType === 'AWS_IAM') {
-        child.addPropertyOverride('AuthorizationType', 'NONE');
-
-        defaults.addCfnSuppressRules(apiMethod, [
-          {
-            id: 'W59',
-            reason: `AWS::ApiGateway::Method AuthorizationType is set to 'NONE' because API Gateway behind CloudFront does not support AWS_IAM authentication`
-          },
-        ]);
-
-      }
-    });
 
     const apiCloudfront: CloudFrontToApiGateway = new CloudFrontToApiGateway(this, 'CloudFrontToApiGateway', {
       existingApiGatewayObj: this.apiGateway,

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.expected.json
@@ -1,6 +1,177 @@
 {
   "Description": "Integration Test for aws-cloudfront-apigateway-lambda custom Cloudfront Logging Bucket",
   "Resources": {
+    "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunctionServiceRole00AAA44C": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunction86ECA8C3": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+          },
+          "S3Key": "42a35bbf0dec9ef0ac5b0dde87e71a1b8929e8d2d178dd09ccfb2c928ec0198c.zip"
+        },
+        "Handler": ".handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunctionServiceRole00AAA44C",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs16.x"
+      },
+      "DependsOn": [
+        "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunctionServiceRole00AAA44C"
+      ],
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W58",
+              "reason": "Test Resource"
+            },
+            {
+              "id": "W89",
+              "reason": "Test Resource"
+            },
+            {
+              "id": "W92",
+              "reason": "Test Resource"
+            }
+          ]
+        }
+      }
+    },
+    "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunctioncftaplamcustomCloudfrontLoggingBucketcftaplamcustomCloudfrontLoggingBucketauthorizer02C97B0FPermissionsBF8A1A3B": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunction86ECA8C3",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "cfapigwlambdaLambdaRestApi775C255B"
+              },
+              "/authorizers/",
+              {
+                "Ref": "cftaplamcustomCloudfrontLoggingBucketauthorizer4D180075"
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "cftaplamcustomCloudfrontLoggingBucketauthorizer4D180075": {
+      "Type": "AWS::ApiGateway::Authorizer",
+      "Properties": {
+        "AuthorizerUri": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Fn::Select": [
+                  1,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunction86ECA8C3",
+                          "Arn"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              ":apigateway:",
+              {
+                "Fn::Select": [
+                  3,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunction86ECA8C3",
+                          "Arn"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "cftaplamcustomCloudfrontLoggingBucketauthorizerAuthFunction86ECA8C3",
+                  "Arn"
+                ]
+              },
+              "/invocations"
+            ]
+          ]
+        },
+        "IdentitySource": "method.request.header.Authorization",
+        "Name": "cftaplamcustomCloudfrontLoggingBucketcftaplamcustomCloudfrontLoggingBucketauthorizer02C97B0F",
+        "RestApiId": {
+          "Ref": "cfapigwlambdaLambdaRestApi775C255B"
+        },
+        "Type": "REQUEST"
+      }
+    },
     "cfapigwlambdaLambdaFunctionServiceRole9B40D826": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -169,7 +340,7 @@
         "Name": "LambdaRestApi"
       }
     },
-    "cfapigwlambdaLambdaRestApiDeployment33C24C7D5b6eb6dc887b9e8b9bde9a765f4aacbb": {
+    "cfapigwlambdaLambdaRestApiDeployment33C24C7D41e6d6ff15b0c6d292b31cce930b3216": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -206,7 +377,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "cfapigwlambdaLambdaRestApiDeployment33C24C7D5b6eb6dc887b9e8b9bde9a765f4aacbb"
+          "Ref": "cfapigwlambdaLambdaRestApiDeployment33C24C7D41e6d6ff15b0c6d292b31cce930b3216"
         },
         "MethodSettings": [
           {
@@ -319,7 +490,10 @@
     "cfapigwlambdaLambdaRestApiproxyANY68181290": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "cftaplamcustomCloudfrontLoggingBucketauthorizer4D180075"
+        },
         "HttpMethod": "ANY",
         "Integration": {
           "IntegrationHttpMethod": "POST",
@@ -353,16 +527,6 @@
         },
         "RestApiId": {
           "Ref": "cfapigwlambdaLambdaRestApi775C255B"
-        }
-      },
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "W59",
-              "reason": "AWS::ApiGateway::Method AuthorizationType is set to 'NONE' because API Gateway behind CloudFront does not support AWS_IAM authentication"
-            }
-          ]
         }
       }
     },
@@ -447,7 +611,10 @@
     "cfapigwlambdaLambdaRestApiANY81C176E9": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "cftaplamcustomCloudfrontLoggingBucketauthorizer4D180075"
+        },
         "HttpMethod": "ANY",
         "Integration": {
           "IntegrationHttpMethod": "POST",
@@ -484,16 +651,6 @@
         },
         "RestApiId": {
           "Ref": "cfapigwlambdaLambdaRestApi775C255B"
-        }
-      },
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "W59",
-              "reason": "AWS::ApiGateway::Method AuthorizationType is set to 'NONE' because API Gateway behind CloudFront does not support AWS_IAM authentication"
-            }
-          ]
         }
       }
     },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-customCloudfrontLoggingBucket.ts
@@ -16,7 +16,8 @@ import { App, Stack, RemovalPolicy } from "aws-cdk-lib";
 import { CloudFrontToApiGatewayToLambda } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { BucketEncryption } from "aws-cdk-lib/aws-s3";
-import { generateIntegStackName, suppressAutoDeleteHandlerWarnings } from '@aws-solutions-constructs/core';
+import { generateIntegStackName, suppressAutoDeleteHandlerWarnings, CreateApiAuthorizer } from '@aws-solutions-constructs/core';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 
 // Setup
 const app = new App();
@@ -24,6 +25,12 @@ const stack = new Stack(app, generateIntegStackName(__filename));
 stack.templateOptions.description = 'Integration Test for aws-cloudfront-apigateway-lambda custom Cloudfront Logging Bucket';
 
 new CloudFrontToApiGatewayToLambda(stack, 'cf-apigw-lambda', {
+  apiGatewayProps: {
+    defaultMethodOptions: {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: CreateApiAuthorizer(stack, `${generateIntegStackName(__filename)}-authorizer`)
+    },
+  },
   lambdaFunctionProps: {
     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
     runtime: lambda.Runtime.NODEJS_16_X,

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.expected.json
@@ -1,6 +1,177 @@
 {
   "Description": "Integration Test for aws-cloudfront-apigateway-lambda",
   "Resources": {
+    "cftaplamnoargumentsauthorizerAuthFunctionServiceRole122160C6": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    "cftaplamnoargumentsauthorizerAuthFunction9B127993": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+          },
+          "S3Key": "42a35bbf0dec9ef0ac5b0dde87e71a1b8929e8d2d178dd09ccfb2c928ec0198c.zip"
+        },
+        "Handler": ".handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "cftaplamnoargumentsauthorizerAuthFunctionServiceRole122160C6",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs16.x"
+      },
+      "DependsOn": [
+        "cftaplamnoargumentsauthorizerAuthFunctionServiceRole122160C6"
+      ],
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W58",
+              "reason": "Test Resource"
+            },
+            {
+              "id": "W89",
+              "reason": "Test Resource"
+            },
+            {
+              "id": "W92",
+              "reason": "Test Resource"
+            }
+          ]
+        }
+      }
+    },
+    "cftaplamnoargumentsauthorizerAuthFunctioncftaplamnoargumentscftaplamnoargumentsauthorizer14876A7BPermissionsE711C432": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "cftaplamnoargumentsauthorizerAuthFunction9B127993",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "testcloudfrontapigatewaylambdaLambdaRestApi6A4CBD44"
+              },
+              "/authorizers/",
+              {
+                "Ref": "cftaplamnoargumentsauthorizerD7B341B1"
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "cftaplamnoargumentsauthorizerD7B341B1": {
+      "Type": "AWS::ApiGateway::Authorizer",
+      "Properties": {
+        "AuthorizerUri": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Fn::Select": [
+                  1,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "cftaplamnoargumentsauthorizerAuthFunction9B127993",
+                          "Arn"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              ":apigateway:",
+              {
+                "Fn::Select": [
+                  3,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "cftaplamnoargumentsauthorizerAuthFunction9B127993",
+                          "Arn"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "cftaplamnoargumentsauthorizerAuthFunction9B127993",
+                  "Arn"
+                ]
+              },
+              "/invocations"
+            ]
+          ]
+        },
+        "IdentitySource": "method.request.header.Authorization",
+        "Name": "cftaplamnoargumentscftaplamnoargumentsauthorizer14876A7B",
+        "RestApiId": {
+          "Ref": "testcloudfrontapigatewaylambdaLambdaRestApi6A4CBD44"
+        },
+        "Type": "REQUEST"
+      }
+    },
     "testcloudfrontapigatewaylambdaLambdaFunctionServiceRoleCB74590F": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -169,7 +340,7 @@
         "Name": "LambdaRestApi"
       }
     },
-    "testcloudfrontapigatewaylambdaLambdaRestApiDeployment0C4661C03abb023c303d9e3ff2b4d984cd5d60ab": {
+    "testcloudfrontapigatewaylambdaLambdaRestApiDeployment0C4661C0be4652c0c81d13dbdf8cd82fdf384ca9": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -206,7 +377,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "testcloudfrontapigatewaylambdaLambdaRestApiDeployment0C4661C03abb023c303d9e3ff2b4d984cd5d60ab"
+          "Ref": "testcloudfrontapigatewaylambdaLambdaRestApiDeployment0C4661C0be4652c0c81d13dbdf8cd82fdf384ca9"
         },
         "MethodSettings": [
           {
@@ -319,7 +490,10 @@
     "testcloudfrontapigatewaylambdaLambdaRestApiproxyANYAE500A13": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "cftaplamnoargumentsauthorizerD7B341B1"
+        },
         "HttpMethod": "ANY",
         "Integration": {
           "IntegrationHttpMethod": "POST",
@@ -353,16 +527,6 @@
         },
         "RestApiId": {
           "Ref": "testcloudfrontapigatewaylambdaLambdaRestApi6A4CBD44"
-        }
-      },
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "W59",
-              "reason": "AWS::ApiGateway::Method AuthorizationType is set to 'NONE' because API Gateway behind CloudFront does not support AWS_IAM authentication"
-            }
-          ]
         }
       }
     },
@@ -447,7 +611,10 @@
     "testcloudfrontapigatewaylambdaLambdaRestApiANYBC435DFD": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "cftaplamnoargumentsauthorizerD7B341B1"
+        },
         "HttpMethod": "ANY",
         "Integration": {
           "IntegrationHttpMethod": "POST",
@@ -484,16 +651,6 @@
         },
         "RestApiId": {
           "Ref": "testcloudfrontapigatewaylambdaLambdaRestApi6A4CBD44"
-        }
-      },
-      "Metadata": {
-        "cfn_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "W59",
-              "reason": "AWS::ApiGateway::Method AuthorizationType is set to 'NONE' because API Gateway behind CloudFront does not support AWS_IAM authentication"
-            }
-          ]
         }
       }
     },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-no-arguments.ts
@@ -15,7 +15,8 @@
 import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
 import { CloudFrontToApiGatewayToLambda } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import { generateIntegStackName, suppressAutoDeleteHandlerWarnings } from '@aws-solutions-constructs/core';
+import { generateIntegStackName, suppressAutoDeleteHandlerWarnings, CreateApiAuthorizer } from '@aws-solutions-constructs/core';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 
 // Setup
 const app = new App();
@@ -29,6 +30,12 @@ const lambdaProps: lambda.FunctionProps = {
 };
 
 new CloudFrontToApiGatewayToLambda(stack, 'test-cloudfront-apigateway-lambda', {
+  apiGatewayProps: {
+    defaultMethodOptions: {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: CreateApiAuthorizer(stack, `${generateIntegStackName(__filename)}-authorizer`)
+    },
+  },
   lambdaFunctionProps: lambdaProps,
   cloudFrontLoggingBucketProps: {
     removalPolicy: RemovalPolicy.DESTROY,

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.expected.json
@@ -49,6 +49,177 @@
         }
       }
     },
+    "cftaplamoverridebehaviorauthorizerAuthFunctionServiceRoleA606974F": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    "cftaplamoverridebehaviorauthorizerAuthFunction9DD827D6": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+          },
+          "S3Key": "42a35bbf0dec9ef0ac5b0dde87e71a1b8929e8d2d178dd09ccfb2c928ec0198c.zip"
+        },
+        "Handler": ".handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "cftaplamoverridebehaviorauthorizerAuthFunctionServiceRoleA606974F",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs16.x"
+      },
+      "DependsOn": [
+        "cftaplamoverridebehaviorauthorizerAuthFunctionServiceRoleA606974F"
+      ],
+      "Metadata": {
+        "cfn_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "W58",
+              "reason": "Test Resource"
+            },
+            {
+              "id": "W89",
+              "reason": "Test Resource"
+            },
+            {
+              "id": "W92",
+              "reason": "Test Resource"
+            }
+          ]
+        }
+      }
+    },
+    "cftaplamoverridebehaviorauthorizerAuthFunctioncftaplamoverridebehaviorcftaplamoverridebehaviorauthorizer3042C32CPermissions33B8870B": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "cftaplamoverridebehaviorauthorizerAuthFunction9DD827D6",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "cfapilambdaoverrideLambdaRestApi6E7952FC"
+              },
+              "/authorizers/",
+              {
+                "Ref": "cftaplamoverridebehaviorauthorizer74D77225"
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "cftaplamoverridebehaviorauthorizer74D77225": {
+      "Type": "AWS::ApiGateway::Authorizer",
+      "Properties": {
+        "AuthorizerUri": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Fn::Select": [
+                  1,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "cftaplamoverridebehaviorauthorizerAuthFunction9DD827D6",
+                          "Arn"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              ":apigateway:",
+              {
+                "Fn::Select": [
+                  3,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "cftaplamoverridebehaviorauthorizerAuthFunction9DD827D6",
+                          "Arn"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "cftaplamoverridebehaviorauthorizerAuthFunction9DD827D6",
+                  "Arn"
+                ]
+              },
+              "/invocations"
+            ]
+          ]
+        },
+        "IdentitySource": "method.request.header.Authorization",
+        "Name": "cftaplamoverridebehaviorcftaplamoverridebehaviorauthorizer3042C32C",
+        "RestApiId": {
+          "Ref": "cfapilambdaoverrideLambdaRestApi6E7952FC"
+        },
+        "Type": "REQUEST"
+      }
+    },
     "cfapilambdaoverrideLambdaFunctionServiceRole4B1A4043": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -217,7 +388,7 @@
         "Name": "LambdaRestApi"
       }
     },
-    "cfapilambdaoverrideLambdaRestApiDeployment82ACBB00e7f3a114a506221ddcaf53765c4dd518": {
+    "cfapilambdaoverrideLambdaRestApiDeployment82ACBB00a88f54114ca67f75c1f46116226ebd9d": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -255,7 +426,7 @@
           "Format": "{\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"user\":\"$context.identity.user\",\"caller\":\"$context.identity.caller\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"status\":\"$context.status\",\"protocol\":\"$context.protocol\",\"responseLength\":\"$context.responseLength\"}"
         },
         "DeploymentId": {
-          "Ref": "cfapilambdaoverrideLambdaRestApiDeployment82ACBB00e7f3a114a506221ddcaf53765c4dd518"
+          "Ref": "cfapilambdaoverrideLambdaRestApiDeployment82ACBB00a88f54114ca67f75c1f46116226ebd9d"
         },
         "MethodSettings": [
           {
@@ -290,7 +461,10 @@
     "cfapilambdaoverrideLambdaRestApistaticGET81EF9C24": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "cftaplamoverridebehaviorauthorizer74D77225"
+        },
         "HttpMethod": "GET",
         "Integration": {
           "IntegrationHttpMethod": "GET",
@@ -411,7 +585,10 @@
     "cfapilambdaoverrideLambdaRestApidynamicGET15050D54": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "cftaplamoverridebehaviorauthorizer74D77225"
+        },
         "HttpMethod": "GET",
         "Integration": {
           "IntegrationHttpMethod": "POST",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/integ.cftaplam-override-behavior.ts
@@ -20,7 +20,7 @@ import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as cdk from 'aws-cdk-lib';
 import { Duration } from "aws-cdk-lib";
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
-import { generateIntegStackName, suppressAutoDeleteHandlerWarnings } from '@aws-solutions-constructs/core';
+import { generateIntegStackName, suppressAutoDeleteHandlerWarnings, CreateApiAuthorizer } from '@aws-solutions-constructs/core';
 
 // Setup
 const app = new App();
@@ -54,7 +54,8 @@ const construct = new CloudFrontToApiGatewayToLambda(stack, 'cf-api-lambda-overr
   apiGatewayProps: {
     proxy: false,
     defaultMethodOptions: {
-      authorizationType: apigateway.AuthorizationType.NONE,
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: CreateApiAuthorizer(stack, `${generateIntegStackName(__filename)}-authorizer`)
     },
   },
   cloudFrontDistributionProps: {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-customCloudfrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-customCloudfrontLoggingBucket.expected.json
@@ -72,7 +72,7 @@
         }
       }
     },
-    "cftapicustomCloudfrontLoggingBucketapiAuthFunctionServiceRole3CEABBB5": {
+    "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunctionServiceRole13E010C8": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -103,7 +103,7 @@
         ]
       }
     },
-    "cftapicustomCloudfrontLoggingBucketapiAuthFunctionC39181D9": {
+    "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunction38CBEC38": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -115,14 +115,14 @@
         "Handler": ".handler",
         "Role": {
           "Fn::GetAtt": [
-            "cftapicustomCloudfrontLoggingBucketapiAuthFunctionServiceRole3CEABBB5",
+            "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunctionServiceRole13E010C8",
             "Arn"
           ]
         },
         "Runtime": "nodejs16.x"
       },
       "DependsOn": [
-        "cftapicustomCloudfrontLoggingBucketapiAuthFunctionServiceRole3CEABBB5"
+        "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunctionServiceRole13E010C8"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -143,13 +143,13 @@
         }
       }
     },
-    "cftapicustomCloudfrontLoggingBucketapiAuthFunctioncftapicustomCloudfrontLoggingBucketcftapicustomCloudfrontLoggingBucketapiauthorizerFD948D42Permissions0550732B": {
+    "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunctioncftapicustomCloudfrontLoggingBucketcftapicustomCloudfrontLoggingBucketapiauthorizerFD948D42Permissions5BB59610": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "cftapicustomCloudfrontLoggingBucketapiAuthFunctionC39181D9",
+            "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunction38CBEC38",
             "Arn"
           ]
         },
@@ -199,7 +199,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "cftapicustomCloudfrontLoggingBucketapiAuthFunctionC39181D9",
+                          "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunction38CBEC38",
                           "Arn"
                         ]
                       }
@@ -216,7 +216,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "cftapicustomCloudfrontLoggingBucketapiAuthFunctionC39181D9",
+                          "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunction38CBEC38",
                           "Arn"
                         ]
                       }
@@ -227,7 +227,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "cftapicustomCloudfrontLoggingBucketapiAuthFunctionC39181D9",
+                  "cftapicustomCloudfrontLoggingBucketapiauthorizerAuthFunction38CBEC38",
                   "Arn"
                 ]
               },

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/test/integ.cftapi-no-arguments.expected.json
@@ -72,7 +72,7 @@
         }
       }
     },
-    "cftapinoargumentsapiAuthFunctionServiceRole97907F32": {
+    "cftapinoargumentsapiauthorizerAuthFunctionServiceRole33BC576C": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -103,7 +103,7 @@
         ]
       }
     },
-    "cftapinoargumentsapiAuthFunctionFCC239B2": {
+    "cftapinoargumentsapiauthorizerAuthFunction5A0061F7": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -115,14 +115,14 @@
         "Handler": ".handler",
         "Role": {
           "Fn::GetAtt": [
-            "cftapinoargumentsapiAuthFunctionServiceRole97907F32",
+            "cftapinoargumentsapiauthorizerAuthFunctionServiceRole33BC576C",
             "Arn"
           ]
         },
         "Runtime": "nodejs16.x"
       },
       "DependsOn": [
-        "cftapinoargumentsapiAuthFunctionServiceRole97907F32"
+        "cftapinoargumentsapiauthorizerAuthFunctionServiceRole33BC576C"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -143,13 +143,13 @@
         }
       }
     },
-    "cftapinoargumentsapiAuthFunctioncftapinoargumentscftapinoargumentsapiauthorizerCA624E68Permissions8A31DDB0": {
+    "cftapinoargumentsapiauthorizerAuthFunctioncftapinoargumentscftapinoargumentsapiauthorizerCA624E68Permissions3907BB66": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "cftapinoargumentsapiAuthFunctionFCC239B2",
+            "cftapinoargumentsapiauthorizerAuthFunction5A0061F7",
             "Arn"
           ]
         },
@@ -199,7 +199,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "cftapinoargumentsapiAuthFunctionFCC239B2",
+                          "cftapinoargumentsapiauthorizerAuthFunction5A0061F7",
                           "Arn"
                         ]
                       }
@@ -216,7 +216,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "cftapinoargumentsapiAuthFunctionFCC239B2",
+                          "cftapinoargumentsapiauthorizerAuthFunction5A0061F7",
                           "Arn"
                         ]
                       }
@@ -227,7 +227,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "cftapinoargumentsapiAuthFunctionFCC239B2",
+                  "cftapinoargumentsapiauthorizerAuthFunction5A0061F7",
                   "Arn"
                 ]
               },

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/integ.wafapi-existing-waf-to-multiple-gateways.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/integ.wafapi-existing-waf-to-multiple-gateways.expected.json
@@ -71,7 +71,7 @@
         }
       }
     },
-    "testOneAuthFunctionServiceRole08948D81": {
+    "testOneauthorizerAuthFunctionServiceRoleE1B4208E": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -102,7 +102,7 @@
         ]
       }
     },
-    "testOneAuthFunction09B411BE": {
+    "testOneauthorizerAuthFunctionB12D8D93": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -114,14 +114,14 @@
         "Handler": ".handler",
         "Role": {
           "Fn::GetAtt": [
-            "testOneAuthFunctionServiceRole08948D81",
+            "testOneauthorizerAuthFunctionServiceRoleE1B4208E",
             "Arn"
           ]
         },
         "Runtime": "nodejs16.x"
       },
       "DependsOn": [
-        "testOneAuthFunctionServiceRole08948D81"
+        "testOneauthorizerAuthFunctionServiceRoleE1B4208E"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -142,13 +142,13 @@
         }
       }
     },
-    "testOneAuthFunctionwafapiexistingwaftomultiplegatewaystestOneauthorizer7F4D0710PermissionsB6FB990A": {
+    "testOneauthorizerAuthFunctionwafapiexistingwaftomultiplegatewaystestOneauthorizer7F4D0710Permissions21D6CD33": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "testOneAuthFunction09B411BE",
+            "testOneauthorizerAuthFunctionB12D8D93",
             "Arn"
           ]
         },
@@ -198,7 +198,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testOneAuthFunction09B411BE",
+                          "testOneauthorizerAuthFunctionB12D8D93",
                           "Arn"
                         ]
                       }
@@ -215,7 +215,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testOneAuthFunction09B411BE",
+                          "testOneauthorizerAuthFunctionB12D8D93",
                           "Arn"
                         ]
                       }
@@ -226,7 +226,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "testOneAuthFunction09B411BE",
+                  "testOneauthorizerAuthFunctionB12D8D93",
                   "Arn"
                 ]
               },
@@ -701,7 +701,7 @@
         }
       }
     },
-    "testTwoAuthFunctionServiceRole711DF356": {
+    "testTwoauthorizerAuthFunctionServiceRole4C3292A3": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -732,7 +732,7 @@
         ]
       }
     },
-    "testTwoAuthFunctionCD4DE414": {
+    "testTwoauthorizerAuthFunction1DBBD707": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -744,14 +744,14 @@
         "Handler": ".handler",
         "Role": {
           "Fn::GetAtt": [
-            "testTwoAuthFunctionServiceRole711DF356",
+            "testTwoauthorizerAuthFunctionServiceRole4C3292A3",
             "Arn"
           ]
         },
         "Runtime": "nodejs16.x"
       },
       "DependsOn": [
-        "testTwoAuthFunctionServiceRole711DF356"
+        "testTwoauthorizerAuthFunctionServiceRole4C3292A3"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -772,13 +772,13 @@
         }
       }
     },
-    "testTwoAuthFunctionwafapiexistingwaftomultiplegatewaystestTwoauthorizer9B2C525EPermissionsE4DE5C10": {
+    "testTwoauthorizerAuthFunctionwafapiexistingwaftomultiplegatewaystestTwoauthorizer9B2C525EPermissions44287234": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "testTwoAuthFunctionCD4DE414",
+            "testTwoauthorizerAuthFunction1DBBD707",
             "Arn"
           ]
         },
@@ -828,7 +828,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testTwoAuthFunctionCD4DE414",
+                          "testTwoauthorizerAuthFunction1DBBD707",
                           "Arn"
                         ]
                       }
@@ -845,7 +845,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testTwoAuthFunctionCD4DE414",
+                          "testTwoauthorizerAuthFunction1DBBD707",
                           "Arn"
                         ]
                       }
@@ -856,7 +856,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "testTwoAuthFunctionCD4DE414",
+                  "testTwoauthorizerAuthFunction1DBBD707",
                   "Arn"
                 ]
               },

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/integ.wafapi-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/integ.wafapi-no-arguments.expected.json
@@ -71,7 +71,7 @@
         }
       }
     },
-    "testAuthFunctionServiceRole67229217": {
+    "testauthorizerAuthFunctionServiceRole6F05059E": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -102,7 +102,7 @@
         ]
       }
     },
-    "testAuthFunctionDEE315BB": {
+    "testauthorizerAuthFunctionCE2F3743": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -114,14 +114,14 @@
         "Handler": ".handler",
         "Role": {
           "Fn::GetAtt": [
-            "testAuthFunctionServiceRole67229217",
+            "testauthorizerAuthFunctionServiceRole6F05059E",
             "Arn"
           ]
         },
         "Runtime": "nodejs16.x"
       },
       "DependsOn": [
-        "testAuthFunctionServiceRole67229217"
+        "testauthorizerAuthFunctionServiceRole6F05059E"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -142,13 +142,13 @@
         }
       }
     },
-    "testAuthFunctionwafapinoargumentstestauthorizerB886165DPermissions26C374CC": {
+    "testauthorizerAuthFunctionwafapinoargumentstestauthorizerB886165DPermissions0BD74048": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "testAuthFunctionDEE315BB",
+            "testauthorizerAuthFunctionCE2F3743",
             "Arn"
           ]
         },
@@ -198,7 +198,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testAuthFunctionDEE315BB",
+                          "testauthorizerAuthFunctionCE2F3743",
                           "Arn"
                         ]
                       }
@@ -215,7 +215,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testAuthFunctionDEE315BB",
+                          "testauthorizerAuthFunctionCE2F3743",
                           "Arn"
                         ]
                       }
@@ -226,7 +226,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "testAuthFunctionDEE315BB",
+                  "testauthorizerAuthFunctionCE2F3743",
                   "Arn"
                 ]
               },

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/integ.wafapi-partial-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/test/integ.wafapi-partial-arguments.expected.json
@@ -71,7 +71,7 @@
         }
       }
     },
-    "testAuthFunctionServiceRole67229217": {
+    "testauthorizerAuthFunctionServiceRole6F05059E": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -102,7 +102,7 @@
         ]
       }
     },
-    "testAuthFunctionDEE315BB": {
+    "testauthorizerAuthFunctionCE2F3743": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
@@ -114,14 +114,14 @@
         "Handler": ".handler",
         "Role": {
           "Fn::GetAtt": [
-            "testAuthFunctionServiceRole67229217",
+            "testauthorizerAuthFunctionServiceRole6F05059E",
             "Arn"
           ]
         },
         "Runtime": "nodejs16.x"
       },
       "DependsOn": [
-        "testAuthFunctionServiceRole67229217"
+        "testauthorizerAuthFunctionServiceRole6F05059E"
       ],
       "Metadata": {
         "cfn_nag": {
@@ -142,13 +142,13 @@
         }
       }
     },
-    "testAuthFunctionwafapipartialargumentstestauthorizerDC0C2973Permissions3E01E2C8": {
+    "testauthorizerAuthFunctionwafapipartialargumentstestauthorizerDC0C2973PermissionsCD5A1000": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "testAuthFunctionDEE315BB",
+            "testauthorizerAuthFunctionCE2F3743",
             "Arn"
           ]
         },
@@ -198,7 +198,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testAuthFunctionDEE315BB",
+                          "testauthorizerAuthFunctionCE2F3743",
                           "Arn"
                         ]
                       }
@@ -215,7 +215,7 @@
                       ":",
                       {
                         "Fn::GetAtt": [
-                          "testAuthFunctionDEE315BB",
+                          "testauthorizerAuthFunctionCE2F3743",
                           "Arn"
                         ]
                       }
@@ -226,7 +226,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "testAuthFunctionDEE315BB",
+                  "testauthorizerAuthFunctionCE2F3743",
                   "Arn"
                 ]
               },

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-defaults.ts
@@ -26,25 +26,25 @@ import { generatePhysicalName } from './utils';
 /**
  * Private function to configure an api.RestApiProps
  * @param scope - the construct to which the RestApi should be attached to.
- * @param _endpointType - endpoint type for Api Gateway e.g. Regional, Global, Private
- * @param _logGroup - CW Log group for Api Gateway access logging
+ * @param endpointType - endpoint type for Api Gateway e.g. Regional, Global, Private
+ * @param logGroup - CW Log group for Api Gateway access logging
  */
-function DefaultRestApiProps(_endpointType: api.EndpointType[], _logGroup: LogGroup): api.RestApiProps {
+function DefaultRestApiProps(endpointType: api.EndpointType[], logGroup: LogGroup, includeAuth: boolean = true): api.RestApiProps {
   return {
     endpointConfiguration: {
-      types: _endpointType
+      types: endpointType
     },
     cloudWatchRole: false,
     // Configure API Gateway Access logging
     deployOptions: {
-      accessLogDestination: new api.LogGroupLogDestination(_logGroup),
+      accessLogDestination: new api.LogGroupLogDestination(logGroup),
       accessLogFormat: api.AccessLogFormat.jsonWithStandardFields(),
       loggingLevel: api.MethodLoggingLevel.INFO,
       dataTraceEnabled: false,
       tracingEnabled: true
     },
     defaultMethodOptions: {
-      authorizationType: api.AuthorizationType.IAM
+      authorizationType: includeAuth ? api.AuthorizationType.IAM : undefined
     }
 
   } as api.RestApiProps;
@@ -74,13 +74,15 @@ export function DefaultGlobalLambdaRestApiProps(_existingLambdaObj: lambda.Funct
  * Provides the default set of properties for Regional Lambda backed RestApi
  * @param scope - the construct to which the RestApi should be attached to.
  * @param _endpointType - endpoint type for Api Gateway e.g. Regional, Global, Private
- * @param _logGroup - CW Log group for Api Gateway access logging
+ * @param logGroup - CW Log group for Api Gateway access logging
  */
-export function DefaultRegionalLambdaRestApiProps(_existingLambdaObj: lambda.Function, _logGroup: LogGroup): api.LambdaRestApiProps {
-  const baseProps: api.RestApiProps = DefaultRestApiProps([api.EndpointType.REGIONAL], _logGroup);
+export function DefaultRegionalLambdaRestApiProps(existingLambdaObj: lambda.Function,
+  logGroup: LogGroup,
+  includeAuth: boolean = true): api.LambdaRestApiProps {
+  const baseProps: api.RestApiProps = DefaultRestApiProps([api.EndpointType.REGIONAL], logGroup, includeAuth);
 
   const extraProps: api.LambdaRestApiProps = {
-    handler: _existingLambdaObj,
+    handler: existingLambdaObj,
   };
 
   return Object.assign(baseProps, extraProps);

--- a/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/apigateway-helper.ts
@@ -217,11 +217,13 @@ export interface RegionalLambdaRestApiResponse {
  * @param apiGatewayProps - (optional) user-specified properties to override the default properties.
  */
 export function RegionalLambdaRestApi(scope: Construct, existingLambdaObj: lambda.Function,
-  apiGatewayProps?: apigateway.LambdaRestApiProps, logGroupProps?: logs.LogGroupProps): RegionalLambdaRestApiResponse {
+  apiGatewayProps?: apigateway.LambdaRestApiProps,
+  logGroupProps?: logs.LogGroupProps,
+  useDefaultAuth: boolean = true): RegionalLambdaRestApiResponse {
   // Configure log group for API Gateway AccessLogging
   const logGroup = buildLogGroup(scope, 'ApiAccessLogGroup', logGroupProps);
 
-  const defaultProps = apiDefaults.DefaultRegionalLambdaRestApiProps(existingLambdaObj, logGroup);
+  const defaultProps = apiDefaults.DefaultRegionalLambdaRestApiProps(existingLambdaObj, logGroup, useDefaultAuth);
   const configureLambdaRestApiResponse = configureLambdaRestApi(scope, defaultProps, apiGatewayProps);
   return { api: configureLambdaRestApiResponse.api, role: configureLambdaRestApiResponse.role, group: logGroup};
 }

--- a/source/patterns/@aws-solutions-constructs/core/test/glue-job-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/glue-job-helper.test.ts
@@ -169,7 +169,6 @@ test('Test custom deployment properties', () => {
   });
 
   const template = Template.fromStack(stack);
-  defaults.printWarning(`***********${JSON.stringify(template)}`);
   // check if Glue Job Resource was created correctly
   template.hasResource('AWS::Glue::Job', {
     Properties: {

--- a/source/patterns/@aws-solutions-constructs/core/test/test-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/test-helper.ts
@@ -210,25 +210,12 @@ export function CreateTestApi(stack: Stack, id: string): api.LambdaRestApi {
   addCfnSuppressRules(lambdaFunction, [{ id: "W58", reason: "Test Resource" }]);
   addCfnSuppressRules(lambdaFunction, [{ id: "W89", reason: "Test Resource" }]);
   addCfnSuppressRules(lambdaFunction, [{ id: "W92", reason: "Test Resource" }]);
-  const authFn = new lambda.Function(stack, `${id}AuthFunction`, {
-    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
-    runtime: lambda.Runtime.NODEJS_16_X,
-    handler: ".handler",
-  });
-  addCfnSuppressRules(authFn, [{ id: "W58", reason: "Test Resource" }]);
-  addCfnSuppressRules(authFn, [{ id: "W89", reason: "Test Resource" }]);
-  addCfnSuppressRules(authFn, [{ id: "W92", reason: "Test Resource" }]);
-
-  const auth = new api.RequestAuthorizer(stack, `${id}-authorizer`, {
-    handler: authFn,
-    identitySources: [api.IdentitySource.header('Authorization')]
-  });
 
   const restApi = new api.LambdaRestApi(stack, `${id}Api`, {
     handler: lambdaFunction,
     defaultMethodOptions: {
       authorizationType: api.AuthorizationType.CUSTOM,
-      authorizer: auth
+      authorizer: CreateApiAuthorizer(stack, `${id}-authorizer`)
     }
   });
 
@@ -249,6 +236,24 @@ export function CreateTestApi(stack: Stack, id: string): api.LambdaRestApi {
   addCfnSuppressRules(newStage, [{ id: "W69", reason: "Test Resource" }]);
 
   return restApi;
+}
+
+export function CreateApiAuthorizer(stack: Stack, id: string): api.IAuthorizer {
+  const authFn = new lambda.Function(stack, `${id}AuthFunction`, {
+    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+    runtime: lambda.Runtime.NODEJS_16_X,
+    handler: ".handler",
+  });
+  addCfnSuppressRules(authFn, [{ id: "W58", reason: "Test Resource" }]);
+  addCfnSuppressRules(authFn, [{ id: "W89", reason: "Test Resource" }]);
+  addCfnSuppressRules(authFn, [{ id: "W92", reason: "Test Resource" }]);
+
+  const authorizer = new api.RequestAuthorizer(stack, id, {
+    handler: authFn,
+    identitySources: [api.IdentitySource.header('Authorization')]
+  });
+
+  return authorizer;
 }
 
 // Create a short, unique to this stack name


### PR DESCRIPTION
*Issue #, if available:*
Closes #1043


*Description of changes:*
Check incoming props to require explicit auth type
Update all integration tests from no auth to custom auth


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.