### PR TITLE
fix(aws-cloudfront-s3): disable cloudfront access logs when `logS3AccessLogs` is set to `false`

### DIFF
--- a/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/cloudfront-distribution-helper.ts
@@ -109,6 +109,7 @@ export interface CreateCloudFrontDistributionForS3Props {
   readonly httpSecurityHeaders?: boolean,
   readonly cloudFrontLoggingBucketProps?: s3.BucketProps,
   readonly responseHeadersPolicyProps?: cloudfront.ResponseHeadersPolicyProps
+  readonly enableCloudFrontLogging?: boolean;
 }
 
 export interface CreateCloudFrontDistributionForS3Response {
@@ -129,7 +130,12 @@ export function createCloudFrontDistributionForS3(
   const httpSecurityHeaders = props.httpSecurityHeaders ?? true;
   const cloudfrontFunction = getCloudfrontFunction(httpSecurityHeaders, scope);
 
-  const loggingBucket = getLoggingBucket(props.cloudFrontDistributionProps, scope, props.cloudFrontLoggingBucketProps);
+  const enableCloudFrontLogging = props.enableCloudFrontLogging ?? true;
+
+  const loggingBucket = enableCloudFrontLogging ? 
+    getLoggingBucket(props.cloudFrontDistributionProps, scope, props.cloudFrontLoggingBucketProps) : 
+    undefined;
+
 
   let originAccessControl;
   let originProps = {};
@@ -157,6 +163,8 @@ export function createCloudFrontDistributionForS3(
       new cloudfront.ResponseHeadersPolicy(scope, 'ResponseHeadersPolicy', props.responseHeadersPolicyProps) :
       undefined
   );
+
+  defaultprops.enableLogging = enableCloudFrontLogging;
 
   const cfprops = consolidateProps(defaultprops, props.cloudFrontDistributionProps);
   // Create the Cloudfront Distribution


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.