### PR TITLE
fix(aws-cloudfront-s3): do not create s3 access log bucket for cf log bucket when an existing bucket is provided

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/test.cloudfront-s3.test.ts
@@ -589,3 +589,17 @@ test("If a customer provides their own httpOrigin, or other origin type, use tha
     }
   });
 });
+
+test('Test that we do not create an S3 Access Log bucket for CF logs if one is provided', () => {
+  const stack = new cdk.Stack();
+  const cfS3AccessLogBucket = new s3.Bucket(stack, 'cf-s3-access-logs');
+  new CloudFrontToS3(stack, 'test-cloudfront-s3', {
+    cloudFrontLoggingBucketProps: {
+      serverAccessLogsBucket: cfS3AccessLogBucket
+    }
+  });
+
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("AWS::S3::Bucket", 4);
+
+});


### PR DESCRIPTION
*Description of changes:*
In this situation:

```
  const cfS3AccessLogBucket = new s3.Bucket(stack, 'cf-s3-access-logs');
  new CloudFrontToS3(stack, 'test-cloudfront-s3', {
    cloudFrontLoggingBucketProps: {
      serverAccessLogsBucket: cfS3AccessLogBucket
    }
  });
```

The construct will still create an S3 Access Log bucket for the CF log bucket. The provided bucket is ignored. What should happen is that the provided bucket is configured to accept the logs and no additional bucket is created.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.