### PR TITLE
fix(openapigateway-to-lambda): refine python example in README based on deployed code

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/README.md
@@ -22,7 +22,9 @@
 
 This AWS Solutions Construct implements an Amazon API Gateway REST API defined by an OpenAPI specification file connected to an AWS Lambda function.
 
-Here is a minimal deployable pattern definition:
+Here is a minimal deployable pattern definition. 
+
+**NOTE** The referenced `openapi/apiDefinition.yaml` openapi definition file and `messages-lambda` lambda package directory for the three code samples below can both be found under this constructs `test` folder (`<repository_root>/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test`)
 
 Typescript
 ``` typescript
@@ -34,7 +36,7 @@ import * as path from 'path';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 const apiDefinitionAsset = new Asset(this, 'ApiDefinitionAsset', {
-  path: path.join(__dirname, 'openapispec.yaml')
+  path: path.join(__dirname, 'openapi/apiDefinition.yaml')
 });
 
 new OpenApiGatewayToLambda(this, 'OpenApiGatewayToLambda', {
@@ -99,13 +101,13 @@ import java.util.Collections;
 
 import static software.amazon.awscdk.services.lambda.Runtime.NODEJS_18_X;
 
-final Asset apiDefinitionAsset = new Asset(this, "ApiDefinition", AssetProps.builder().path("openapispec.yaml").build());
+final Asset apiDefinitionAsset = new Asset(this, "ApiDefinition", AssetProps.builder().path("openapi/apiDefinition.yaml").build());
 
 final ApiIntegration apiIntegration = ApiIntegration.builder()
     .id("MessagesHandler")
     .lambdaFunctionProps(new FunctionProps.Builder()
         .runtime(NODEJS_18_X)
-        .code(Code.fromAsset("lambda"))
+        .code(Code.fromAsset("messages-lambda"))
         .handler("index.handler")
         .build())
     .build();


### PR DESCRIPTION
I recently created a python-based CDK app using the `openapigateway-to-lambda` solutions construct, and noticed a few discrepancies with the example in our README. This PR updates the example code to be correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.