### PR TITLE
fix(resources/template-writer): add IAM policy as customResource dependency

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/cc472bbc9b3f388de29e5834aa43374fb2caf4fa98fdf07936cb76dc9f9697f2.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4657e305aa94c87300b65d66b779b36f89e94a27a6cbec6f10fa032edb836a56.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/opilam-apiFromAssetExistingLambdaFunctions.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/opilam-apiFromAssetExistingLambdaFunctions.assets.json
@@ -79,7 +79,7 @@
         }
       }
     },
-    "cc472bbc9b3f388de29e5834aa43374fb2caf4fa98fdf07936cb76dc9f9697f2": {
+    "4657e305aa94c87300b65d66b779b36f89e94a27a6cbec6f10fa032edb836a56": {
       "source": {
         "path": "opilam-apiFromAssetExistingLambdaFunctions.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "cc472bbc9b3f388de29e5834aa43374fb2caf4fa98fdf07936cb76dc9f9697f2.json",
+          "objectKey": "4657e305aa94c87300b65d66b779b36f89e94a27a6cbec6f10fa032edb836a56.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/opilam-apiFromAssetExistingLambdaFunctions.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/opilam-apiFromAssetExistingLambdaFunctions.template.json
@@ -737,6 +737,9 @@
      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
     }
    },
+   "DependsOn": [
+    "OpenApiGatewayToLambdaApiTemplateWriterPolicy5B3085E5"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetExistingLambdaFunctions.js.snapshot/tree.json
@@ -1350,7 +1350,7 @@
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-openapigateway-lambda.OpenApiGatewayToLambda",
-              "version": "2.60.0"
+              "version": "2.61.0"
             }
           },
           "LatestNodeRuntimeMap": {

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/b2c940c9e01aafc78df6b0ddb8102def3ff0a14f316d80e3d76921915a8a6b12.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/34e4475454df938a6455b7952b7d26f110717f4f3163067061885efdfba1c0c3.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/opilam-apiFromAssetNewLambdaFunctions.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/opilam-apiFromAssetNewLambdaFunctions.assets.json
@@ -79,7 +79,7 @@
         }
       }
     },
-    "b2c940c9e01aafc78df6b0ddb8102def3ff0a14f316d80e3d76921915a8a6b12": {
+    "34e4475454df938a6455b7952b7d26f110717f4f3163067061885efdfba1c0c3": {
       "source": {
         "path": "opilam-apiFromAssetNewLambdaFunctions.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b2c940c9e01aafc78df6b0ddb8102def3ff0a14f316d80e3d76921915a8a6b12.json",
+          "objectKey": "34e4475454df938a6455b7952b7d26f110717f4f3163067061885efdfba1c0c3.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/opilam-apiFromAssetNewLambdaFunctions.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/opilam-apiFromAssetNewLambdaFunctions.template.json
@@ -736,6 +736,9 @@
      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
     }
    },
+   "DependsOn": [
+    "OpenApiGatewayToLambdaApiTemplateWriterPolicy5B3085E5"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetNewLambdaFunctions.js.snapshot/tree.json
@@ -1349,7 +1349,7 @@
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-openapigateway-lambda.OpenApiGatewayToLambda",
-              "version": "2.60.0"
+              "version": "2.61.0"
             }
           },
           "LatestNodeRuntimeMap": {

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/853470d1f0bc850f4dc49b30dde72ad23ca69dfaf079be46d6cf4c36d29094f1.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0a7a6398c4b2441c2df95bebf2fa1bf0210be8ad13baa7b830bc7a3551f1e101.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/opilam-apiFromAssetWithCognitoAuth.assets.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/opilam-apiFromAssetWithCognitoAuth.assets.json
@@ -79,7 +79,7 @@
         }
       }
     },
-    "853470d1f0bc850f4dc49b30dde72ad23ca69dfaf079be46d6cf4c36d29094f1": {
+    "0a7a6398c4b2441c2df95bebf2fa1bf0210be8ad13baa7b830bc7a3551f1e101": {
       "source": {
         "path": "opilam-apiFromAssetWithCognitoAuth.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "853470d1f0bc850f4dc49b30dde72ad23ca69dfaf079be46d6cf4c36d29094f1.json",
+          "objectKey": "0a7a6398c4b2441c2df95bebf2fa1bf0210be8ad13baa7b830bc7a3551f1e101.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/opilam-apiFromAssetWithCognitoAuth.template.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/opilam-apiFromAssetWithCognitoAuth.template.json
@@ -736,6 +736,9 @@
      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
     }
    },
+   "DependsOn": [
+    "OpenApiGatewayToLambdaApiTemplateWriterPolicy5B3085E5"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/tree.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/integ.opilam-apiFromAssetWithCognitoAuth.js.snapshot/tree.json
@@ -1349,7 +1349,7 @@
             },
             "constructInfo": {
               "fqn": "@aws-solutions-constructs/aws-openapigateway-lambda.OpenApiGatewayToLambda",
-              "version": "2.60.0"
+              "version": "2.61.0"
             }
           },
           "LatestNodeRuntimeMap": {

--- a/source/patterns/@aws-solutions-constructs/resources/lib/template-writer.ts
+++ b/source/patterns/@aws-solutions-constructs/resources/lib/template-writer.ts
@@ -140,6 +140,8 @@ export function createTemplateWriterCustomResource(
     }
   });
 
+  customResource.node.addDependency(templateWriterPolicy);
+
   return {
     s3Bucket: outputAsset.bucket,
     s3Key: customResource.getAttString('TemplateOutputKey'),

--- a/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-asset.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-asset.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/674ff8d03f3f67ae845dfc5bdba69f5d60210f5c4bc6eda2d950a379a7b3b668.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/bbc26051b499cb1d06bdf02dc0f0acd036f5577bb6e2f3a2dea1262ced2c6e20.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-asset.js.snapshot/template-writer-from-asset.assets.json
+++ b/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-asset.js.snapshot/template-writer-from-asset.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "674ff8d03f3f67ae845dfc5bdba69f5d60210f5c4bc6eda2d950a379a7b3b668": {
+    "bbc26051b499cb1d06bdf02dc0f0acd036f5577bb6e2f3a2dea1262ced2c6e20": {
       "source": {
         "path": "template-writer-from-asset.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "674ff8d03f3f67ae845dfc5bdba69f5d60210f5c4bc6eda2d950a379a7b3b668.json",
+          "objectKey": "bbc26051b499cb1d06bdf02dc0f0acd036f5577bb6e2f3a2dea1262ced2c6e20.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-asset.js.snapshot/template-writer-from-asset.template.json
+++ b/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-asset.js.snapshot/template-writer-from-asset.template.json
@@ -347,6 +347,9 @@
      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
     }
    },
+   "DependsOn": [
+    "TestTemplateWriterPolicy8177DE02"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   }

--- a/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-large-asset.js.snapshot/manifest.json
+++ b/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-large-asset.js.snapshot/manifest.json
@@ -66,7 +66,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/5dd2fd9947fca23c108771ba84b7f81fc023ffa9ed968daf7d893728adb871ed.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/25072d476c1c822407709a831d0a1e35d0ef566c9ebc838be4f3336e42077f0a.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-large-asset.js.snapshot/template-writer-from-large-asset.assets.json
+++ b/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-large-asset.js.snapshot/template-writer-from-large-asset.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "5dd2fd9947fca23c108771ba84b7f81fc023ffa9ed968daf7d893728adb871ed": {
+    "25072d476c1c822407709a831d0a1e35d0ef566c9ebc838be4f3336e42077f0a": {
       "source": {
         "path": "template-writer-from-large-asset.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5dd2fd9947fca23c108771ba84b7f81fc023ffa9ed968daf7d893728adb871ed.json",
+          "objectKey": "25072d476c1c822407709a831d0a1e35d0ef566c9ebc838be4f3336e42077f0a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-large-asset.js.snapshot/template-writer-from-large-asset.template.json
+++ b/source/patterns/@aws-solutions-constructs/resources/test/integ.template-writer-from-large-asset.js.snapshot/template-writer-from-large-asset.template.json
@@ -349,6 +349,9 @@
      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
     }
    },
+   "DependsOn": [
+    "TestTemplateWriterPolicy8177DE02"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Resources provisioned using the construct `@aws-solutions-constructs/aws-openapigateway-lambda` succeed on initial deploy however when a modification is made to the referenced OpenAPI specification the deployment fails. Resulting in the following error.

```
CustomResource attribute error: Vendor response doesn't contain TemplateOutputKey attribute in object arn:aws:cloudformation:ap-southeast-2:000000000000:stack/TestStac
k/1de47700-433e-11ef-8d9f-02222ec9a44d|OpenApiGatewayToLambdaApiTemplateWriterCustomResource957D1BA4|98e1521e-6163-4459-a73d-68f2b50cb336
```

The issue is caused by `./resources/template-writer`. When the specification changes this results in a new S3 asset which is used by `template-writer` to update the inline IAM policy which is attached to the custom resource Lambda responsible for managing the create and update lifecycle events.

![image](https://github.com/user-attachments/assets/f4c52c9d-1853-4fef-9ae8-a78bb02917c1)

However during a stack update this Lambda will fail to execute as it still references the old IAM policy and so this results in a 403 error when `await s3Client.send(new client_s3_1.GetObjectCommand ...` is attempted as the supplied `event.ResourceProperties.TemplateInputKey` does not match the current policy.

To address this the following has been added, to ensure that the policy is in place when the Lambda is executed.

`customResource.node.addDependency(templateWriterPolicy);`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.