### PR TITLE
fix(stepfunctions): find correct logs policy statement to replace

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-existing-eventbus.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-existing-eventbus.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "da11f95fde1d9075ed3264126ffcd826047a6aa868f5cbd98eff1d1a3df9bcdc": {
+    "05fc1edac52c415d21de480b023de45248585d3e28f56576b766faa03e026538": {
       "source": {
         "path": "evtstp-eventbridge-stepfunctions-existing-eventbus.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "da11f95fde1d9075ed3264126ffcd826047a6aa868f5cbd98eff1d1a3df9bcdc.json",
+          "objectKey": "05fc1edac52c415d21de480b023de45248585d3e28f56576b766faa03e026538.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-existing-eventbus.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-existing-eventbus.template.json
@@ -209,13 +209,7 @@
     "PolicyDocument": {
      "Statement": [
       {
-       "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
+       "Action": "lambda:InvokeFunction",
        "Effect": "Allow",
        "Resource": [
         {
@@ -239,20 +233,6 @@
          ]
         }
        ]
-      },
-      {
-       "Action": [
-        "logs:CreateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:DescribeLogGroups",
-        "logs:DescribeResourcePolicies",
-        "logs:GetLogDelivery",
-        "logs:ListLogDeliveries",
-        "logs:PutResourcePolicy",
-        "logs:UpdateLogDelivery"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
       },
       {
        "Action": [
@@ -281,6 +261,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/da11f95fde1d9075ed3264126ffcd826047a6aa868f5cbd98eff1d1a3df9bcdc.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/05fc1edac52c415d21de480b023de45248585d3e28f56576b766faa03e026538.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-existing-eventbus.js.snapshot/tree.json
@@ -371,20 +371,6 @@
                                     },
                                     {
                                       "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
-                                    {
-                                      "Action": [
                                         "logs:DescribeLogGroups",
                                         "logs:DescribeResourcePolicies",
                                         "logs:PutResourcePolicy"
@@ -410,6 +396,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -748,7 +745,7 @@
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-eventbridge-stepfunctions.EventbridgeToStepfunctions",
-              "version": "2.52.0"
+              "version": "2.52.1"
             }
           },
           "Integ": {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-new-eventbus.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-new-eventbus.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "d4212e8d929b062b40e40dcfbacaede417427324202a45b045106e146029e41f": {
+    "c0c6a4481a83c0f870bcda3ac5271734a130dea0f47a3ce4a714a30ddcbc93b4": {
       "source": {
         "path": "evtstp-eventbridge-stepfunctions-new-eventbus.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d4212e8d929b062b40e40dcfbacaede417427324202a45b045106e146029e41f.json",
+          "objectKey": "c0c6a4481a83c0f870bcda3ac5271734a130dea0f47a3ce4a714a30ddcbc93b4.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-new-eventbus.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/evtstp-eventbridge-stepfunctions-new-eventbus.template.json
@@ -203,13 +203,7 @@
     "PolicyDocument": {
      "Statement": [
       {
-       "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
+       "Action": "lambda:InvokeFunction",
        "Effect": "Allow",
        "Resource": [
         {
@@ -233,20 +227,6 @@
          ]
         }
        ]
-      },
-      {
-       "Action": [
-        "logs:CreateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:DescribeLogGroups",
-        "logs:DescribeResourcePolicies",
-        "logs:GetLogDelivery",
-        "logs:ListLogDeliveries",
-        "logs:PutResourcePolicy",
-        "logs:UpdateLogDelivery"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
       },
       {
        "Action": [
@@ -275,6 +255,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d4212e8d929b062b40e40dcfbacaede417427324202a45b045106e146029e41f.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/c0c6a4481a83c0f870bcda3ac5271734a130dea0f47a3ce4a714a30ddcbc93b4.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-new-eventbus.js.snapshot/tree.json
@@ -347,20 +347,6 @@
                                     },
                                     {
                                       "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
-                                    {
-                                      "Action": [
                                         "logs:DescribeLogGroups",
                                         "logs:DescribeResourcePolicies",
                                         "logs:PutResourcePolicy"
@@ -386,6 +372,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -748,7 +745,7 @@
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-eventbridge-stepfunctions.EventbridgeToStepfunctions",
-              "version": "2.52.0"
+              "version": "2.52.1"
             }
           },
           "Integ": {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/evtstp-eventbridge-stepfunctions-no-argument.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/evtstp-eventbridge-stepfunctions-no-argument.assets.json
@@ -1,7 +1,7 @@
 {
   "version": "36.0.0",
   "files": {
-    "a2b717be0cc15f970accbb140a60f1e3b476049031f96be81324d837e2638014": {
+    "74c566a36a8a986121cbe9ec6bb4c53b6f80a7bd4748db737199b26d4dc2a25f": {
       "source": {
         "path": "evtstp-eventbridge-stepfunctions-no-argument.template.json",
         "packaging": "file"
@@ -9,7 +9,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a2b717be0cc15f970accbb140a60f1e3b476049031f96be81324d837e2638014.json",
+          "objectKey": "74c566a36a8a986121cbe9ec6bb4c53b6f80a7bd4748db737199b26d4dc2a25f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/evtstp-eventbridge-stepfunctions-no-argument.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/evtstp-eventbridge-stepfunctions-no-argument.template.json
@@ -66,17 +66,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -102,6 +91,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/a2b717be0cc15f970accbb140a60f1e3b476049031f96be81324d837e2638014.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/74c566a36a8a986121cbe9ec6bb4c53b6f80a7bd4748db737199b26d4dc2a25f.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-no-argument.js.snapshot/tree.json
@@ -13,7 +13,7 @@
             "path": "evtstp-eventbridge-stepfunctions-no-argument/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-eventbridge-stepfunctions-construct": {
@@ -55,13 +55,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "StateMachine": {
@@ -77,7 +77,7 @@
                         "path": "evtstp-eventbridge-stepfunctions-no-argument/test-eventbridge-stepfunctions-construct/StateMachine/Role/ImportRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -102,7 +102,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -117,20 +117,6 @@
                               "aws:cdk:cloudformation:props": {
                                 "policyDocument": {
                                   "Statement": [
-                                    {
-                                      "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
                                     {
                                       "Action": [
                                         "logs:DescribeLogGroups",
@@ -158,6 +144,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -172,19 +169,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -219,13 +216,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "EventsRuleRole": {
@@ -237,7 +234,7 @@
                     "path": "evtstp-eventbridge-stepfunctions-no-argument/test-eventbridge-stepfunctions-construct/EventsRuleRole/ImportEventsRuleRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -262,7 +259,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -297,19 +294,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "EventsRule": {
@@ -342,13 +339,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_events.CfnRule",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_events.Rule",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionFailedAlarm": {
@@ -381,13 +378,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionThrottledAlarm": {
@@ -420,13 +417,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionAbortedAlarm": {
@@ -459,19 +456,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-eventbridge-stepfunctions.EventbridgeToStepfunctions",
-              "version": "2.50.0"
+              "version": "2.52.1"
             }
           },
           "Integ": {
@@ -487,7 +484,7 @@
                     "path": "evtstp-eventbridge-stepfunctions-no-argument/Integ/DefaultTest/Default",
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   },
                   "DeployAssert": {
@@ -499,7 +496,7 @@
                         "path": "evtstp-eventbridge-stepfunctions-no-argument/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -507,25 +504,25 @@
                         "path": "evtstp-eventbridge-stepfunctions-no-argument/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -533,7 +530,7 @@
             "path": "evtstp-eventbridge-stepfunctions-no-argument/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -541,13 +538,13 @@
             "path": "evtstp-eventbridge-stepfunctions-no-argument/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -555,13 +552,13 @@
         "path": "Tree",
         "constructInfo": {
           "fqn": "constructs.Construct",
-          "version": "10.0.0"
+          "version": "10.3.0"
         }
       }
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/evtstp-eventbridge-stepfunctions-with-lambda.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/evtstp-eventbridge-stepfunctions-with-lambda.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "776b897e19bdea233e7a06ee36ebc326740e1dea2cd3f8b004e3f74e904d70ad": {
+    "cb442f99a002893cc1e6f48fb8336a0467628c91842ae526fc379f72b51abfbc": {
       "source": {
         "path": "evtstp-eventbridge-stepfunctions-with-lambda.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "776b897e19bdea233e7a06ee36ebc326740e1dea2cd3f8b004e3f74e904d70ad.json",
+          "objectKey": "cb442f99a002893cc1e6f48fb8336a0467628c91842ae526fc379f72b51abfbc.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/evtstp-eventbridge-stepfunctions-with-lambda.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/evtstp-eventbridge-stepfunctions-with-lambda.template.json
@@ -203,13 +203,7 @@
     "PolicyDocument": {
      "Statement": [
       {
-       "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
+       "Action": "lambda:InvokeFunction",
        "Effect": "Allow",
        "Resource": [
         {
@@ -233,20 +227,6 @@
          ]
         }
        ]
-      },
-      {
-       "Action": [
-        "logs:CreateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:DescribeLogGroups",
-        "logs:DescribeResourcePolicies",
-        "logs:GetLogDelivery",
-        "logs:ListLogDeliveries",
-        "logs:PutResourcePolicy",
-        "logs:UpdateLogDelivery"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
       },
       {
        "Action": [
@@ -275,6 +255,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/776b897e19bdea233e7a06ee36ebc326740e1dea2cd3f8b004e3f74e904d70ad.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/cb442f99a002893cc1e6f48fb8336a0467628c91842ae526fc379f72b51abfbc.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/integ.evtstp-eventbridge-stepfunctions-with-lambda.js.snapshot/tree.json
@@ -347,20 +347,6 @@
                                     },
                                     {
                                       "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
-                                    {
-                                      "Action": [
                                         "logs:DescribeLogGroups",
                                         "logs:DescribeResourcePolicies",
                                         "logs:PutResourcePolicy"
@@ -386,6 +372,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -717,7 +714,7 @@
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-eventbridge-stepfunctions.EventbridgeToStepfunctions",
-              "version": "2.52.0"
+              "version": "2.52.1"
             }
           },
           "Integ": {

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/farstp-new-resources.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/farstp-new-resources.assets.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "3ccec9bde08a4676fc40240a1caf03ee418f662fad024199b2018de74930cc48": {
+    "79f7e68f42f1a7299b1bce98dff3c3f0b61c7c946ac7a79a099faffea981e911": {
       "source": {
         "path": "farstp-new-resources.template.json",
         "packaging": "file"
@@ -23,7 +23,7 @@
       "destinations": {
         "current_account-us-east-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1",
-          "objectKey": "3ccec9bde08a4676fc40240a1caf03ee418f662fad024199b2018de74930cc48.json",
+          "objectKey": "79f7e68f42f1a7299b1bce98dff3c3f0b61c7c946ac7a79a099faffea981e911.json",
           "region": "us-east-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-east-1"
         }

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/farstp-new-resources.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/farstp-new-resources.template.json
@@ -1111,17 +1111,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -1147,6 +1136,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-us-east-1",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-us-east-1",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/3ccec9bde08a4676fc40240a1caf03ee418f662fad024199b2018de74930cc48.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/79f7e68f42f1a7299b1bce98dff3c3f0b61c7c946ac7a79a099faffea981e911.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-new-resources.js.snapshot/tree.json
@@ -32,7 +32,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnVPC",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PublicSubnet1": {
@@ -76,7 +76,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -84,7 +84,7 @@
                     "path": "farstp-new-resources/Vpc/PublicSubnet1/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -106,7 +106,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -125,7 +125,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -145,7 +145,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EIP": {
@@ -165,7 +165,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnEIP",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "NATGateway": {
@@ -193,13 +193,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnNatGateway",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PublicSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PublicSubnet2": {
@@ -243,7 +243,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -251,7 +251,7 @@
                     "path": "farstp-new-resources/Vpc/PublicSubnet2/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -273,7 +273,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -292,7 +292,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -312,7 +312,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EIP": {
@@ -332,7 +332,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnEIP",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "NATGateway": {
@@ -360,13 +360,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnNatGateway",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PublicSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PrivateSubnet1": {
@@ -410,7 +410,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -418,7 +418,7 @@
                     "path": "farstp-new-resources/Vpc/PrivateSubnet1/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -440,7 +440,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -459,7 +459,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -479,13 +479,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PrivateSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PrivateSubnet2": {
@@ -529,7 +529,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -537,7 +537,7 @@
                     "path": "farstp-new-resources/Vpc/PrivateSubnet2/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -559,7 +559,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -578,7 +578,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -598,13 +598,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PrivateSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "IGW": {
@@ -623,7 +623,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnInternetGateway",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "VPCGW": {
@@ -642,7 +642,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnVPCGatewayAttachment",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "RestrictDefaultSecurityGroupCustomResource": {
@@ -654,13 +654,13 @@
                     "path": "farstp-new-resources/Vpc/RestrictDefaultSecurityGroupCustomResource/Default",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CustomResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "FlowLog": {
@@ -676,7 +676,7 @@
                         "path": "farstp-new-resources/Vpc/FlowLog/IAMRole/ImportIAMRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -707,7 +707,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -759,19 +759,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "LogGroup": {
@@ -795,13 +795,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "FlowLog": {
@@ -835,13 +835,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnFlowLog",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.FlowLog",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ECR_API": {
@@ -880,13 +880,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ECR_DKR": {
@@ -925,13 +925,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "S3": {
@@ -978,13 +978,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.GatewayVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "STEP_FUNCTIONS": {
@@ -1023,19 +1023,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.Vpc",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "Custom::VpcRestrictDefaultSGCustomResourceProvider": {
@@ -1047,7 +1047,7 @@
                 "path": "farstp-new-resources/Custom::VpcRestrictDefaultSGCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Role": {
@@ -1055,7 +1055,7 @@
                 "path": "farstp-new-resources/Custom::VpcRestrictDefaultSGCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Handler": {
@@ -1063,13 +1063,13 @@
                 "path": "farstp-new-resources/Custom::VpcRestrictDefaultSGCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProviderBase",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "StartState": {
@@ -1077,7 +1077,7 @@
             "path": "farstp-new-resources/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "farstp-new-resources-ECR_API-security-group": {
@@ -1133,13 +1133,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "farstp-new-resources-ECR_DKR-security-group": {
@@ -1195,13 +1195,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-cluster": {
@@ -1217,13 +1217,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.CfnCluster",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ecs.Cluster",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-taskdef": {
@@ -1239,7 +1239,7 @@
                     "path": "farstp-new-resources/test-taskdef/TaskRole/ImportTaskRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -1264,7 +1264,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -1299,19 +1299,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Resource": {
@@ -1359,7 +1359,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.CfnTaskDefinition",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "test-container": {
@@ -1367,13 +1367,13 @@
                 "path": "farstp-new-resources/test-taskdef/test-container",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.ContainerDefinition",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ecs.FargateTaskDefinition",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-sg": {
@@ -1401,13 +1401,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-service": {
@@ -1464,13 +1464,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.CfnService",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ecs.FargateService",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-construct": {
@@ -1512,13 +1512,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "StateMachine": {
@@ -1534,7 +1534,7 @@
                         "path": "farstp-new-resources/test-construct/StateMachine/Role/ImportRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -1559,7 +1559,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -1574,20 +1574,6 @@
                               "aws:cdk:cloudformation:props": {
                                 "policyDocument": {
                                   "Statement": [
-                                    {
-                                      "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
                                     {
                                       "Action": [
                                         "logs:DescribeLogGroups",
@@ -1615,6 +1601,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -1629,19 +1626,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -1676,13 +1673,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionFailedAlarm": {
@@ -1715,13 +1712,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionThrottledAlarm": {
@@ -1754,13 +1751,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionAbortedAlarm": {
@@ -1793,19 +1790,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-fargate-stepfunctions.FargateToStepfunctions",
-              "version": "2.51.0"
+              "version": "2.52.1"
             }
           },
           "farstp-new-resources-STEP_FUNCTIONS-security-group": {
@@ -1861,13 +1858,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "Integ": {
@@ -1895,7 +1892,7 @@
                         "path": "farstp-new-resources/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -1903,25 +1900,25 @@
                         "path": "farstp-new-resources/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -1929,7 +1926,7 @@
             "path": "farstp-new-resources/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -1937,13 +1934,13 @@
             "path": "farstp-new-resources/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -1957,7 +1954,7 @@
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/farstp-no-cloudwatch-alarms.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/farstp-no-cloudwatch-alarms.assets.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "c2b106d1047c93f2b3ec72f7d05e59b29aa185f9e10652378e11338d3b61bb3d": {
+    "ab98c1a38fd4451b6b4b362fbcdc7ce5647a809f7cb96d31674747b6d4d5042a": {
       "source": {
         "path": "farstp-no-cloudwatch-alarms.template.json",
         "packaging": "file"
@@ -23,7 +23,7 @@
       "destinations": {
         "current_account-us-east-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1",
-          "objectKey": "c2b106d1047c93f2b3ec72f7d05e59b29aa185f9e10652378e11338d3b61bb3d.json",
+          "objectKey": "ab98c1a38fd4451b6b4b362fbcdc7ce5647a809f7cb96d31674747b6d4d5042a.json",
           "region": "us-east-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-east-1"
         }

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/farstp-no-cloudwatch-alarms.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/farstp-no-cloudwatch-alarms.template.json
@@ -1111,17 +1111,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -1147,6 +1136,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-us-east-1",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-us-east-1",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/c2b106d1047c93f2b3ec72f7d05e59b29aa185f9e10652378e11338d3b61bb3d.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/ab98c1a38fd4451b6b4b362fbcdc7ce5647a809f7cb96d31674747b6d4d5042a.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/test/integ.farstp-no-cloudwatch-alarms.js.snapshot/tree.json
@@ -32,7 +32,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnVPC",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PublicSubnet1": {
@@ -76,7 +76,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -84,7 +84,7 @@
                     "path": "farstp-no-cloudwatch-alarms/Vpc/PublicSubnet1/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -106,7 +106,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -125,7 +125,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -145,7 +145,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EIP": {
@@ -165,7 +165,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnEIP",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "NATGateway": {
@@ -193,13 +193,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnNatGateway",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PublicSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PublicSubnet2": {
@@ -243,7 +243,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -251,7 +251,7 @@
                     "path": "farstp-no-cloudwatch-alarms/Vpc/PublicSubnet2/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -273,7 +273,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -292,7 +292,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -312,7 +312,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EIP": {
@@ -332,7 +332,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnEIP",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "NATGateway": {
@@ -360,13 +360,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnNatGateway",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PublicSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PrivateSubnet1": {
@@ -410,7 +410,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -418,7 +418,7 @@
                     "path": "farstp-no-cloudwatch-alarms/Vpc/PrivateSubnet1/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -440,7 +440,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -459,7 +459,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -479,13 +479,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PrivateSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "PrivateSubnet2": {
@@ -529,7 +529,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -537,7 +537,7 @@
                     "path": "farstp-no-cloudwatch-alarms/Vpc/PrivateSubnet2/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -559,7 +559,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -578,7 +578,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultRoute": {
@@ -598,13 +598,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRoute",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PrivateSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "IGW": {
@@ -623,7 +623,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnInternetGateway",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "VPCGW": {
@@ -642,7 +642,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnVPCGatewayAttachment",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "RestrictDefaultSecurityGroupCustomResource": {
@@ -654,13 +654,13 @@
                     "path": "farstp-no-cloudwatch-alarms/Vpc/RestrictDefaultSecurityGroupCustomResource/Default",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CustomResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "FlowLog": {
@@ -676,7 +676,7 @@
                         "path": "farstp-no-cloudwatch-alarms/Vpc/FlowLog/IAMRole/ImportIAMRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -707,7 +707,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -759,19 +759,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "LogGroup": {
@@ -795,13 +795,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "FlowLog": {
@@ -835,13 +835,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnFlowLog",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.FlowLog",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ECR_API": {
@@ -880,13 +880,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ECR_DKR": {
@@ -925,13 +925,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "S3": {
@@ -978,13 +978,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.GatewayVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "STEP_FUNCTIONS": {
@@ -1023,19 +1023,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.Vpc",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "Custom::VpcRestrictDefaultSGCustomResourceProvider": {
@@ -1047,7 +1047,7 @@
                 "path": "farstp-no-cloudwatch-alarms/Custom::VpcRestrictDefaultSGCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Role": {
@@ -1055,7 +1055,7 @@
                 "path": "farstp-no-cloudwatch-alarms/Custom::VpcRestrictDefaultSGCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Handler": {
@@ -1063,13 +1063,13 @@
                 "path": "farstp-no-cloudwatch-alarms/Custom::VpcRestrictDefaultSGCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProviderBase",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "StartState": {
@@ -1077,7 +1077,7 @@
             "path": "farstp-no-cloudwatch-alarms/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "farstp-no-cloudwatch-alarms-ECR_API-security-group": {
@@ -1133,13 +1133,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "farstp-no-cloudwatch-alarms-ECR_DKR-security-group": {
@@ -1195,13 +1195,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-cluster": {
@@ -1217,13 +1217,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.CfnCluster",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ecs.Cluster",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-taskdef": {
@@ -1239,7 +1239,7 @@
                     "path": "farstp-no-cloudwatch-alarms/test-taskdef/TaskRole/ImportTaskRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -1264,7 +1264,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -1299,19 +1299,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Resource": {
@@ -1359,7 +1359,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.CfnTaskDefinition",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "test-container": {
@@ -1367,13 +1367,13 @@
                 "path": "farstp-no-cloudwatch-alarms/test-taskdef/test-container",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.ContainerDefinition",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ecs.FargateTaskDefinition",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-sg": {
@@ -1401,13 +1401,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-service": {
@@ -1464,13 +1464,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ecs.CfnService",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ecs.FargateService",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-construct": {
@@ -1512,13 +1512,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "StateMachine": {
@@ -1534,7 +1534,7 @@
                         "path": "farstp-no-cloudwatch-alarms/test-construct/StateMachine/Role/ImportRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -1559,7 +1559,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -1574,20 +1574,6 @@
                               "aws:cdk:cloudformation:props": {
                                 "policyDocument": {
                                   "Statement": [
-                                    {
-                                      "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
                                     {
                                       "Action": [
                                         "logs:DescribeLogGroups",
@@ -1615,6 +1601,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -1629,19 +1626,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -1676,19 +1673,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-fargate-stepfunctions.FargateToStepfunctions",
-              "version": "2.51.0"
+              "version": "2.52.1"
             }
           },
           "farstp-no-cloudwatch-alarms-STEP_FUNCTIONS-security-group": {
@@ -1744,13 +1741,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "Integ": {
@@ -1778,7 +1775,7 @@
                         "path": "farstp-no-cloudwatch-alarms/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -1786,25 +1783,25 @@
                         "path": "farstp-no-cloudwatch-alarms/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -1812,7 +1809,7 @@
             "path": "farstp-no-cloudwatch-alarms/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -1820,13 +1817,13 @@
             "path": "farstp-no-cloudwatch-alarms/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -1840,7 +1837,7 @@
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/.eslintignore
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/.eslintignore
@@ -5,3 +5,4 @@ coverage
 test/integ.*.js.snapshot/
 test/cdk-integ.out.integ.*.snapshot
 test/lambda/index.js
+test/lambda-task/index.js

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/asset.2c77a7150383973352510b020ce9abcf00245f43f72cf37c75d7ee9dc413fee8/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/asset.2c77a7150383973352510b020ce9abcf00245f43f72cf37c75d7ee9dc413fee8/index.js
@@ -1,0 +1,10 @@
+exports.handler = async event => {
+  // Log the event argument for debugging and for use in local development.
+  console.log(JSON.stringify(event, undefined, 2));
+
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "text/plain" },
+    body: JSON.stringify({ status: "OK", message: "SUCCESS" }),
+  };
+};

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/lamstp-deploy-lambda.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/lamstp-deploy-lambda.assets.json
@@ -1,6 +1,19 @@
 {
   "version": "36.0.0",
   "files": {
+    "2c77a7150383973352510b020ce9abcf00245f43f72cf37c75d7ee9dc413fee8": {
+      "source": {
+        "path": "asset.2c77a7150383973352510b020ce9abcf00245f43f72cf37c75d7ee9dc413fee8",
+        "packaging": "zip"
+      },
+      "destinations": {
+        "current_account-current_region": {
+          "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
+          "objectKey": "2c77a7150383973352510b020ce9abcf00245f43f72cf37c75d7ee9dc413fee8.zip",
+          "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
+        }
+      }
+    },
     "fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93": {
       "source": {
         "path": "asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93",
@@ -14,7 +27,7 @@
         }
       }
     },
-    "c2b98904a49287b9ba1363cb78aac93819c58156fcd28a324518b3025a1d44c2": {
+    "5a0b4a97ac40ee534cc8dd7e2b2a811b691eb4b8e17da20c4b309ab130204f24": {
       "source": {
         "path": "lamstp-deploy-lambda.template.json",
         "packaging": "file"
@@ -22,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c2b98904a49287b9ba1363cb78aac93819c58156fcd28a324518b3025a1d44c2.json",
+          "objectKey": "5a0b4a97ac40ee534cc8dd7e2b2a811b691eb4b8e17da20c4b309ab130204f24.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/lamstp-deploy-lambda.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/lamstp-deploy-lambda.template.json
@@ -1,5 +1,143 @@
 {
  "Resources": {
+  "taskFunctionServiceRole31E35058": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "Policies": [
+     {
+      "PolicyDocument": {
+       "Statement": [
+        {
+         "Action": [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+         ],
+         "Effect": "Allow",
+         "Resource": {
+          "Fn::Join": [
+           "",
+           [
+            "arn:",
+            {
+             "Ref": "AWS::Partition"
+            },
+            ":logs:",
+            {
+             "Ref": "AWS::Region"
+            },
+            ":",
+            {
+             "Ref": "AWS::AccountId"
+            },
+            ":log-group:/aws/lambda/*"
+           ]
+          ]
+         }
+        }
+       ],
+       "Version": "2012-10-17"
+      },
+      "PolicyName": "LambdaFunctionServiceRolePolicy"
+     }
+    ]
+   }
+  },
+  "taskFunctionServiceRoleDefaultPolicyDD9784DE": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "xray:PutTelemetryRecords",
+        "xray:PutTraceSegments"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "taskFunctionServiceRoleDefaultPolicyDD9784DE",
+    "Roles": [
+     {
+      "Ref": "taskFunctionServiceRole31E35058"
+     }
+    ]
+   },
+   "Metadata": {
+    "cfn_nag": {
+     "rules_to_suppress": [
+      {
+       "id": "W12",
+       "reason": "Lambda needs the following minimum required permissions to send trace data to X-Ray and access ENIs in a VPC."
+      }
+     ]
+    }
+   }
+  },
+  "taskFunctionBFDAC5DE": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+     },
+     "S3Key": "2c77a7150383973352510b020ce9abcf00245f43f72cf37c75d7ee9dc413fee8.zip"
+    },
+    "Environment": {
+     "Variables": {
+      "LAMBDA_NAME": "existing-function"
+     }
+    },
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "taskFunctionServiceRole31E35058",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs20.x",
+    "TracingConfig": {
+     "Mode": "Active"
+    }
+   },
+   "DependsOn": [
+    "taskFunctionServiceRoleDefaultPolicyDD9784DE",
+    "taskFunctionServiceRole31E35058"
+   ],
+   "Metadata": {
+    "cfn_nag": {
+     "rules_to_suppress": [
+      {
+       "id": "W58",
+       "reason": "Lambda functions has the required permission to write CloudWatch Logs. It uses custom policy instead of arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole with tighter permissions."
+      },
+      {
+       "id": "W89",
+       "reason": "This is not a rule for the general case, just for specific use cases/industries"
+      },
+      {
+       "id": "W92",
+       "reason": "Impossible for us to define the correct concurrency for clients"
+      }
+     ]
+    }
+   }
+  },
   "testlambdastepfunctionsconstructStateMachineLogGroup1FD4C0D4": {
    "Type": "AWS::Logs::LogGroup",
    "Properties": {
@@ -65,15 +203,30 @@
     "PolicyDocument": {
      "Statement": [
       {
-       "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
+       "Action": "lambda:InvokeFunction",
        "Effect": "Allow",
-       "Resource": "*"
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "taskFunctionBFDAC5DE",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "taskFunctionBFDAC5DE",
+             "Arn"
+            ]
+           },
+           ":*"
+          ]
+         ]
+        }
+       ]
       },
       {
        "Action": [
@@ -102,6 +255,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"
@@ -127,7 +291,25 @@
   "testlambdastepfunctionsconstructStateMachineE1526513": {
    "Type": "AWS::StepFunctions::StateMachine",
    "Properties": {
-    "DefinitionString": "{\"StartAt\":\"StartState\",\"States\":{\"StartState\":{\"Type\":\"Pass\",\"End\":true}}}",
+    "DefinitionString": {
+     "Fn::Join": [
+      "",
+      [
+       "{\"StartAt\":\"permission-test\",\"States\":{\"permission-test\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+       {
+        "Fn::GetAtt": [
+         "taskFunctionBFDAC5DE",
+         "Arn"
+        ]
+       },
+       "\",\"Payload.$\":\"$\"}}}}"
+      ]
+     ]
+    },
     "LoggingConfiguration": {
      "Destinations": [
       {
@@ -264,7 +446,6 @@
     },
     "Environment": {
      "Variables": {
-      "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
       "STATE_MACHINE_ARN": {
        "Ref": "testlambdastepfunctionsconstructStateMachineE1526513"
       }
@@ -277,7 +458,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs16.x",
+    "Runtime": "nodejs20.x",
     "TracingConfig": {
      "Mode": "Active"
     }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/c2b98904a49287b9ba1363cb78aac93819c58156fcd28a324518b3025a1d44c2.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/5a0b4a97ac40ee534cc8dd7e2b2a811b691eb4b8e17da20c4b309ab130204f24.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -82,6 +82,24 @@
         "lamstp-deploy-lambda.assets"
       ],
       "metadata": {
+        "/lamstp-deploy-lambda/taskFunctionServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "taskFunctionServiceRole31E35058"
+          }
+        ],
+        "/lamstp-deploy-lambda/taskFunctionServiceRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "taskFunctionServiceRoleDefaultPolicyDD9784DE"
+          }
+        ],
+        "/lamstp-deploy-lambda/taskFunction/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "taskFunctionBFDAC5DE"
+          }
+        ],
         "/lamstp-deploy-lambda/test-lambda-stepfunctions-construct/StateMachineLogGroup/Resource": [
           {
             "type": "aws:cdk:logicalId",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/tree.json
@@ -8,12 +8,206 @@
         "id": "lamstp-deploy-lambda",
         "path": "lamstp-deploy-lambda",
         "children": {
-          "StartState": {
-            "id": "StartState",
-            "path": "lamstp-deploy-lambda/StartState",
+          "taskFunctionServiceRole": {
+            "id": "taskFunctionServiceRole",
+            "path": "lamstp-deploy-lambda/taskFunctionServiceRole",
+            "children": {
+              "ImporttaskFunctionServiceRole": {
+                "id": "ImporttaskFunctionServiceRole",
+                "path": "lamstp-deploy-lambda/taskFunctionServiceRole/ImporttaskFunctionServiceRole",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.Resource",
+                  "version": "2.127.0"
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "lamstp-deploy-lambda/taskFunctionServiceRole/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                  "aws:cdk:cloudformation:props": {
+                    "assumeRolePolicyDocument": {
+                      "Statement": [
+                        {
+                          "Action": "sts:AssumeRole",
+                          "Effect": "Allow",
+                          "Principal": {
+                            "Service": "lambda.amazonaws.com"
+                          }
+                        }
+                      ],
+                      "Version": "2012-10-17"
+                    },
+                    "policies": [
+                      {
+                        "policyName": "LambdaFunctionServiceRolePolicy",
+                        "policyDocument": {
+                          "Statement": [
+                            {
+                              "Action": [
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents"
+                              ],
+                              "Effect": "Allow",
+                              "Resource": {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":logs:",
+                                    {
+                                      "Ref": "AWS::Region"
+                                    },
+                                    ":",
+                                    {
+                                      "Ref": "AWS::AccountId"
+                                    },
+                                    ":log-group:/aws/lambda/*"
+                                  ]
+                                ]
+                              }
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                  "version": "2.127.0"
+                }
+              },
+              "DefaultPolicy": {
+                "id": "DefaultPolicy",
+                "path": "lamstp-deploy-lambda/taskFunctionServiceRole/DefaultPolicy",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "lamstp-deploy-lambda/taskFunctionServiceRole/DefaultPolicy/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                      "aws:cdk:cloudformation:props": {
+                        "policyDocument": {
+                          "Statement": [
+                            {
+                              "Action": [
+                                "xray:PutTelemetryRecords",
+                                "xray:PutTraceSegments"
+                              ],
+                              "Effect": "Allow",
+                              "Resource": "*"
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        },
+                        "policyName": "taskFunctionServiceRoleDefaultPolicyDD9784DE",
+                        "roles": [
+                          {
+                            "Ref": "taskFunctionServiceRole31E35058"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                      "version": "2.127.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.Policy",
+                  "version": "2.127.0"
+                }
+              }
+            },
             "constructInfo": {
-              "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "fqn": "aws-cdk-lib.aws_iam.Role",
+              "version": "2.127.0"
+            }
+          },
+          "taskFunction": {
+            "id": "taskFunction",
+            "path": "lamstp-deploy-lambda/taskFunction",
+            "children": {
+              "Code": {
+                "id": "Code",
+                "path": "lamstp-deploy-lambda/taskFunction/Code",
+                "children": {
+                  "Stage": {
+                    "id": "Stage",
+                    "path": "lamstp-deploy-lambda/taskFunction/Code/Stage",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.AssetStaging",
+                      "version": "2.127.0"
+                    }
+                  },
+                  "AssetBucket": {
+                    "id": "AssetBucket",
+                    "path": "lamstp-deploy-lambda/taskFunction/Code/AssetBucket",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                      "version": "2.127.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                  "version": "2.127.0"
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "lamstp-deploy-lambda/taskFunction/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                  "aws:cdk:cloudformation:props": {
+                    "code": {
+                      "s3Bucket": {
+                        "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                      },
+                      "s3Key": "2c77a7150383973352510b020ce9abcf00245f43f72cf37c75d7ee9dc413fee8.zip"
+                    },
+                    "environment": {
+                      "variables": {
+                        "LAMBDA_NAME": "existing-function"
+                      }
+                    },
+                    "handler": "index.handler",
+                    "role": {
+                      "Fn::GetAtt": [
+                        "taskFunctionServiceRole31E35058",
+                        "Arn"
+                      ]
+                    },
+                    "runtime": "nodejs20.x",
+                    "tracingConfig": {
+                      "mode": "Active"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                  "version": "2.127.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_lambda.Function",
+              "version": "2.127.0"
+            }
+          },
+          "permission-test": {
+            "id": "permission-test",
+            "path": "lamstp-deploy-lambda/permission-test",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.LambdaInvoke",
+              "version": "2.127.0"
             }
           },
           "test-lambda-stepfunctions-construct": {
@@ -55,13 +249,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "StateMachine": {
@@ -77,7 +271,7 @@
                         "path": "lamstp-deploy-lambda/test-lambda-stepfunctions-construct/StateMachine/Role/ImportRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -102,7 +296,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -118,18 +312,30 @@
                                 "policyDocument": {
                                   "Statement": [
                                     {
-                                      "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
+                                      "Action": "lambda:InvokeFunction",
                                       "Effect": "Allow",
-                                      "Resource": "*"
+                                      "Resource": [
+                                        {
+                                          "Fn::GetAtt": [
+                                            "taskFunctionBFDAC5DE",
+                                            "Arn"
+                                          ]
+                                        },
+                                        {
+                                          "Fn::Join": [
+                                            "",
+                                            [
+                                              {
+                                                "Fn::GetAtt": [
+                                                  "taskFunctionBFDAC5DE",
+                                                  "Arn"
+                                                ]
+                                              },
+                                              ":*"
+                                            ]
+                                          ]
+                                        }
+                                      ]
                                     },
                                     {
                                       "Action": [
@@ -158,6 +364,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -172,19 +389,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -193,7 +410,25 @@
                     "attributes": {
                       "aws:cdk:cloudformation:type": "AWS::StepFunctions::StateMachine",
                       "aws:cdk:cloudformation:props": {
-                        "definitionString": "{\"StartAt\":\"StartState\",\"States\":{\"StartState\":{\"Type\":\"Pass\",\"End\":true}}}",
+                        "definitionString": {
+                          "Fn::Join": [
+                            "",
+                            [
+                              "{\"StartAt\":\"permission-test\",\"States\":{\"permission-test\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "taskFunctionBFDAC5DE",
+                                  "Arn"
+                                ]
+                              },
+                              "\",\"Payload.$\":\"$\"}}}}"
+                            ]
+                          ]
+                        },
                         "loggingConfiguration": {
                           "destinations": [
                             {
@@ -219,13 +454,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "LambdaFunctionServiceRole": {
@@ -237,7 +472,7 @@
                     "path": "lamstp-deploy-lambda/test-lambda-stepfunctions-construct/LambdaFunctionServiceRole/ImportLambdaFunctionServiceRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -300,7 +535,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -343,19 +578,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "LambdaFunction": {
@@ -371,7 +606,7 @@
                         "path": "lamstp-deploy-lambda/test-lambda-stepfunctions-construct/LambdaFunction/Code/Stage",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.AssetStaging",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "AssetBucket": {
@@ -379,13 +614,13 @@
                         "path": "lamstp-deploy-lambda/test-lambda-stepfunctions-construct/LambdaFunction/Code/AssetBucket",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -402,7 +637,6 @@
                         },
                         "environment": {
                           "variables": {
-                            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
                             "STATE_MACHINE_ARN": {
                               "Ref": "testlambdastepfunctionsconstructStateMachineE1526513"
                             }
@@ -415,7 +649,7 @@
                             "Arn"
                           ]
                         },
-                        "runtime": "nodejs16.x",
+                        "runtime": "nodejs20.x",
                         "tracingConfig": {
                           "mode": "Active"
                         }
@@ -423,13 +657,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_lambda.Function",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionFailedAlarm": {
@@ -462,13 +696,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionThrottledAlarm": {
@@ -501,13 +735,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionAbortedAlarm": {
@@ -540,19 +774,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-lambda-stepfunctions.LambdaToStepfunctions",
-              "version": "2.50.0"
+              "version": "2.52.1"
             }
           },
           "Integ": {
@@ -568,7 +802,7 @@
                     "path": "lamstp-deploy-lambda/Integ/DefaultTest/Default",
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   },
                   "DeployAssert": {
@@ -580,7 +814,7 @@
                         "path": "lamstp-deploy-lambda/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -588,25 +822,25 @@
                         "path": "lamstp-deploy-lambda/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -614,7 +848,7 @@
             "path": "lamstp-deploy-lambda/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -622,13 +856,13 @@
             "path": "lamstp-deploy-lambda/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -636,13 +870,13 @@
         "path": "Tree",
         "constructInfo": {
           "fqn": "constructs.Construct",
-          "version": "10.0.0"
+          "version": "10.3.0"
         }
       }
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.ts
@@ -15,21 +15,32 @@
 import { App, Stack, RemovalPolicy } from "aws-cdk-lib";
 import { LambdaToStepfunctions, LambdaToStepfunctionsProps } from "../lib";
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
-import { generateIntegStackName } from '@aws-solutions-constructs/core';
+import * as sftasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import { generateIntegStackName, deployLambdaFunction } from '@aws-solutions-constructs/core';
 import { IntegTest } from '@aws-cdk/integ-tests-alpha';
 
 // Setup the app and stack
 const app = new App();
 const stack = new Stack(app, generateIntegStackName(__filename));
 
-// Create a start state for the state machine
-const startState = new stepfunctions.Pass(stack, 'StartState');
+const taskFunction = deployLambdaFunction(stack, {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: 'index.handler',
+  code: lambda.Code.fromAsset(`${__dirname}/lambda-task`),
+  environment: {
+    LAMBDA_NAME: 'existing-function'
+  }
+}, "taskFunction");
+
+// Launch the construct
+const startState = new sftasks.LambdaInvoke(stack, 'permission-test', {
+  lambdaFunction: taskFunction
+});
 
 // Setup the pattern props
 const props: LambdaToStepfunctionsProps = {
   lambdaFunctionProps: {
-    runtime: lambda.Runtime.NODEJS_16_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: 'index.handler',
     code: lambda.Code.fromAsset(`${__dirname}/lambda`)
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/lamstp-deployFunctionWithVpc.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/lamstp-deployFunctionWithVpc.assets.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "b35ce731890f20ab98405e8363a178e9824368b52fc13b0d3103fd6b22a6bf60": {
+    "f73cf110ad7b497d19e6dcbd73be5ed6cfd4a971a096c4f3d2159cf93be9d512": {
       "source": {
         "path": "lamstp-deployFunctionWithVpc.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b35ce731890f20ab98405e8363a178e9824368b52fc13b0d3103fd6b22a6bf60.json",
+          "objectKey": "f73cf110ad7b497d19e6dcbd73be5ed6cfd4a971a096c4f3d2159cf93be9d512.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/lamstp-deployFunctionWithVpc.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/lamstp-deployFunctionWithVpc.template.json
@@ -67,17 +67,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -103,6 +92,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"
@@ -300,7 +300,6 @@
     },
     "Environment": {
      "Variables": {
-      "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
       "STATE_MACHINE_ARN": {
        "Ref": "testlambdastepfunctionsStateMachine807F0A77"
       }
@@ -313,7 +312,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs16.x",
+    "Runtime": "nodejs20.x",
     "TracingConfig": {
      "Mode": "Active"
     },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/b35ce731890f20ab98405e8363a178e9824368b52fc13b0d3103fd6b22a6bf60.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f73cf110ad7b497d19e6dcbd73be5ed6cfd4a971a096c4f3d2159cf93be9d512.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/tree.json
@@ -13,7 +13,7 @@
             "path": "lamstp-deployFunctionWithVpc/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-lambda-stepfunctions": {
@@ -55,13 +55,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "StateMachine": {
@@ -77,7 +77,7 @@
                         "path": "lamstp-deployFunctionWithVpc/test-lambda-stepfunctions/StateMachine/Role/ImportRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -102,7 +102,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -117,20 +117,6 @@
                               "aws:cdk:cloudformation:props": {
                                 "policyDocument": {
                                   "Statement": [
-                                    {
-                                      "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
                                     {
                                       "Action": [
                                         "logs:DescribeLogGroups",
@@ -158,6 +144,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -172,19 +169,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -219,13 +216,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "LambdaFunctionServiceRole": {
@@ -237,7 +234,7 @@
                     "path": "lamstp-deployFunctionWithVpc/test-lambda-stepfunctions/LambdaFunctionServiceRole/ImportLambdaFunctionServiceRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -300,7 +297,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -348,19 +345,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ReplaceDefaultSecurityGroup-security-group": {
@@ -388,13 +385,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "LambdaFunction": {
@@ -410,7 +407,7 @@
                         "path": "lamstp-deployFunctionWithVpc/test-lambda-stepfunctions/LambdaFunction/Code/Stage",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.AssetStaging",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "AssetBucket": {
@@ -418,13 +415,13 @@
                         "path": "lamstp-deployFunctionWithVpc/test-lambda-stepfunctions/LambdaFunction/Code/AssetBucket",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -441,7 +438,6 @@
                         },
                         "environment": {
                           "variables": {
-                            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
                             "STATE_MACHINE_ARN": {
                               "Ref": "testlambdastepfunctionsStateMachine807F0A77"
                             }
@@ -454,7 +450,7 @@
                             "Arn"
                           ]
                         },
-                        "runtime": "nodejs16.x",
+                        "runtime": "nodejs20.x",
                         "tracingConfig": {
                           "mode": "Active"
                         },
@@ -480,13 +476,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_lambda.Function",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionFailedAlarm": {
@@ -519,13 +515,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionThrottledAlarm": {
@@ -558,13 +554,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionAbortedAlarm": {
@@ -597,19 +593,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-lambda-stepfunctions.LambdaToStepfunctions",
-              "version": "2.51.0"
+              "version": "2.52.1"
             }
           },
           "Vpc": {
@@ -636,7 +632,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnVPC",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "isolatedSubnet1": {
@@ -680,7 +676,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -688,7 +684,7 @@
                     "path": "lamstp-deployFunctionWithVpc/Vpc/isolatedSubnet1/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -710,7 +706,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -729,13 +725,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PrivateSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "isolatedSubnet2": {
@@ -779,7 +775,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnet",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Acl": {
@@ -787,7 +783,7 @@
                     "path": "lamstp-deployFunctionWithVpc/Vpc/isolatedSubnet2/Acl",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTable": {
@@ -809,7 +805,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnRouteTable",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "RouteTableAssociation": {
@@ -828,13 +824,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnSubnetRouteTableAssociation",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.PrivateSubnet",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "RestrictDefaultSecurityGroupCustomResource": {
@@ -846,13 +842,13 @@
                     "path": "lamstp-deployFunctionWithVpc/Vpc/RestrictDefaultSecurityGroupCustomResource/Default",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CustomResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "FlowLog": {
@@ -868,7 +864,7 @@
                         "path": "lamstp-deployFunctionWithVpc/Vpc/FlowLog/IAMRole/ImportIAMRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -899,7 +895,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -951,19 +947,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "LogGroup": {
@@ -987,13 +983,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "FlowLog": {
@@ -1027,13 +1023,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnFlowLog",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.FlowLog",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "STEP_FUNCTIONS": {
@@ -1083,19 +1079,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_ec2.CfnVPCEndpoint",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.Vpc",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "Custom::VpcRestrictDefaultSGCustomResourceProvider": {
@@ -1107,7 +1103,7 @@
                 "path": "lamstp-deployFunctionWithVpc/Custom::VpcRestrictDefaultSGCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Role": {
@@ -1115,7 +1111,7 @@
                 "path": "lamstp-deployFunctionWithVpc/Custom::VpcRestrictDefaultSGCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Handler": {
@@ -1123,13 +1119,13 @@
                 "path": "lamstp-deployFunctionWithVpc/Custom::VpcRestrictDefaultSGCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProviderBase",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "lamstp-deployFunctionWithVpc-STEP_FUNCTIONS-security-group": {
@@ -1185,13 +1181,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "Integ": {
@@ -1219,7 +1215,7 @@
                         "path": "lamstp-deployFunctionWithVpc/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -1227,25 +1223,25 @@
                         "path": "lamstp-deployFunctionWithVpc/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -1253,7 +1249,7 @@
             "path": "lamstp-deployFunctionWithVpc/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -1261,13 +1257,13 @@
             "path": "lamstp-deployFunctionWithVpc/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -1281,7 +1277,7 @@
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.ts
@@ -30,7 +30,7 @@ const startState = new stepfunctions.Pass(stack, 'StartState');
 // Definitions
 const props: LambdaToStepfunctionsProps = {
   lambdaFunctionProps: {
-    runtime: lambda.Runtime.NODEJS_16_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: 'index.handler',
     code: lambda.Code.fromAsset(`${__dirname}/lambda`)
   },

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/lamstp-existing-function.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/lamstp-existing-function.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "86ea03637ab5755e02f55730fc4e772609e3f2ef330319dbdc937bcef6a2fd92": {
+    "67c4655b8ea05fc8349a806af930d0eba7d8b47f8331dc6ff49ba1ee1ddfced6": {
       "source": {
         "path": "lamstp-existing-function.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "86ea03637ab5755e02f55730fc4e772609e3f2ef330319dbdc937bcef6a2fd92.json",
+          "objectKey": "67c4655b8ea05fc8349a806af930d0eba7d8b47f8331dc6ff49ba1ee1ddfced6.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/lamstp-existing-function.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/lamstp-existing-function.template.json
@@ -107,7 +107,6 @@
     },
     "Environment": {
      "Variables": {
-      "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
       "STATE_MACHINE_ARN": {
        "Ref": "testlambdastepfunctionsconstructStateMachineE1526513"
       }
@@ -120,7 +119,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs16.x",
+    "Runtime": "nodejs20.x",
     "TracingConfig": {
      "Mode": "Active"
     }
@@ -214,17 +213,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -250,6 +238,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/86ea03637ab5755e02f55730fc4e772609e3f2ef330319dbdc937bcef6a2fd92.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/67c4655b8ea05fc8349a806af930d0eba7d8b47f8331dc6ff49ba1ee1ddfced6.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/tree.json
@@ -13,7 +13,7 @@
             "path": "lamstp-existing-function/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "LambdaFunctionServiceRole": {
@@ -25,7 +25,7 @@
                 "path": "lamstp-existing-function/LambdaFunctionServiceRole/ImportLambdaFunctionServiceRole",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.Resource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Resource": {
@@ -88,7 +88,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "DefaultPolicy": {
@@ -131,19 +131,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Policy",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_iam.Role",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "LambdaFunction": {
@@ -159,7 +159,7 @@
                     "path": "lamstp-existing-function/LambdaFunction/Code/Stage",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.AssetStaging",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "AssetBucket": {
@@ -167,13 +167,13 @@
                     "path": "lamstp-existing-function/LambdaFunction/Code/AssetBucket",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Resource": {
@@ -190,7 +190,6 @@
                     },
                     "environment": {
                       "variables": {
-                        "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
                         "STATE_MACHINE_ARN": {
                           "Ref": "testlambdastepfunctionsconstructStateMachineE1526513"
                         }
@@ -203,7 +202,7 @@
                         "Arn"
                       ]
                     },
-                    "runtime": "nodejs16.x",
+                    "runtime": "nodejs20.x",
                     "tracingConfig": {
                       "mode": "Active"
                     }
@@ -211,13 +210,13 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_lambda.Function",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-lambda-stepfunctions-construct": {
@@ -259,13 +258,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "StateMachine": {
@@ -281,7 +280,7 @@
                         "path": "lamstp-existing-function/test-lambda-stepfunctions-construct/StateMachine/Role/ImportRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -306,7 +305,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -321,20 +320,6 @@
                               "aws:cdk:cloudformation:props": {
                                 "policyDocument": {
                                   "Statement": [
-                                    {
-                                      "Action": [
-                                        "logs:CreateLogDelivery",
-                                        "logs:DeleteLogDelivery",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeResourcePolicies",
-                                        "logs:GetLogDelivery",
-                                        "logs:ListLogDeliveries",
-                                        "logs:PutResourcePolicy",
-                                        "logs:UpdateLogDelivery"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
                                     {
                                       "Action": [
                                         "logs:DescribeLogGroups",
@@ -362,6 +347,17 @@
                                           ]
                                         ]
                                       }
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogDelivery",
+                                        "logs:DeleteLogDelivery",
+                                        "logs:GetLogDelivery",
+                                        "logs:ListLogDeliveries",
+                                        "logs:UpdateLogDelivery"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
                                     }
                                   ],
                                   "Version": "2012-10-17"
@@ -376,19 +372,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -423,13 +419,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionFailedAlarm": {
@@ -462,13 +458,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionThrottledAlarm": {
@@ -501,13 +497,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "ExecutionAbortedAlarm": {
@@ -540,19 +536,19 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-lambda-stepfunctions.LambdaToStepfunctions",
-              "version": "2.50.0"
+              "version": "2.52.1"
             }
           },
           "Integ": {
@@ -568,7 +564,7 @@
                     "path": "lamstp-existing-function/Integ/DefaultTest/Default",
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   },
                   "DeployAssert": {
@@ -580,7 +576,7 @@
                         "path": "lamstp-existing-function/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -588,25 +584,25 @@
                         "path": "lamstp-existing-function/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -614,7 +610,7 @@
             "path": "lamstp-existing-function/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -622,13 +618,13 @@
             "path": "lamstp-existing-function/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -636,13 +632,13 @@
         "path": "Tree",
         "constructInfo": {
           "fqn": "constructs.Construct",
-          "version": "10.0.0"
+          "version": "10.3.0"
         }
       }
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.ts
@@ -29,7 +29,7 @@ const startState = new stepfunctions.Pass(stack, 'StartState');
 
 // Setup the "existing" Lambda function props
 const lambdaFunctionProps = {
-  runtime: lambda.Runtime.NODEJS_16_X,
+  runtime: lambda.Runtime.NODEJS_20_X,
   handler: 'index.handler',
   code: lambda.Code.fromAsset(`${__dirname}/lambda`)
 };

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-stepfunctions.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-stepfunctions.test.ts
@@ -16,9 +16,10 @@ import { Stack } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as defaults from '@aws-solutions-constructs/core';
 import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
+import * as sftasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LambdaToStepfunctions, LambdaToStepfunctionsProps } from '../lib';
-import { Template } from "aws-cdk-lib/assertions";
+import { Template, Match } from "aws-cdk-lib/assertions";
 
 test('Test deployment with new Lambda function', () => {
   // Stack
@@ -27,7 +28,7 @@ test('Test deployment with new Lambda function', () => {
   const startState = new stepfunctions.Pass(stack, 'StartState');
   new LambdaToStepfunctions(stack, 'lambda-to-step-function-stack', {
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
       environment: {
@@ -52,16 +53,13 @@ test('Test deployment with new Lambda function', () => {
   });
 });
 
-// --------------------------------------------------------------
-// Test deployment with existing Lambda function
-// --------------------------------------------------------------
 test('Test deployment with existing Lambda function', () => {
   // Stack
   const stack = new Stack();
   // Helper declaration
   const startState = new stepfunctions.Pass(stack, 'StartState');
   const lambdaFunctionProps = {
-    runtime: lambda.Runtime.NODEJS_16_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: 'index.handler',
     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
     environment: {
@@ -93,7 +91,7 @@ test('Test invocation permissions', () => {
   // Helper declaration
   const startState = new stepfunctions.Pass(stack, 'StartState');
   const lambdaFunctionProps = {
-    runtime: lambda.Runtime.NODEJS_16_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: 'index.handler',
     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
     environment: {
@@ -141,7 +139,7 @@ test('Test the properties', () => {
   const startState = new stepfunctions.Pass(stack, 'StartState');
   const pattern = new LambdaToStepfunctions(stack, 'lambda-to-step-function-stack', {
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
       environment: {
@@ -152,7 +150,7 @@ test('Test the properties', () => {
       definition: startState
     }
   });
-    // Assertion 1
+  // Assertion 1
   const func = pattern.lambdaFunction;
   expect(func).toBeDefined();
   // Assertion 2
@@ -171,7 +169,7 @@ test('Test the properties with no CW Alarms', () => {
   const startState = new stepfunctions.Pass(stack, 'StartState');
   const pattern = new LambdaToStepfunctions(stack, 'lambda-to-step-function-stack', {
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
       environment: {
@@ -200,7 +198,7 @@ test('Test lambda function custom environment variable', () => {
   const startState = new stepfunctions.Pass(stack, 'StartState');
   new LambdaToStepfunctions(stack, 'lambda-to-step-function-stack', {
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`)
     },
@@ -214,10 +212,9 @@ test('Test lambda function custom environment variable', () => {
   const template = Template.fromStack(stack);
   template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'index.handler',
-    Runtime: 'nodejs16.x',
+    Runtime: 'nodejs20.x',
     Environment: {
       Variables: {
-        AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
         CUSTOM_STATE_MAHINCE: {
           Ref: 'lambdatostepfunctionstackStateMachine98EE8EFB'
         }
@@ -233,7 +230,7 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
   // Helper declaration
   new LambdaToStepfunctions(stack, "lambda-to-stepfunctions-stack", {
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`)
     },
@@ -278,9 +275,6 @@ test("Test minimal deployment that deploys a VPC without vpcProps", () => {
   template.resourceCountIs("AWS::EC2::InternetGateway", 0);
 });
 
-// --------------------------------------------------------------
-// Test minimal deployment that deploys a VPC w/vpcProps
-// --------------------------------------------------------------
 test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
   // Stack
   const stack = new Stack();
@@ -288,7 +282,7 @@ test("Test minimal deployment that deploys a VPC w/vpcProps", () => {
   // Helper declaration
   new LambdaToStepfunctions(stack, "lambda-to-stepfunctions-stack", {
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`)
     },
@@ -348,7 +342,7 @@ test("Test minimal deployment with an existing VPC", () => {
   // Helper declaration
   new LambdaToStepfunctions(stack, "lambda-to-stepfunctions-stack", {
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`)
     },
@@ -391,7 +385,7 @@ test("Test minimal deployment with an existing VPC and existing Lambda function 
   const startState = new stepfunctions.Pass(stack, 'StartState');
 
   const testLambdaFunction = new lambda.Function(stack, 'test-lamba', {
-    runtime: lambda.Runtime.NODEJS_16_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: "index.handler",
     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
   });
@@ -426,7 +420,7 @@ test("Confirm CheckVpcProps is called", () => {
     // Helper declaration
     new LambdaToStepfunctions(stack, "lambda-to-stepfunctions-stack", {
       lambdaFunctionProps: {
-        runtime: lambda.Runtime.NODEJS_16_X,
+        runtime: lambda.Runtime.NODEJS_20_X,
         handler: 'index.handler',
         code: lambda.Code.fromAsset(`${__dirname}/lambda`)
       },
@@ -445,7 +439,7 @@ test('Confirm call to CheckLambdaProps', () => {
   // Initial Setup
   const stack = new Stack();
   const lambdaFunction = new lambda.Function(stack, 'a-function', {
-    runtime: lambda.Runtime.NODEJS_16_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: 'index.handler',
     code: lambda.Code.fromAsset(`${__dirname}/lambda`),
   });
@@ -456,7 +450,7 @@ test('Confirm call to CheckLambdaProps', () => {
       definition: startState
     },
     lambdaFunctionProps: {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(`${__dirname}/lambda`),
     },
@@ -467,4 +461,49 @@ test('Confirm call to CheckLambdaProps', () => {
   };
   // Assertion
   expect(app).toThrowError('Error - Either provide lambdaFunctionProps or existingLambdaObj, but not both.\n');
+});
+
+test('Test deployment a state machine that needs priveleges for tasks', () => {
+  // Stack
+  const stack = new Stack();
+
+  const clientFunction = defaults.deployLambdaFunction(stack, {
+    runtime: lambda.Runtime.NODEJS_20_X,
+    handler: 'index.handler',
+    code: lambda.Code.fromAsset(`${__dirname}/lambda`),
+    environment: {
+      LAMBDA_NAME: 'existing-function'
+    }
+  });
+
+  const taskFunction = defaults.deployLambdaFunction(stack, {
+    runtime: lambda.Runtime.NODEJS_20_X,
+    handler: 'index.handler',
+    code: lambda.Code.fromAsset(`${__dirname}/lambda-task`),
+    environment: {
+      LAMBDA_NAME: 'existing-function'
+    }
+  }, "taskFunction");
+
+  // Launch the construct
+  const startState = new sftasks.LambdaInvoke(stack, 'permission-test', {
+    lambdaFunction: taskFunction
+  });
+
+  new LambdaToStepfunctions(stack, 'test-lambda-step-function-construct', {
+    existingLambdaObj: clientFunction,
+    stateMachineProps: {
+      definition: startState
+    }
+  });
+
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties("AWS::IAM::Policy", {
+    PolicyDocument: {
+      Statement: Match.arrayWith([Match.objectLike({
+        Action: 'lambda:InvokeFunction',
+        Effect: 'Allow'
+      })])
+    }
+  });
 });

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-task/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-task/index.js
@@ -1,0 +1,10 @@
+exports.handler = async event => {
+  // Log the event argument for debugging and for use in local development.
+  console.log(JSON.stringify(event, undefined, 2));
+
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "text/plain" },
+    body: JSON.stringify({ status: "OK", message: "SUCCESS" }),
+  };
+};

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4f8f31eed5ad5ae7d4c7c9b696cdfbd1c35f24cc1772faa29155656d61047d97.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/7bbe6eb1b53060cede977b4f562244858912596b2f9f7fbafcbf4113c5f9816c.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/s3stp-customLoggingBucket.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/s3stp-customLoggingBucket.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "4f8f31eed5ad5ae7d4c7c9b696cdfbd1c35f24cc1772faa29155656d61047d97": {
+    "7bbe6eb1b53060cede977b4f562244858912596b2f9f7fbafcbf4113c5f9816c": {
       "source": {
         "path": "s3stp-customLoggingBucket.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4f8f31eed5ad5ae7d4c7c9b696cdfbd1c35f24cc1772faa29155656d61047d97.json",
+          "objectKey": "7bbe6eb1b53060cede977b4f562244858912596b2f9f7fbafcbf4113c5f9816c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/s3stp-customLoggingBucket.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/s3stp-customLoggingBucket.template.json
@@ -433,17 +433,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -469,6 +458,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-customLoggingBucket.js.snapshot/tree.json
@@ -13,7 +13,7 @@
             "path": "s3stp-customLoggingBucket/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-s3-stepfunctions": {
@@ -71,7 +71,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Policy": {
@@ -205,13 +205,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "AutoDeleteObjectsCustomResource": {
@@ -223,19 +223,19 @@
                         "path": "s3stp-customLoggingBucket/test-s3-stepfunctions/S3LoggingBucket/AutoDeleteObjectsCustomResource/Default",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CustomResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "S3Bucket": {
@@ -294,7 +294,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Policy": {
@@ -392,13 +392,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "AutoDeleteObjectsCustomResource": {
@@ -410,13 +410,13 @@
                         "path": "s3stp-customLoggingBucket/test-s3-stepfunctions/S3Bucket/AutoDeleteObjectsCustomResource/Default",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CustomResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Notifications": {
@@ -428,19 +428,19 @@
                         "path": "s3stp-customLoggingBucket/test-s3-stepfunctions/S3Bucket/Notifications/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "test-s3-stepfunctions-event-rule-step-function-construct": {
@@ -482,13 +482,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "StateMachine": {
@@ -504,7 +504,7 @@
                             "path": "s3stp-customLoggingBucket/test-s3-stepfunctions/test-s3-stepfunctions-event-rule-step-function-construct/StateMachine/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           },
                           "Resource": {
@@ -529,7 +529,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -544,20 +544,6 @@
                                   "aws:cdk:cloudformation:props": {
                                     "policyDocument": {
                                       "Statement": [
-                                        {
-                                          "Action": [
-                                            "logs:CreateLogDelivery",
-                                            "logs:DeleteLogDelivery",
-                                            "logs:DescribeLogGroups",
-                                            "logs:DescribeResourcePolicies",
-                                            "logs:GetLogDelivery",
-                                            "logs:ListLogDeliveries",
-                                            "logs:PutResourcePolicy",
-                                            "logs:UpdateLogDelivery"
-                                          ],
-                                          "Effect": "Allow",
-                                          "Resource": "*"
-                                        },
                                         {
                                           "Action": [
                                             "logs:DescribeLogGroups",
@@ -585,6 +571,17 @@
                                               ]
                                             ]
                                           }
+                                        },
+                                        {
+                                          "Action": [
+                                            "logs:CreateLogDelivery",
+                                            "logs:DeleteLogDelivery",
+                                            "logs:GetLogDelivery",
+                                            "logs:ListLogDeliveries",
+                                            "logs:UpdateLogDelivery"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": "*"
                                         }
                                       ],
                                       "Version": "2012-10-17"
@@ -599,19 +596,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.118.0"
+                                  "version": "2.127.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -646,13 +643,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EventsRuleRole": {
@@ -664,7 +661,7 @@
                         "path": "s3stp-customLoggingBucket/test-s3-stepfunctions/test-s3-stepfunctions-event-rule-step-function-construct/EventsRuleRole/ImportEventsRuleRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -689,7 +686,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -724,19 +721,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EventsRule": {
@@ -785,13 +782,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_events.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_events.Rule",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionFailedAlarm": {
@@ -824,13 +821,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionThrottledAlarm": {
@@ -863,13 +860,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionAbortedAlarm": {
@@ -902,25 +899,25 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-solutions-constructs/aws-eventbridge-stepfunctions.EventbridgeToStepfunctions",
-                  "version": "2.50.0"
+                  "version": "2.52.1"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-s3-stepfunctions.S3ToStepfunctions",
-              "version": "2.50.0"
+              "version": "2.52.1"
             }
           },
           "Custom::S3AutoDeleteObjectsCustomResourceProvider": {
@@ -932,7 +929,7 @@
                 "path": "s3stp-customLoggingBucket/Custom::S3AutoDeleteObjectsCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Role": {
@@ -940,7 +937,7 @@
                 "path": "s3stp-customLoggingBucket/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Handler": {
@@ -948,13 +945,13 @@
                 "path": "s3stp-customLoggingBucket/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProviderBase",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "BucketNotificationsHandler050a0587b7544547bf325f094a3db834": {
@@ -970,7 +967,7 @@
                     "path": "s3stp-customLoggingBucket/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/ImportRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -1009,7 +1006,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -1042,19 +1039,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Resource": {
@@ -1062,13 +1059,13 @@
                 "path": "s3stp-customLoggingBucket/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Resource",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "constructs.Construct",
-              "version": "10.0.0"
+              "version": "10.3.0"
             }
           },
           "Integ": {
@@ -1084,7 +1081,7 @@
                     "path": "s3stp-customLoggingBucket/Integ/DefaultTest/Default",
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   },
                   "DeployAssert": {
@@ -1096,7 +1093,7 @@
                         "path": "s3stp-customLoggingBucket/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -1104,25 +1101,25 @@
                         "path": "s3stp-customLoggingBucket/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -1130,7 +1127,7 @@
             "path": "s3stp-customLoggingBucket/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -1138,13 +1135,13 @@
             "path": "s3stp-customLoggingBucket/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -1152,13 +1149,13 @@
         "path": "Tree",
         "constructInfo": {
           "fqn": "constructs.Construct",
-          "version": "10.0.0"
+          "version": "10.3.0"
         }
       }
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/93bec72bfde49aeae2880613cbc62da257bb897e19b98b20b3de3f249cc2801d.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3b3b1f35263dc91b13ee5f6e4c7814483f94c66e2b1e70c9d4c938e6c429dc4b.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/s3stp-pre-existing-bucket.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/s3stp-pre-existing-bucket.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "93bec72bfde49aeae2880613cbc62da257bb897e19b98b20b3de3f249cc2801d": {
+    "3b3b1f35263dc91b13ee5f6e4c7814483f94c66e2b1e70c9d4c938e6c429dc4b": {
       "source": {
         "path": "s3stp-pre-existing-bucket.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "93bec72bfde49aeae2880613cbc62da257bb897e19b98b20b3de3f249cc2801d.json",
+          "objectKey": "3b3b1f35263dc91b13ee5f6e4c7814483f94c66e2b1e70c9d4c938e6c429dc4b.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/s3stp-pre-existing-bucket.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/s3stp-pre-existing-bucket.template.json
@@ -573,17 +573,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -609,6 +598,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-pre-existing-bucket.js.snapshot/tree.json
@@ -40,7 +40,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Policy": {
@@ -174,13 +174,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "AutoDeleteObjectsCustomResource": {
@@ -192,19 +192,19 @@
                     "path": "s3stp-pre-existing-bucket/scrapBucketLog/AutoDeleteObjectsCustomResource/Default",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CustomResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_s3.Bucket",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "Custom::S3AutoDeleteObjectsCustomResourceProvider": {
@@ -216,7 +216,7 @@
                 "path": "s3stp-pre-existing-bucket/Custom::S3AutoDeleteObjectsCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Role": {
@@ -224,7 +224,7 @@
                 "path": "s3stp-pre-existing-bucket/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Handler": {
@@ -232,13 +232,13 @@
                 "path": "s3stp-pre-existing-bucket/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProviderBase",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "scrapBucket": {
@@ -278,7 +278,7 @@
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Policy": {
@@ -376,13 +376,13 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "AutoDeleteObjectsCustomResource": {
@@ -394,13 +394,13 @@
                     "path": "s3stp-pre-existing-bucket/scrapBucket/AutoDeleteObjectsCustomResource/Default",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CustomResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Notifications": {
@@ -412,19 +412,19 @@
                     "path": "s3stp-pre-existing-bucket/scrapBucket/Notifications/Resource",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
-                  "version": "10.0.0"
+                  "version": "10.3.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_s3.Bucket",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "BucketNotificationsHandler050a0587b7544547bf325f094a3db834": {
@@ -440,7 +440,7 @@
                     "path": "s3stp-pre-existing-bucket/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/ImportRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -479,7 +479,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -512,19 +512,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Resource": {
@@ -532,13 +532,13 @@
                 "path": "s3stp-pre-existing-bucket/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Resource",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "constructs.Construct",
-              "version": "10.0.0"
+              "version": "10.3.0"
             }
           },
           "StartState": {
@@ -546,7 +546,7 @@
             "path": "s3stp-pre-existing-bucket/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-s3-stepfunctions-pre-existing-bucket-construct": {
@@ -592,13 +592,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "StateMachine": {
@@ -614,7 +614,7 @@
                             "path": "s3stp-pre-existing-bucket/test-s3-stepfunctions-pre-existing-bucket-construct/test-s3-stepfunctions-pre-existing-bucket-construct-event-rule-step-function-construct/StateMachine/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           },
                           "Resource": {
@@ -639,7 +639,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -654,20 +654,6 @@
                                   "aws:cdk:cloudformation:props": {
                                     "policyDocument": {
                                       "Statement": [
-                                        {
-                                          "Action": [
-                                            "logs:CreateLogDelivery",
-                                            "logs:DeleteLogDelivery",
-                                            "logs:DescribeLogGroups",
-                                            "logs:DescribeResourcePolicies",
-                                            "logs:GetLogDelivery",
-                                            "logs:ListLogDeliveries",
-                                            "logs:PutResourcePolicy",
-                                            "logs:UpdateLogDelivery"
-                                          ],
-                                          "Effect": "Allow",
-                                          "Resource": "*"
-                                        },
                                         {
                                           "Action": [
                                             "logs:DescribeLogGroups",
@@ -695,6 +681,17 @@
                                               ]
                                             ]
                                           }
+                                        },
+                                        {
+                                          "Action": [
+                                            "logs:CreateLogDelivery",
+                                            "logs:DeleteLogDelivery",
+                                            "logs:GetLogDelivery",
+                                            "logs:ListLogDeliveries",
+                                            "logs:UpdateLogDelivery"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": "*"
                                         }
                                       ],
                                       "Version": "2012-10-17"
@@ -709,19 +706,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.118.0"
+                                  "version": "2.127.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -756,13 +753,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EventsRuleRole": {
@@ -774,7 +771,7 @@
                         "path": "s3stp-pre-existing-bucket/test-s3-stepfunctions-pre-existing-bucket-construct/test-s3-stepfunctions-pre-existing-bucket-construct-event-rule-step-function-construct/EventsRuleRole/ImportEventsRuleRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -799,7 +796,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -834,19 +831,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EventsRule": {
@@ -895,13 +892,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_events.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_events.Rule",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionFailedAlarm": {
@@ -934,13 +931,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionThrottledAlarm": {
@@ -973,13 +970,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionAbortedAlarm": {
@@ -1012,25 +1009,25 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-solutions-constructs/aws-eventbridge-stepfunctions.EventbridgeToStepfunctions",
-                  "version": "2.50.0"
+                  "version": "2.52.1"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-s3-stepfunctions.S3ToStepfunctions",
-              "version": "2.50.0"
+              "version": "2.52.1"
             }
           },
           "Integ": {
@@ -1046,7 +1043,7 @@
                     "path": "s3stp-pre-existing-bucket/Integ/DefaultTest/Default",
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   },
                   "DeployAssert": {
@@ -1058,7 +1055,7 @@
                         "path": "s3stp-pre-existing-bucket/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -1066,25 +1063,25 @@
                         "path": "s3stp-pre-existing-bucket/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -1092,7 +1089,7 @@
             "path": "s3stp-pre-existing-bucket/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -1100,13 +1097,13 @@
             "path": "s3stp-pre-existing-bucket/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -1114,13 +1111,13 @@
         "path": "Tree",
         "constructInfo": {
           "fqn": "constructs.Construct",
-          "version": "10.0.0"
+          "version": "10.3.0"
         }
       }
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/27dd0857086a60fa45f9d4df1ec6cdffe3a0f1beb514be4184187179163f7c17.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0e2cf5494f34ef06909ced76e0a098d3a51a3bab1d020f973a3c4da6411423c6.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/s3stp-s3-stepfunctions-no-argument.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/s3stp-s3-stepfunctions-no-argument.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "27dd0857086a60fa45f9d4df1ec6cdffe3a0f1beb514be4184187179163f7c17": {
+    "0e2cf5494f34ef06909ced76e0a098d3a51a3bab1d020f973a3c4da6411423c6": {
       "source": {
         "path": "s3stp-s3-stepfunctions-no-argument.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "27dd0857086a60fa45f9d4df1ec6cdffe3a0f1beb514be4184187179163f7c17.json",
+          "objectKey": "0e2cf5494f34ef06909ced76e0a098d3a51a3bab1d020f973a3c4da6411423c6.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/s3stp-s3-stepfunctions-no-argument.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/s3stp-s3-stepfunctions-no-argument.template.json
@@ -430,17 +430,6 @@
      "Statement": [
       {
        "Action": [
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": [
         "logs:DescribeLogGroups",
         "logs:DescribeResourcePolicies",
         "logs:PutResourcePolicy"
@@ -466,6 +455,17 @@
          ]
         ]
        }
+      },
+      {
+       "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:UpdateLogDelivery"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
       }
      ],
      "Version": "2012-10-17"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/integ.s3stp-s3-stepfunctions-no-argument.js.snapshot/tree.json
@@ -13,7 +13,7 @@
             "path": "s3stp-s3-stepfunctions-no-argument/StartState",
             "constructInfo": {
               "fqn": "aws-cdk-lib.aws_stepfunctions.Pass",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "test-s3-stepfunctions-construct": {
@@ -58,7 +58,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Policy": {
@@ -192,13 +192,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "AutoDeleteObjectsCustomResource": {
@@ -210,19 +210,19 @@
                         "path": "s3stp-s3-stepfunctions-no-argument/test-s3-stepfunctions-construct/S3LoggingBucket/AutoDeleteObjectsCustomResource/Default",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CustomResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "S3Bucket": {
@@ -281,7 +281,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Policy": {
@@ -379,13 +379,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "AutoDeleteObjectsCustomResource": {
@@ -397,13 +397,13 @@
                         "path": "s3stp-s3-stepfunctions-no-argument/test-s3-stepfunctions-construct/S3Bucket/AutoDeleteObjectsCustomResource/Default",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CustomResource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Notifications": {
@@ -415,19 +415,19 @@
                         "path": "s3stp-s3-stepfunctions-no-argument/test-s3-stepfunctions-construct/S3Bucket/Notifications/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "test-s3-stepfunctions-construct-event-rule-step-function-construct": {
@@ -469,13 +469,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "StateMachine": {
@@ -491,7 +491,7 @@
                             "path": "s3stp-s3-stepfunctions-no-argument/test-s3-stepfunctions-construct/test-s3-stepfunctions-construct-event-rule-step-function-construct/StateMachine/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           },
                           "Resource": {
@@ -516,7 +516,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -531,20 +531,6 @@
                                   "aws:cdk:cloudformation:props": {
                                     "policyDocument": {
                                       "Statement": [
-                                        {
-                                          "Action": [
-                                            "logs:CreateLogDelivery",
-                                            "logs:DeleteLogDelivery",
-                                            "logs:DescribeLogGroups",
-                                            "logs:DescribeResourcePolicies",
-                                            "logs:GetLogDelivery",
-                                            "logs:ListLogDeliveries",
-                                            "logs:PutResourcePolicy",
-                                            "logs:UpdateLogDelivery"
-                                          ],
-                                          "Effect": "Allow",
-                                          "Resource": "*"
-                                        },
                                         {
                                           "Action": [
                                             "logs:DescribeLogGroups",
@@ -572,6 +558,17 @@
                                               ]
                                             ]
                                           }
+                                        },
+                                        {
+                                          "Action": [
+                                            "logs:CreateLogDelivery",
+                                            "logs:DeleteLogDelivery",
+                                            "logs:GetLogDelivery",
+                                            "logs:ListLogDeliveries",
+                                            "logs:UpdateLogDelivery"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": "*"
                                         }
                                       ],
                                       "Version": "2012-10-17"
@@ -586,19 +583,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.118.0"
+                                  "version": "2.127.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -633,13 +630,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_stepfunctions.CfnStateMachine",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_stepfunctions.StateMachine",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EventsRuleRole": {
@@ -651,7 +648,7 @@
                         "path": "s3stp-s3-stepfunctions-no-argument/test-s3-stepfunctions-construct/test-s3-stepfunctions-construct-event-rule-step-function-construct/EventsRuleRole/ImportEventsRuleRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "Resource": {
@@ -676,7 +673,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "DefaultPolicy": {
@@ -711,19 +708,19 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                              "version": "2.118.0"
+                              "version": "2.127.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Policy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "EventsRule": {
@@ -772,13 +769,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_events.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_events.Rule",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionFailedAlarm": {
@@ -811,13 +808,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionThrottledAlarm": {
@@ -850,13 +847,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "ExecutionAbortedAlarm": {
@@ -889,25 +886,25 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_cloudwatch.CfnAlarm",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_cloudwatch.Alarm",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-solutions-constructs/aws-eventbridge-stepfunctions.EventbridgeToStepfunctions",
-                  "version": "2.50.0"
+                  "version": "2.52.1"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-s3-stepfunctions.S3ToStepfunctions",
-              "version": "2.50.0"
+              "version": "2.52.1"
             }
           },
           "Custom::S3AutoDeleteObjectsCustomResourceProvider": {
@@ -919,7 +916,7 @@
                 "path": "s3stp-s3-stepfunctions-no-argument/Custom::S3AutoDeleteObjectsCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Role": {
@@ -927,7 +924,7 @@
                 "path": "s3stp-s3-stepfunctions-no-argument/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Handler": {
@@ -935,13 +932,13 @@
                 "path": "s3stp-s3-stepfunctions-no-argument/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProviderBase",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "BucketNotificationsHandler050a0587b7544547bf325f094a3db834": {
@@ -957,7 +954,7 @@
                     "path": "s3stp-s3-stepfunctions-no-argument/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/ImportRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "Resource": {
@@ -996,7 +993,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -1029,19 +1026,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               },
               "Resource": {
@@ -1049,13 +1046,13 @@
                 "path": "s3stp-s3-stepfunctions-no-argument/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Resource",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.118.0"
+                  "version": "2.127.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "constructs.Construct",
-              "version": "10.0.0"
+              "version": "10.3.0"
             }
           },
           "Integ": {
@@ -1071,7 +1068,7 @@
                     "path": "s3stp-s3-stepfunctions-no-argument/Integ/DefaultTest/Default",
                     "constructInfo": {
                       "fqn": "constructs.Construct",
-                      "version": "10.0.0"
+                      "version": "10.3.0"
                     }
                   },
                   "DeployAssert": {
@@ -1083,7 +1080,7 @@
                         "path": "s3stp-s3-stepfunctions-no-argument/Integ/DefaultTest/DeployAssert/BootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnParameter",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       },
                       "CheckBootstrapVersion": {
@@ -1091,25 +1088,25 @@
                         "path": "s3stp-s3-stepfunctions-no-argument/Integ/DefaultTest/DeployAssert/CheckBootstrapVersion",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnRule",
-                          "version": "2.118.0"
+                          "version": "2.127.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Stack",
-                      "version": "2.118.0"
+                      "version": "2.127.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "@aws-cdk/integ-tests-alpha.IntegTestCase",
-                  "version": "2.118.0-alpha.0"
+                  "version": "2.127.0-alpha.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "@aws-cdk/integ-tests-alpha.IntegTest",
-              "version": "2.118.0-alpha.0"
+              "version": "2.127.0-alpha.0"
             }
           },
           "BootstrapVersion": {
@@ -1117,7 +1114,7 @@
             "path": "s3stp-s3-stepfunctions-no-argument/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -1125,13 +1122,13 @@
             "path": "s3stp-s3-stepfunctions-no-argument/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.118.0"
+              "version": "2.127.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.118.0"
+          "version": "2.127.0"
         }
       },
       "Tree": {
@@ -1139,13 +1136,13 @@
         "path": "Tree",
         "constructInfo": {
           "fqn": "constructs.Construct",
-          "version": "10.0.0"
+          "version": "10.3.0"
         }
       }
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.118.0"
+      "version": "2.127.0"
     }
   }
 }

--- a/source/patterns/@aws-solutions-constructs/core/test/step-function-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/step-function-helper.test.ts
@@ -90,21 +90,9 @@ test('Check default Cloudwatch permissions', () => {
   });
   // Assertion
   expect(buildStateMachineResponse.stateMachine).toBeDefined();
-  expect(buildStateMachineResponse.stateMachine).toBeDefined();
   Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
     PolicyDocument: {
       Statement: [
-        {
-          Action: [
-            "logs:CreateLogDelivery",
-            "logs:GetLogDelivery",
-            "logs:UpdateLogDelivery",
-            "logs:DeleteLogDelivery",
-            "logs:ListLogDeliveries"
-          ],
-          Effect: "Allow",
-          Resource: "*"
-        },
         {
           Action: [
             "logs:PutResourcePolicy",
@@ -132,6 +120,17 @@ test('Check default Cloudwatch permissions', () => {
               ]
             ]
           }
+        },
+        {
+          Action: [
+            "logs:CreateLogDelivery",
+            "logs:GetLogDelivery",
+            "logs:UpdateLogDelivery",
+            "logs:DeleteLogDelivery",
+            "logs:ListLogDeliveries"
+          ],
+          Effect: "Allow",
+          Resource: "*"
         }
       ],
       Version: "2012-10-17"
@@ -149,7 +148,6 @@ test('Count State Machine CW Alarms', () => {
     definition: startState
   });
   const cwList = defaults.buildStepFunctionCWAlarms(stack, buildStateMachineResponse.stateMachine);
-  expect(buildStateMachineResponse.stateMachine).toBeDefined();
   expect(buildStateMachineResponse.stateMachine).toBeDefined();
 
   expect(cwList.length).toEqual(3);


### PR DESCRIPTION
…ests to confirm

*Issue #, if available:*
Fixes: #1077 

*Description of changes:*
Instead of relying on a fixed ordinal to find the cloudwatch log permissions, traverse the policy to ensure we are replacing the correct statment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.