### PR TITLE
fix(aws-eventbridge-lambdba): handle provided role correctly

### DIFF
--- a/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/lambda-helper.ts
@@ -179,13 +179,15 @@ export function deployLambdaFunction(scope: Construct,
     // Find the X-Ray IAM Policy
     const cfnLambdafunctionDefPolicy = lambdafunction.role?.node.tryFindChild('DefaultPolicy')?.node.findChild('Resource') as iam.CfnPolicy;
 
-    // Add the CFN NAG suppress to allow for "Resource": "*" for AWS X-Ray
-    addCfnSuppressRules(cfnLambdafunctionDefPolicy, [
-      {
-        id: 'W12',
-        reason: `Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.`
-      }
-    ]);
+    if (cfnLambdafunctionDefPolicy) {
+      // Add the CFN NAG suppress to allow for "Resource": "*" for AWS X-Ray
+      addCfnSuppressRules(cfnLambdafunctionDefPolicy, [
+        {
+          id: 'W12',
+          reason: `Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC.`
+        }
+      ]);
+    }
   }
 
   return lambdafunction;


### PR DESCRIPTION
*Description of changes:*
If the client provides a role without a default policy, we need to ensure we don't try to add cfn_nag suppression to the non-existent policy.

This applies to all Lambda based constructs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.