### PR TITLE
fix(aws-cloudfront-s3): insert empty originAccessIdentity

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-bucket-encrypted-with-cmk-provided-as-existingbucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-bucket-encrypted-with-cmk-provided-as-existingbucket.expected.json
@@ -580,7 +580,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-bucket-encrypted-with-managed-key-provided-as-existingbucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-bucket-encrypted-with-managed-key-provided-as-existingbucket.expected.json
@@ -538,7 +538,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-cmk-provided-as-bucket-prop.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-cmk-provided-as-bucket-prop.expected.json
@@ -580,7 +580,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-headers.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-headers.expected.json
@@ -849,7 +849,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-originPath.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-custom-originPath.expected.json
@@ -818,7 +818,9 @@
                 ]
               },
               "OriginPath": "/testPath",
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customCloudFrontLoggingBucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customCloudFrontLoggingBucket.expected.json
@@ -568,7 +568,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customLoggingBuckets.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-customLoggingBuckets.expected.json
@@ -855,7 +855,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-existing-bucket.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-existing-bucket.expected.json
@@ -904,7 +904,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             },
             {
               "DomainName": {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-arguments.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-arguments.expected.json
@@ -827,7 +827,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-security-headers.expected.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/test/integ.cfts3-no-security-headers.expected.json
@@ -794,7 +794,9 @@
                   "Id"
                 ]
               },
-              "S3OriginConfig": {}
+              "S3OriginConfig": {
+                "OriginAccessIdentity": ""
+              }
             }
           ]
         }

--- a/source/patterns/@aws-solutions-constructs/core/lib/s3-oac-origin.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/s3-oac-origin.ts
@@ -83,6 +83,6 @@ class S3OacBucketOrigin extends cloudfront.OriginBase {
   }
 
   protected renderS3OriginConfig(): cloudfront.CfnDistribution.S3OriginConfigProperty | undefined {
-    return { };
+    return { originAccessIdentity: '' };
   }
 }


### PR DESCRIPTION
…rement

*Issue #, if available:*
Currently a stack creating aws-cloudfront-s3 requires IAM permissions for OAIs even though none exist. By
inserting an explicitly empty originAccessIdentity in the S3OriginConfig we remove the CFN requirement for this privilege.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.