### PR TITLE
fix(aws-kinesisstreams-kinesisfirehose-s3): allow later versions of cdk lib by updating peerDependencies

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
@@ -82,7 +82,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "^0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisstreams-lambda": "0.0.0"
   },

--- a/source/use_cases/aws-custom-glue-etl/package.json
+++ b/source/use_cases/aws-custom-glue-etl/package.json
@@ -47,6 +47,6 @@
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/package.json
@@ -53,6 +53,6 @@
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d7ef2fab3e8af1933261371cc1e90baab16122dc5fca1ca9e5ea26a4720f4eee/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d7ef2fab3e8af1933261371cc1e90baab16122dc5fca1ca9e5ea26a4720f4eee/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/use_cases/aws-s3-static-website/package.json
+++ b/source/use_cases/aws-s3-static-website/package.json
@@ -47,6 +47,6 @@
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Addresses Issue 1094

*Description of changes:*
Update package.json for aws-kinesisstreams-kinesisfirehose-s3 and 6 other constructs/samples with the same issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.