### PR TITLE
fix(all): a dropped caret on peerdependencies led to version compatibility issues

### DIFF
--- a/deployment/v2/align-version.js
+++ b/deployment/v2/align-version.js
@@ -22,7 +22,7 @@ for (const file of process.argv.splice(4)) {
   pkg.version = targetSolutionsConstructsVersion;
 
   pkg.dependencies = updateDependencyVersionNumbers(pkg.dependencies || { });
-  pkg.peerDependencies = updateDependencyVersionNumbers(pkg.peerDependencies || { });
+  pkg.peerDependencies = updateDependencyVersionNumbers(pkg.peerDependencies || { }, '^');
   pkg.devDependencies = updateDependencyVersionNumbers(pkg.devDependencies || { });
 
   // This will be removed in the next PR when we remove cdk-integ
@@ -35,13 +35,13 @@ for (const file of process.argv.splice(4)) {
 
 }
 
-function updateDependencyVersionNumbers(section) {  let newdependencies = {};
+function updateDependencyVersionNumbers(section, orBetter = '') {  let newdependencies = {};
   for (const [ name, version ] of Object.entries(section)) {
     if (name.startsWith('@aws-solutions-constructs')) {
       newdependencies[name] = version.replace(nullVersionMarker, targetSolutionsConstructsVersion);
     }
     else if (name.startsWith('aws-cdk-lib')) {
-      newdependencies[name] = version.replace(nullVersionMarker, awsCdkLibVersion);
+      newdependencies[name] = version.replace(nullVersionMarker, orBetter+awsCdkLibVersion);
     }
     else {
       newdependencies[name] = version;

--- a/source/package.json
+++ b/source/package.json
@@ -28,11 +28,11 @@
     "tslint": "^5.20.1",
     "typescript": "4.7.4",
     "aws-cdk-migration": "^1.135.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "lerna": "^3.22.1",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "workspaces": {
@@ -58,7 +58,7 @@
     "**/@typescript-eslint/parser": "^4.1.1"
   },
   "peerDependencies": {
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
@@ -55,12 +55,12 @@
   "dependencies": {
     "@aws-solutions-constructs/aws-cloudfront-apigateway": "0.0.0",
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-cloudfront-apigateway": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
@@ -55,12 +55,12 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
@@ -56,12 +56,12 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
@@ -55,12 +55,12 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
@@ -55,14 +55,14 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/jest": "^26.0.22",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
@@ -55,12 +55,12 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
@@ -56,12 +56,12 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-iot-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-dynamodb": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-iot-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-dynamodb": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
@@ -56,12 +56,12 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisstreams-lambda": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisstreams-lambda": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
@@ -50,14 +50,14 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0",
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -76,7 +76,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
@@ -55,12 +55,12 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
@@ -56,12 +56,12 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-sqs": "0.0.0",
     "@aws-solutions-constructs/aws-sqs-lambda": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-sqs": "0.0.0",
     "@aws-solutions-constructs/aws-sqs-lambda": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "eslint-plugin-import": "^2.22.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
@@ -55,14 +55,14 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "@aws-sdk/client-s3": "^3.0.0",
     "@types/aws-lambda": "^8.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -82,7 +82,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0"
   },
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@types/node": "^10.3.0",
     "prettier": "^2.5.1",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
@@ -55,12 +55,12 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
@@ -55,12 +55,12 @@
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-route53-alb": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-route53-alb": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
@@ -54,13 +54,13 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,7 +79,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "aws-cdk-lib": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/core/package.json
+++ b/source/patterns/@aws-solutions-constructs/core/package.json
@@ -55,7 +55,7 @@
     "deep-diff": "^1.0.2",
     "deepmerge": "^4.0.0",
     "npmlog": "^4.1.2",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/deep-diff": "^1.0.0",
@@ -63,7 +63,7 @@
     "@types/prettier": "2.6.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -86,7 +86,7 @@
     "deep-diff"
   ],
   "peerDependencies": {
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/resources/package.json
+++ b/source/patterns/@aws-solutions-constructs/resources/package.json
@@ -56,12 +56,12 @@
     "@aws-sdk/client-s3": "^3.478.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "aws-sdk-client-mock": "^3.0.0",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -85,7 +85,7 @@
   ],
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/use_cases/aws-custom-glue-etl/package.json
+++ b/source/use_cases/aws-custom-glue-etl/package.json
@@ -31,12 +31,12 @@
     "@aws-solutions-constructs/aws-kinesisstreams-gluejob": "0.0.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "source-map-support": "^0.5.16",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.9.1",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -45,7 +45,7 @@
     ]
   },
   "peerDependencies": {
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/package.json
@@ -9,14 +9,14 @@
   "license": "ISC",
   "dependencies": {
     "uuid": "^8.3.2",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "peerDependencies": {
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "devDependencies": {
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -48,10 +48,10 @@
     "@aws-solutions-constructs/aws-lambda-stepfunctions": "0.0.0",
     "source-map-support": "^0.5.16",
     "typescript": "^4.2.4",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "peerDependencies": {
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }

--- a/source/use_cases/aws-s3-static-website/package.json
+++ b/source/use_cases/aws-s3-static-website/package.json
@@ -31,12 +31,12 @@
     "@aws-solutions-constructs/aws-cloudfront-s3": "0.0.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "source-map-support": "^0.5.16",
-    "constructs": "10.0.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },
   "jest": {
@@ -45,7 +45,7 @@
     ]
   },
   "peerDependencies": {
-    "constructs": "10.0.0",
+    "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a ^ to aws-cdk-lib version entry under peer dependencies, and to all constructs versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.