### PR TITLE
chore(build-patterns.sh): split functionality into two scripts

### DIFF
--- a/deployment/v2/bootstrap.sh
+++ b/deployment/v2/bootstrap.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#!/bin/bash
+set -euo pipefail
+
+starting_dir=$PWD
+deployment_dir=$(cd $(dirname $0) && pwd)
+source_dir="$deployment_dir/../../source"
+
+echo "============================================================================================="
+echo "aligning versions and updating package.json for CDK v2..."
+/bin/bash $deployment_dir/align-version.sh
+
+bail="--bail"
+runtarget="build+lint+test"
+cd $source_dir/
+
+export PATH=$source_dir/node_modules/.bin:$PATH
+export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-}"
+
+npm install -g @aws-cdk/integ-runner
+npm install -g aws-cdk
+
+echo "============================================================================================="
+echo "installing..."
+yarn install --frozen-lockfile
+
+cd $starting_dir

--- a/deployment/v2/build-all.sh
+++ b/deployment/v2/build-all.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+deployment_dir=$(cd $(dirname $0) && pwd)
+source_dir="$deployment_dir/../../source"
+
+echo "============================================================================================="
+echo "aligning versions and updating package.json for CDK v2..."
+/bin/bash $deployment_dir/align-version.sh
+
+bail="--bail"
+runtarget="build+lint+test"
+cd $source_dir/
+
+export PATH=$source_dir/node_modules/.bin:$PATH
+export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-}"
+
+echo "============================================================================================="
+echo "building..."
+time lerna run $bail --stream $runtarget || fail
+
+echo "============================================================================================="
+echo "packaging..."
+time lerna run --bail --stream jsii-pacmak || fail
+
+echo "============================================================================================="
+echo "reverting back versions and updates to package.json for CDK v2..."
+/bin/bash $deployment_dir/align-version.sh revert

--- a/deployment/v2/build-patterns.sh
+++ b/deployment/v2/build-patterns.sh
@@ -2,33 +2,7 @@
 set -euo pipefail
 
 deployment_dir=$(cd $(dirname $0) && pwd)
-source_dir="$deployment_dir/../../source"
 
-echo "============================================================================================="
-echo "aligning versions and updating package.json for CDK v2..."
-/bin/bash $deployment_dir/align-version.sh
+source $deployment_dir/bootstrap.sh
 
-bail="--bail"
-runtarget="build+lint+test"
-cd $source_dir/
-
-export PATH=$source_dir/node_modules/.bin:$PATH
-export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-}"
-
- npm install -g @aws-cdk/integ-runner
-
-echo "============================================================================================="
-echo "installing..."
-yarn install --frozen-lockfile
-
-echo "============================================================================================="
-echo "building..."
-time lerna run $bail --stream $runtarget || fail
-
-echo "============================================================================================="
-echo "packaging..."
-time lerna run --bail --stream jsii-pacmak || fail
-
-echo "============================================================================================="
-echo "reverting back versions and updates to package.json for CDK v2..."
-/bin/bash $deployment_dir/align-version.sh revert
+source $deployment_dir/build-all.sh


### PR DESCRIPTION
*Description of changes:*
Take contents of build-patterns.sh and create bootstrap.sh to initialize the docker container and build-all.sh, which actually builds the entire library. In this way when you open a container around an already built codebase you only need to run bootstrap.sh. build-patterns.sh is now pretty much empty - it just invokes these two scripts.By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.