### PR TITLE
fix(aws-dynamodbstreams-lambda) Documentation Update

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/README.md
@@ -99,10 +99,6 @@ new DynamoDBStreamsToLambda(this, "test-dynamodbstreams-lambda",
 |dynamoTable?|[`dynamodb.Table`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.Table.html)|Returns an instance of dynamodb.Table created by the construct. IMPORTANT: If existingTableInterface was provided in Pattern Construct Props, this property will be `undefined`|
 |lambdaFunction|[`lambda.Function`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Function.html)|Returns an instance of lambda.Function created by the construct|
 
-## Lambda Function
-
-This pattern requires a lambda function that can post data into the Elasticsearch. A sample function is provided [here](https://github.com/awslabs/aws-solutions-constructs/blob/master/source/patterns/%40aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/lambda/index.js).
-
 ## Default settings
 
 Out of the box implementation of the Construct without any override will set the following defaults:


### PR DESCRIPTION
I was in this construct to grab a reference to how we configure the dlq on stream processing error, and noticed this bit of the README that seems to be for a different solutions construct (aws-dynamodbstreams-lambda-elasticsearch-kibana). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.