### PR TITLE
chore(build-patterns.sh): split functionality into two scripts

### DIFF
--- a/deployment/v2/bootstrap.sh
+++ b/deployment/v2/bootstrap.sh
@@ -2,12 +2,6 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ "$PWD" != *aws-solutions-constructs ]]
-then
-  echo Script must be run from aws-solutions-constructs folder
-  exit 1
-fi
-
 starting_dir=$PWD
 deployment_dir=$(cd $(dirname $0) && pwd)
 source_dir="$deployment_dir/../../source"

--- a/deployment/v2/bootstrap.sh
+++ b/deployment/v2/bootstrap.sh
@@ -2,7 +2,7 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[$PWD!=aws-solutions-constructs]]
+if [[ "$PWD" != *aws-solutions-constructs ]]
 then
   echo Script must be run from aws-solutions-constructs folder
   exit 1
@@ -31,3 +31,4 @@ echo "installing..."
 yarn install --frozen-lockfile
 
 cd $starting_dir
+exit 1

--- a/deployment/v2/bootstrap.sh
+++ b/deployment/v2/bootstrap.sh
@@ -31,4 +31,3 @@ echo "installing..."
 yarn install --frozen-lockfile
 
 cd $starting_dir
-exit 1

--- a/deployment/v2/bootstrap.sh
+++ b/deployment/v2/bootstrap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#!/bin/bash
+set -euo pipefail
+
+if [[$PWD!=aws-solutions-constructs]]
+then
+  echo Script must be run from aws-solutions-constructs folder
+  exit 1
+fi
+
+starting_dir=$PWD
+deployment_dir=$(cd $(dirname $0) && pwd)
+source_dir="$deployment_dir/../../source"
+
+echo "============================================================================================="
+echo "aligning versions and updating package.json for CDK v2..."
+/bin/bash $deployment_dir/align-version.sh
+
+bail="--bail"
+runtarget="build+lint+test"
+cd $source_dir/
+
+export PATH=$source_dir/node_modules/.bin:$PATH
+export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-}"
+
+npm install -g @aws-cdk/integ-runner
+npm install -g aws-cdk
+
+echo "============================================================================================="
+echo "installing..."
+yarn install --frozen-lockfile
+
+cd $starting_dir

--- a/deployment/v2/build-all.sh
+++ b/deployment/v2/build-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[$PWD!=aws-solutions-constructs]]
+if [[ "$PWD" != *aws-solutions-constructs ]]
 then
   echo Script must be run from aws-solutions-constructs folder
   exit 1

--- a/deployment/v2/build-all.sh
+++ b/deployment/v2/build-all.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ "$PWD" != *aws-solutions-constructs ]]
-then
-  echo Script must be run from aws-solutions-constructs folder
-  exit 1
-fi
-
 deployment_dir=$(cd $(dirname $0) && pwd)
 source_dir="$deployment_dir/../../source"
 

--- a/deployment/v2/build-all.sh
+++ b/deployment/v2/build-all.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[$PWD!=aws-solutions-constructs]]
+then
+  echo Script must be run from aws-solutions-constructs folder
+  exit 1
+fi
+
+deployment_dir=$(cd $(dirname $0) && pwd)
+source_dir="$deployment_dir/../../source"
+
+echo "============================================================================================="
+echo "aligning versions and updating package.json for CDK v2..."
+/bin/bash $deployment_dir/align-version.sh
+
+bail="--bail"
+runtarget="build+lint+test"
+cd $source_dir/
+
+export PATH=$source_dir/node_modules/.bin:$PATH
+export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-}"
+
+echo "============================================================================================="
+echo "building..."
+time lerna run $bail --stream $runtarget || fail
+
+echo "============================================================================================="
+echo "packaging..."
+time lerna run --bail --stream jsii-pacmak || fail
+
+echo "============================================================================================="
+echo "reverting back versions and updates to package.json for CDK v2..."
+/bin/bash $deployment_dir/align-version.sh revert

--- a/deployment/v2/build-patterns.sh
+++ b/deployment/v2/build-patterns.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[$PWD!=aws-solutions-constructs]]
+if [[ "$PWD" != *aws-solutions-constructs ]]
 then
   echo Script must be run from aws-solutions-constructs folder
   exit 1

--- a/deployment/v2/build-patterns.sh
+++ b/deployment/v2/build-patterns.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ "$PWD" != *aws-solutions-constructs ]]
-then
-  echo Script must be run from aws-solutions-constructs folder
-  exit 1
-fi
-
 deployment_dir=$(cd $(dirname $0) && pwd)
 
 source $deployment_dir/bootstrap.sh

--- a/deployment/v2/build-patterns.sh
+++ b/deployment/v2/build-patterns.sh
@@ -1,34 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+if [[$PWD!=aws-solutions-constructs]]
+then
+  echo Script must be run from aws-solutions-constructs folder
+  exit 1
+fi
+
 deployment_dir=$(cd $(dirname $0) && pwd)
-source_dir="$deployment_dir/../../source"
 
-echo "============================================================================================="
-echo "aligning versions and updating package.json for CDK v2..."
-/bin/bash $deployment_dir/align-version.sh
+source $deployment_dir/bootstrap.sh
 
-bail="--bail"
-runtarget="build+lint+test"
-cd $source_dir/
-
-export PATH=$source_dir/node_modules/.bin:$PATH
-export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-}"
-
- npm install -g @aws-cdk/integ-runner
-
-echo "============================================================================================="
-echo "installing..."
-yarn install --frozen-lockfile
-
-echo "============================================================================================="
-echo "building..."
-time lerna run $bail --stream $runtarget || fail
-
-echo "============================================================================================="
-echo "packaging..."
-time lerna run --bail --stream jsii-pacmak || fail
-
-echo "============================================================================================="
-echo "reverting back versions and updates to package.json for CDK v2..."
-/bin/bash $deployment_dir/align-version.sh revert
+source $deployment_dir/build-all.sh

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-solutions-constructs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "AWS Solutions Constructs Library",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
   },
   "private": true,
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "eslint": "^6.8.0",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "lerna": "^3.22.1",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "workspaces": {
     "packages": [
@@ -60,6 +60,6 @@
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-alb-fargate",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for Application Load Balancer to AWS Fargate integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-alb-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for Application Load Balancer to AWS Lambda integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-apigateway-dynamodb",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS API Gateway and Amazon DynamoDB integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-apigateway-iot",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs to proxy communication to IotCore using a APIGateway(REST).",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-apigateway-kinesisstreams",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS API Gateway and Amazon Kinesis Data Streams integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-apigateway-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an API Gateway and a Lambda function.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-apigateway-sagemakerendpoint",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS API Gateway and Amazon SageMaker Endpoint integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-apigateway-sqs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an Amazon S3 bucket.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-cloudfront-apigateway-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Cloudfront to AWS API Gateway to AWS Lambda integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/aws-cloudfront-apigateway": "0.0.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/aws-cloudfront-apigateway": "2.62.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,10 +79,10 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-cloudfront-apigateway": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-cloudfront-apigateway": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-cloudfront-apigateway",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Cloudfront to AWS API Gateway integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-cloudfront-mediastore",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for Amazon CloudFront to AWS Elemental MediaStore integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-cloudfront-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Cloudfront to AWS S3 integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/resources": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/resources": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,10 +79,10 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/resources": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/resources": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-cognito-apigateway-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Cognito to AWS API Gateway to AWS Lambda integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-constructs-factories/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-constructs-factories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-constructs-factories",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "Factories to allow creation of individual resources",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,14 +53,14 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "2.147.3",
     "constructs": "^10.0.0"
   },
   "jest": {
@@ -78,8 +78,8 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "aws-cdk-lib": "2.147.3",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for Amazon Dynamodb streams to AWS Lambda to AWS Elasticsearch with Kibana integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,17 +53,17 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -80,11 +80,11 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-dynamodbstreams-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS DynamoDB Streams to AWS Lambda integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for Amazon CloudWatch Events Rule to Amazon Kinesis Firehose to Amazon S3 integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,10 +79,10 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-eventbridge-kinesisstreams",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for deploying Amazon CloudWatch Events Rule that invokes Amazon Kinesis Data Stream",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-eventbridge-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for deploying AWS Events Rule that inveokes AWS Lambda",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-eventbridge-sns",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for deploying AWS Events Rule that invokes AWS SNS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-eventbridge-sqs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for deploying AWS Eventbridge that invokes AWS SQS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-eventbridge-stepfunctions",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for deploying AWS Events Rule that invokes AWS Step Functions",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-dynamodb",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon DynamoDB integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-eventbridge",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon Eventbridge integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-kinesisfirehose",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon Kinesis Firehose integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "2.147.3",
     "constructs": "^10.0.0"
   },
   "jest": {
@@ -80,8 +80,8 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "^0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "aws-cdk-lib": "^2.147.3",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-kinesisstreams",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to an Amazon Kinesis Data Stream ",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-opensearch",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon OpenSearch Service",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon S3 integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-secretsmanager",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon Secrets Manager integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-sns",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon SNS integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-sqs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon SQS integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-ssmstringparameter",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to AWS SSM Parameter Store Integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-fargate-stepfunctions",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Fargate to Amazon Step Functions integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "@types/jest": "^26.0.22",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-iot-kinesisfirehose-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS IoT to AWS Kinesis Firehose to AWS S3 integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,10 +79,10 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-iot-kinesisstreams",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS IoT to AWS Kinesis Data Stream.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-iot-lambda-dynamodb",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS IoT to AWS Lambda to AWS DyanmoDB integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,17 +53,17 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-iot-lambda": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-dynamodb": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-iot-lambda": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-dynamodb": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -80,11 +80,11 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-iot-lambda": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-dynamodb": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-iot-lambda": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-dynamodb": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-iot-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS IoT to AWS Lambda integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-iot-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS IoT to AWS S3 integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,8 +78,8 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-iot-sqs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS IoT to AWS SQS integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,8 +78,8 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-kinesisfirehose-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon Kinesis Data Firehose delivery stream and an Amazon S3 bucket.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-kinesisstreams-gluejob",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for streaming data from AWS Kinesis Data Stream for Glue ETL custom Job processing",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon Kinesis Data Stream (KDS), Amazon Kinesis Data Firehose (KDF) delivery stream and an Amazon S3 bucket.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,17 +53,17 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisstreams-lambda": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisstreams-lambda": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -80,11 +80,11 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisstreams-lambda": "0.0.0"
+    "aws-cdk-lib": "^2.147.3",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisstreams-lambda": "2.62.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-kinesisstreams-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon Kinesis Data Stream and an AWS Lambda function.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-dynamodb",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Lambda to AWS DynamoDB integration.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-elasticachememcached",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an Amazon Elasticache memcached cache.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Lambda to AWS Elasticsearch with Kibana integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-eventbridge",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an Amazon EventBridge.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-kendra",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an existing Amazon Kinesis Firehose Delivery Stream.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -49,15 +49,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "aws-cdk-lib": "0.0.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "aws-cdk-lib": "2.147.3",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "jest": {
@@ -75,8 +75,8 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "^0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "aws-cdk-lib": "^2.147.3",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-kinesisfirehose",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an existing Amazon Kinesis Firehose Delivery Stream.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-kinesisfirehose-s3": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-kinesisstreams",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda Function and an Amazon Kinesis Data Stream.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-opensearch",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS Lambda to Amazon OpenSearch Service",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-s3",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an Amazon S3 bucket.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-sagemakerendpoint",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an Amazon SageMaker inference endpoint.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-secretsmanager",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and AWS Secrets Manager.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -69,9 +69,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-sns",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an Amazon SNS topic.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-sqs-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK construct that provisions (1) an AWS Lambda function that is configured to send messages to a queue; (2) an Amazon SQS queue; and (3) an AWS Lambda function configured to consume messages from the queue.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,17 +53,17 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-sqs": "0.0.0",
-    "@aws-solutions-constructs/aws-sqs-lambda": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-sqs": "2.62.0",
+    "@aws-solutions-constructs/aws-sqs-lambda": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -80,11 +80,11 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-sqs": "0.0.0",
-    "@aws-solutions-constructs/aws-sqs-lambda": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-sqs": "2.62.0",
+    "@aws-solutions-constructs/aws-sqs-lambda": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-sqs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an Amazon SQS queue.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-ssmstringparameter",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and AWS Systems Manager Parameter Store String parameter",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -69,9 +69,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-lambda-stepfunctions",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an AWS Lambda function and an AWS Step Function.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,8 +53,8 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
@@ -62,7 +62,7 @@
     "@types/node": "^10.3.0",
     "eslint-plugin-import": "^2.22.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,8 +79,8 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-openapigateway-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an OpenAPI-defined API Gateway and one or more Lambda functions.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,9 +53,9 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/resources": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/resources": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "@aws-sdk/client-s3": "^3.0.0",
     "@types/aws-lambda": "^8.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -81,10 +81,10 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/resources": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/resources": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-route53-alb",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon Route53 domain and an Application Load Balancer.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
     "@types/node": "^10.3.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-route53-apigateway",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for connecting an Amazon Route53 domain to an API Gateway.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,8 +53,8 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
@@ -62,7 +62,7 @@
     "@types/node": "^10.3.0",
     "prettier": "^2.5.1",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,9 +79,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-s3-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS S3 to AWS Lambda integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-s3-sns",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon S3 bucket and an Amazon SNS Topic.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-s3-sqs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon S3 bucket and an Amazon SQS queue.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-s3-stepfunctions",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS S3 to AWS Step Functions integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,10 +79,10 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-sns-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK Constructs for AWS SNS to AWS Lambda integration",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-sns-sqs",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon SNS topic and an Amazon SQS queue.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-sqs-lambda",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an interaction between an Amazon SQS queue and an AWS Lambda function.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-wafwebacl-alb",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an AWS web WAF connected to an Application Load Balancer.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,16 +53,16 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-route53-alb": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-route53-alb": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -79,10 +79,10 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@aws-solutions-constructs/aws-route53-alb": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "@aws-solutions-constructs/aws-route53-alb": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-wafwebacl-apigateway",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an AWS web WAF connected to Amazon API Gateway REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-wafwebacl-appsync",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an AWS web WAF connected to an AWS AppSync API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,14 +53,14 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "2.147.3",
     "constructs": "^10.0.0"
   },
   "jest": {
@@ -78,8 +78,8 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "^0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
+    "aws-cdk-lib": "^2.147.3",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-wafwebacl-cloudfront",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "CDK constructs for defining an AWS web WAF connected to Amazon CloudFront.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -53,15 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -78,9 +78,9 @@
     ]
   },
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/core/package.json
+++ b/source/patterns/@aws-solutions-constructs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/core",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "Core CDK Construct for patterns library",
   "main": "index.js",
   "types": "index.ts",
@@ -52,7 +52,7 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
     "deep-diff": "^1.0.2",
     "deepmerge": "^4.0.0",
     "npmlog": "^7.0.0",
@@ -65,7 +65,7 @@
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -88,6 +88,6 @@
   ],
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/resources/package.json
+++ b/source/patterns/@aws-solutions-constructs/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/resources",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "Resource CDK Constructs for patterns library",
   "main": "index.js",
   "types": "index.ts",
@@ -52,10 +52,10 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
     "@aws-sdk/client-kms": "^3.478.0",
     "@aws-sdk/client-s3": "^3.478.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "aws-sdk-client-mock": "^3.0.0",
     "constructs": "^10.0.0"
   },
@@ -63,7 +63,7 @@
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -85,8 +85,8 @@
     "aws-sdk-client-mock"
   ],
   "peerDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/use_cases/aws-custom-glue-etl/package.json
+++ b/source/use_cases/aws-custom-glue-etl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-cust0m-glue-etl",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "Use case pattern for creating a custom ETL job in AWS Glue.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,9 +28,9 @@
     "build+lint+test": "npm run build && npm run lint && npm test && npm run integ-assert"
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/aws-kinesisstreams-gluejob": "0.0.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/aws-kinesisstreams-gluejob": "2.62.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "source-map-support": "^0.5.16",
     "constructs": "^10.0.0"
   },
@@ -38,7 +38,7 @@
     "@types/jest": "^24.9.1",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -47,6 +47,6 @@
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-order",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -8,16 +8,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
     "uuid": "^8.3.2",
     "constructs": "^10.0.0"
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "devDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-restaurant-management-demo",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "Use case pattern for deploying a complex business system and reference architecture.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -32,7 +32,7 @@
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -40,19 +40,19 @@
     ]
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/aws-cognito-apigateway-lambda": "0.0.0",
-    "@aws-solutions-constructs/aws-eventbridge-lambda": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-dynamodb": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-s3": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-sns": "0.0.0",
-    "@aws-solutions-constructs/aws-lambda-stepfunctions": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/aws-cognito-apigateway-lambda": "2.62.0",
+    "@aws-solutions-constructs/aws-eventbridge-lambda": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-dynamodb": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-s3": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-sns": "2.62.0",
+    "@aws-solutions-constructs/aws-lambda-stepfunctions": "2.62.0",
     "source-map-support": "^0.5.16",
     "typescript": "^4.2.4",
     "constructs": "^10.0.0"
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d7ef2fab3e8af1933261371cc1e90baab16122dc5fca1ca9e5ea26a4720f4eee/package.json
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d7ef2fab3e8af1933261371cc1e90baab16122dc5fca1ca9e5ea26a4720f4eee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-order",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -8,16 +8,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
     "uuid": "^8.3.2",
     "constructs": "^10.0.0"
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "devDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }

--- a/source/use_cases/aws-s3-static-website/package.json
+++ b/source/use_cases/aws-s3-static-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-solutions-constructs/aws-s3-static-website",
-  "version": "0.0.0",
+  "version": "2.62.0",
   "description": "Use case pattern for deploying a S3 static website.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,9 +28,9 @@
     "build+lint+test": "npm run build && npm run lint && npm test && npm run integ-assert"
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
-    "@aws-solutions-constructs/aws-cloudfront-s3": "0.0.0",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "2.147.3-alpha.0",
+    "@aws-solutions-constructs/aws-cloudfront-s3": "2.62.0",
+    "@aws-solutions-constructs/core": "2.62.0",
     "source-map-support": "^0.5.16",
     "constructs": "^10.0.0"
   },
@@ -38,7 +38,7 @@
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.147.3"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -47,6 +47,6 @@
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "^0.0.0"
+    "aws-cdk-lib": "^2.147.3"
   }
 }


### PR DESCRIPTION
*Description of changes:*
Take contents of build-patterns.sh and create bootstrap.sh to initialize the docker container and build-all.sh, which actually builds the entire library. In this way when you open a container around an already built codebase you only need to run bootstrap.sh. build-patterns.sh is now pretty much empty - it just invokes these two scripts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.