### PR TITLE
fix(aws-alb-lambda): allow vpc in loadBalancerProps when specifying subnets

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/alb-fargate.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/test/alb-fargate.test.ts
@@ -519,3 +519,35 @@ test('Confirm that CheckAlbProps is called', () => {
   // Assertion
   expect(app).toThrowError('Error - Either provide loadBalancerProps or existingLoadBalancerObj, but not both.\n');
 });
+
+test('Test sending VPC in loadBalancerProps error', () => {
+  const props = {
+    loadBalancerProps: {
+      vpc: { val: 'placeholder' }
+    }
+  };
+
+  const app = () => {
+    defaults.CheckAlbProps(props);
+  };
+
+  expect(app).toThrowError("Any existing VPC must be defined in the construct props (props.existingVpc). A VPC specified in the loadBalancerProps must be the same VPC");
+});
+
+test('WHen providing VPC in construct and resource props, the vpcId must match', () => {
+  const fakeVpcOne = {vpcId: 'one'};
+  const fakeVpcTwo = {vpcId: 'two'};
+
+  const props = {
+    existingVpc: fakeVpcOne,
+    loadBalancerProps: {
+      vpc: fakeVpcTwo
+    }
+  };
+
+  const app = () => {
+    defaults.CheckAlbProps(props);
+  };
+
+  expect(app).toThrowError("Any existing VPC must be defined in the construct props (props.existingVpc). A VPC specified in the loadBalancerProps must be the same VPC");
+});

--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/test/alb-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/test/alb-lambda.test.ts
@@ -1050,3 +1050,35 @@ test('Confirm that CheckAlbProps is called', () => {
   // Assertion
   expect(app).toThrowError('Error - Either provide loadBalancerProps or existingLoadBalancerObj, but not both.\n');
 });
+
+test('Test sending VPC in loadBalancerProps error', () => {
+  const props = {
+    loadBalancerProps: {
+      vpc: { val: 'placeholder' }
+    }
+  };
+
+  const app = () => {
+    defaults.CheckAlbProps(props);
+  };
+
+  expect(app).toThrowError("Any existing VPC must be defined in the construct props (props.existingVpc). A VPC specified in the loadBalancerProps must be the same VPC");
+});
+
+test('WHen providing VPC in construct and resource props, the vpcId must match', () => {
+  const fakeVpcOne = {vpcId: 'one'};
+  const fakeVpcTwo = {vpcId: 'two'};
+
+  const props = {
+    existingVpc: fakeVpcOne,
+    loadBalancerProps: {
+      vpc: fakeVpcTwo
+    }
+  };
+
+  const app = () => {
+    defaults.CheckAlbProps(props);
+  };
+
+  expect(app).toThrowError("Any existing VPC must be defined in the construct props (props.existingVpc). A VPC specified in the loadBalancerProps must be the same VPC");
+});

--- a/source/patterns/@aws-solutions-constructs/core/lib/alb-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/core/lib/alb-helper.ts
@@ -264,8 +264,12 @@ export function CheckAlbProps(props: any) {
   }
 
   if (props.loadBalancerProps?.vpc) {
-    errorFound = true;
-    errorMessages += 'Specify any existing VPC at the construct level, not within loadBalancerProps.\n';
+    // Only reason this should exist is to enable specifying ALB network configuration. There must still
+    // be a construct VPC and  they must match
+    if ((!props.existingVpc) || (props.existingVpc.vpcId !== props.loadBalancerProps?.vpc.vpcId)) {
+      errorFound = true;
+      errorMessages += 'Any existing VPC must be defined in the construct props (props.existingVpc). A VPC specified in the loadBalancerProps must be the same VPC';
+    }
   }
 
   if (props.existingLoadBalancerObj) {

--- a/source/patterns/@aws-solutions-constructs/core/test/alb-helper.test.ts
+++ b/source/patterns/@aws-solutions-constructs/core/test/alb-helper.test.ts
@@ -17,7 +17,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as defaults from '../index';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 
 test('Test ObtainAlb with existing ALB', () => {
   const stack = new Stack();
@@ -59,7 +59,6 @@ test('Test ObtainAlb for new ALB with provided props', () => {
     publicApi: true,
     loadBalancerProps: {
       loadBalancerName: 'new-loadbalancer',
-      vpc,
       internetFacing: true
     }
   });
@@ -90,6 +89,43 @@ test('Test ObtainAlb for new ALB with default props', () => {
 
   template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
     Scheme: "internal",
+  });
+});
+
+test('Test ObtainAlb with specific subnets', () => {
+  const stack = new Stack(undefined, undefined, {
+    env: { account: "123456789012", region: 'us-east-1' },
+  });
+  // Build VPC
+  const vpc = defaults.buildVpc(stack, {
+    defaultVpcProps: defaults.DefaultPublicPrivateVpcProps(),
+    userVpcProps: {
+      availabilityZones: [
+        "us-east-1a",
+        "us-east-1b",
+        "us-east-1c",
+        "us-east-1d",
+        "us-east-1e",
+      ],
+    }
+  });
+
+  defaults.ObtainAlb(stack, 'test', {
+    vpc,
+    publicApi: true,
+    loadBalancerProps: {
+      vpc,
+      vpcSubnets: { availabilityZones: ["us-east-1b", "us-east-1d"] }
+    }
+  });
+
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+    Subnets: [
+      Match.anyValue(),
+      Match.anyValue(),
+    ]
   });
 });
 
@@ -567,7 +603,6 @@ test('Test sending loadBalancerProps and existingLoadBalancerObj is an error', (
     existingLoadBalancerObj: existingLoadBalancer,
     loadBalancerProps: {
       loadBalancerName: 'new-loadbalancer',
-      vpc,
       internetFacing: true
     }
   };
@@ -608,7 +643,25 @@ test('Test sending VPC in loadBalancerProps error', () => {
     defaults.CheckAlbProps(props);
   };
 
-  expect(app).toThrowError('Specify any existing VPC at the construct level, not within loadBalancerProps.\n');
+  expect(app).toThrowError("Any existing VPC must be defined in the construct props (props.existingVpc). A VPC specified in the loadBalancerProps must be the same VPC");
+});
+
+test('WHen providing VPC in construct and resource props, the vpcId must match', () => {
+  const fakeVpcOne = {vpcId: 'one'};
+  const fakeVpcTwo = {vpcId: 'two'};
+
+  const props = {
+    existingVpc: fakeVpcOne,
+    loadBalancerProps: {
+      vpc: fakeVpcTwo
+    }
+  };
+
+  const app = () => {
+    defaults.CheckAlbProps(props);
+  };
+
+  expect(app).toThrowError("Any existing VPC must be defined in the construct props (props.existingVpc). A VPC specified in the loadBalancerProps must be the same VPC");
 });
 
 function CreateTestLoadBalancer(stack: Stack, vpc: ec2.IVpc): elb.ApplicationLoadBalancer {


### PR DESCRIPTION
*Issue #, if available:*
closes #1159

*Description of changes:*
Remove check that rejected vpc's in loadBalancer props, but confirm if one is received that it is also specified at the construct level


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.