### PR TITLE
chore: migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.dbslamels-deploy-with-vpc.js.snapshot/asset.92927de5fcc3aea277bddecb845bee318fb502f7375daedbdafb72c0400bc197/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.dbslamels-deploy-with-vpc.js.snapshot/asset.92927de5fcc3aea277bddecb845bee318fb502f7375daedbdafb72c0400bc197/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'lambda-type'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context, id) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.dbslamels-no-arguments.js.snapshot/asset.92927de5fcc3aea277bddecb845bee318fb502f7375daedbdafb72c0400bc197/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/integ.dbslamels-no-arguments.js.snapshot/asset.92927de5fcc3aea277bddecb845bee318fb502f7375daedbdafb72c0400bc197/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'lambda-type'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context, id) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/lambda/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'lambda-type'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context, id) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployFunctionWithClusterConfig.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployFunctionWithClusterConfig.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployFunctionWithExistingVpc.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployFunctionWithExistingVpc.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployFunctionWithVpcProps.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployFunctionWithVpcProps.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployToFiveZones.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-deployToFiveZones.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-disabledZoneAwareness.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-disabledZoneAwareness.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-domain-arguments.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-domain-arguments.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-no-arguments.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/integ.lamels-no-arguments.js.snapshot/asset.35bbbc7b04b21f225891f139adf234188f348ebad5f4bbc2c06edf8aa3784c97/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/lambda/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var esDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint =  new AWS.Endpoint(esDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint =  new URL(esDomain.endpoint);
 
 function postDocumentToES(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-deployFunction.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-deployFunction.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
@@ -11,8 +11,11 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
-const eventbridge = new aws.EventBridge();
+
+
+const { EventBridge } = require('@aws-sdk/client-eventbridge');
+
+const eventbridge = new EventBridge();
 exports.handler = () => {
   const params = {
     Entries: [{

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-deployFunctionWithNewEventBus.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-deployFunctionWithNewEventBus.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
@@ -11,8 +11,11 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
-const eventbridge = new aws.EventBridge();
+
+
+const { EventBridge } = require('@aws-sdk/client-eventbridge');
+
+const eventbridge = new EventBridge();
 exports.handler = () => {
   const params = {
     Entries: [{

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-deployFunctionWithVpc.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-deployFunctionWithVpc.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
@@ -11,8 +11,11 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
-const eventbridge = new aws.EventBridge();
+
+
+const { EventBridge } = require('@aws-sdk/client-eventbridge');
+
+const eventbridge = new EventBridge();
 exports.handler = () => {
   const params = {
     Entries: [{

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-existingEventBus.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-existingEventBus.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
@@ -11,8 +11,11 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
-const eventbridge = new aws.EventBridge();
+
+
+const { EventBridge } = require('@aws-sdk/client-eventbridge');
+
+const eventbridge = new EventBridge();
 exports.handler = () => {
   const params = {
     Entries: [{

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-existingFunction.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/integ.lamevt-existingFunction.js.snapshot/asset.b5faf4ff1ebde477120133d1e645d20d7c3d4952b76c3b586100069b94b2f146/index.js
@@ -11,8 +11,11 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
-const eventbridge = new aws.EventBridge();
+
+
+const { EventBridge } = require('@aws-sdk/client-eventbridge');
+
+const eventbridge = new EventBridge();
 exports.handler = () => {
   const params = {
     Entries: [{

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/test/lambda/index.js
@@ -11,8 +11,11 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
-const eventbridge = new aws.EventBridge();
+
+
+const { EventBridge } = require('@aws-sdk/client-eventbridge');
+
+const eventbridge = new EventBridge();
 exports.handler = () => {
   const params = {
     Entries: [{

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-cluster-config.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-cluster-config.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var openSearchDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint = new AWS.Endpoint(openSearchDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint = new URL(openSearchDomain.endpoint);
 
 function postDocumentToOpenSearch(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-disabled-zone-awareness.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-disabled-zone-awareness.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var openSearchDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint = new AWS.Endpoint(openSearchDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint = new URL(openSearchDomain.endpoint);
 
 function postDocumentToOpenSearch(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-domain-arguments.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-domain-arguments.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var openSearchDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint = new AWS.Endpoint(openSearchDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint = new URL(openSearchDomain.endpoint);
 
 function postDocumentToOpenSearch(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-existing-vpc.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-existing-vpc.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var openSearchDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint = new AWS.Endpoint(openSearchDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint = new URL(openSearchDomain.endpoint);
 
 function postDocumentToOpenSearch(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-no-arguments.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-no-arguments.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var openSearchDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint = new AWS.Endpoint(openSearchDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint = new URL(openSearchDomain.endpoint);
 
 function postDocumentToOpenSearch(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-vpc-props.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/integ.lamopn-vpc-props.js.snapshot/asset.abbc4eca9e7ddabc31da3ce83159e6eee8e72e2c358ab8af0711044514c41290/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var openSearchDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint = new AWS.Endpoint(openSearchDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint = new URL(openSearchDomain.endpoint);
 
 function postDocumentToOpenSearch(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/lambda/index.js
@@ -1,4 +1,7 @@
 var AWS = require('aws-sdk');
+
+const { fromEnv } = require('@aws-sdk/credential-providers');
+
 var path = require('path');
 
 console.log('Loading function');
@@ -10,8 +13,11 @@ var openSearchDomain = {
     doctype: 'movie'
 };
 
-var creds = new AWS.EnvironmentCredentials('AWS');
-var endpoint = new AWS.Endpoint(openSearchDomain.endpoint);
+var creds = // JS SDK v3 switched credential providers from classes to functions.
+// This is the closest approximation from codemod of what your application needs.
+// Reference: https://www.npmjs.com/package/@aws-sdk/credential-providers
+fromEnv('AWS');
+var endpoint = new URL(openSearchDomain.endpoint);
 
 function postDocumentToOpenSearch(doc, context) {
     var req = new AWS.HttpRequest(endpoint);

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-defaultDeployment.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-defaultDeployment.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 exports.handler = () => {
     console.log('Loading producer function');
@@ -19,7 +21,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-deployProducerFunctionWithVpc.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-deployProducerFunctionWithVpc.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 exports.handler = () => {
     console.log('Loading producer function');
@@ -19,7 +21,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-existingConsumerFunction.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-existingConsumerFunction.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 exports.handler = () => {
     console.log('Loading producer function');
@@ -19,7 +21,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-existingProducerFunction.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-existingProducerFunction.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 exports.handler = () => {
     console.log('Loading producer function');
@@ -19,7 +21,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-existingQueue.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/integ.lamsqslam-existingQueue.js.snapshot/asset.075b2d402078d97c329028d1af17df69ef86062dc7ace374b10a10022db6fb8d/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 exports.handler = () => {
     console.log('Loading producer function');
@@ -19,7 +21,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/lambda/producer-function/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/test/lambda/producer-function/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 exports.handler = () => {
     console.log('Loading producer function');
@@ -19,7 +21,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-deployFunction.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-deployFunction.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 console.log('Loading function');
 
@@ -20,7 +22,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-deployFunctionWithVpc.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-deployFunctionWithVpc.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 console.log('Loading function');
 
@@ -20,7 +22,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-existingFunction.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-existingFunction.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 console.log('Loading function');
 
@@ -20,7 +22,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-useCmk.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/integ.lamsqs-useCmk.js.snapshot/asset.42887c62b1163d790cdb42902037c9f639feb35681616a16826e400c8d1a4435/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 console.log('Loading function');
 
@@ -20,7 +22,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/test/lambda/index.js
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-const aws = require('aws-sdk');
+
+
+const { SQS } = require('@aws-sdk/client-sqs');
 
 console.log('Loading function');
 
@@ -20,7 +22,7 @@ exports.handler = () => {
         MessageBody: 'sample-message-body',
         QueueUrl: process.env.SQS_QUEUE_URL
     };
-    const sqs = new aws.SQS();
+    const sqs = new SQS();
     sqs.sendMessage(params, function (err, data) {
         if (err) {
             throw Error('An error occurred sending the message.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deploy-lambda.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
@@ -1,4 +1,4 @@
-const aws = require('aws-sdk');
+const { SFN } = require('@aws-sdk/client-sfn');
 
 console.log('Loading function');
 
@@ -7,7 +7,7 @@ exports.handler = () => {
     stateMachineArn: process.env.STATE_MACHINE_ARN,
     input: JSON.stringify({})
   };
-  const stepFunction = new aws.StepFunctions();
+  const stepFunction = new SFN();
   stepFunction.startExecution(params, function (err, data) {
     if (err) {
       throw Error('An error occurred executing the step function.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-deployFunctionWithVpc.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
@@ -1,4 +1,4 @@
-const aws = require('aws-sdk');
+const { SFN } = require('@aws-sdk/client-sfn');
 
 console.log('Loading function');
 
@@ -7,7 +7,7 @@ exports.handler = () => {
     stateMachineArn: process.env.STATE_MACHINE_ARN,
     input: JSON.stringify({})
   };
-  const stepFunction = new aws.StepFunctions();
+  const stepFunction = new SFN();
   stepFunction.startExecution(params, function (err, data) {
     if (err) {
       throw Error('An error occurred executing the step function.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-existing-function.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
@@ -1,4 +1,4 @@
-const aws = require('aws-sdk');
+const { SFN } = require('@aws-sdk/client-sfn');
 
 console.log('Loading function');
 
@@ -7,7 +7,7 @@ exports.handler = () => {
     stateMachineArn: process.env.STATE_MACHINE_ARN,
     input: JSON.stringify({})
   };
-  const stepFunction = new aws.StepFunctions();
+  const stepFunction = new SFN();
   stepFunction.startExecution(params, function (err, data) {
     if (err) {
       throw Error('An error occurred executing the step function.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-state-machine-defintion.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/integ.lamstp-state-machine-defintion.js.snapshot/asset.fd7a741674eeef7951675d2a57f0459376e046d88e5bee9aab601d8f5a704c93/index.js
@@ -1,4 +1,4 @@
-const aws = require('aws-sdk');
+const { SFN } = require('@aws-sdk/client-sfn');
 
 console.log('Loading function');
 
@@ -7,7 +7,7 @@ exports.handler = () => {
     stateMachineArn: process.env.STATE_MACHINE_ARN,
     input: JSON.stringify({})
   };
-  const stepFunction = new aws.StepFunctions();
+  const stepFunction = new SFN();
   stepFunction.startExecution(params, function (err, data) {
     if (err) {
       throw Error('An error occurred executing the step function.');

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda/index.js
@@ -1,4 +1,4 @@
-const aws = require('aws-sdk');
+const { SFN } = require('@aws-sdk/client-sfn');
 
 console.log('Loading function');
 
@@ -7,7 +7,7 @@ exports.handler = () => {
     stateMachineArn: process.env.STATE_MACHINE_ARN,
     input: JSON.stringify({})
   };
-  const stepFunction = new aws.StepFunctions();
+  const stepFunction = new SFN();
   stepFunction.startExecution(params, function (err, data) {
     if (err) {
       throw Error('An error occurred executing the step function.');

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/kitchen-staff/complete-order/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/kitchen-staff/complete-order/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 // Handler
 exports.handler = async (event) => {
@@ -34,7 +38,7 @@ exports.handler = async (event) => {
 
   // Add the item to the database
   try {
-    const res = await ddb.update(params).promise();
+    const res = await ddb.update(params);
     return {
       statusCode: 200,
       isBase64Encoded: false,

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/kitchen-staff/get-open-orders/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/kitchen-staff/get-open-orders/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 // Handler
 exports.handler = async (event) => {
@@ -32,7 +36,7 @@ exports.handler = async (event) => {
 
   // Perform the query
   try {
-    const result = await ddb.query(params).promise();
+    const result = await ddb.query(params);
     // Extract the order JSON objects
     const orders = Array.from(result.Items);
     // Return the open orders

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/layer/db-access.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/layer/db-access.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 /**
  * Common function for scanning the database and getting all entries. Supports multiple functions within the system.
@@ -32,7 +36,7 @@ exports.scanTable = async () => {
   // Perform the scan
   try {
     do {
-        items = await ddb.scan(params).promise();
+        items = await ddb.scan(params);
         items.Items.forEach((item) => scanResults.push(item));
         params.ExclusiveStartKey = items.LastEvaluatedKey;
     } while (typeof items.LastEvaluatedKey != "undefined");

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/archive-orders/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/archive-orders/index.js
@@ -12,9 +12,14 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const s3 = new aws.S3();
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+const { S3 } = require('@aws-sdk/client-s3');
+
+const s3 = new S3();
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 const db_access = require('/opt/db-access');
 
 exports.handler = async (event) => {
@@ -46,7 +51,7 @@ exports.handler = async (event) => {
   
   // Save the report
   try {
-    await s3.putObject(s3_params).promise();
+    await s3.putObject(s3_params);
     console.log(`Successfully saved the report to "${process.env.S3_BUCKET_NAME}"`);
     console.log(`Report filename: "${s3_params.Key}"`);
   } catch (err) {

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/calculate-tips/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/calculate-tips/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const sns = new aws.SNS();
+
+
+const { SNS } = require('@aws-sdk/client-sns');
+
+const sns = new SNS();
 const db_access = require('/opt/db-access');
 
 // Handler

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/check-late-orders/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/check-late-orders/index.js
@@ -12,9 +12,14 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
-const sns = new aws.SNS();
+
+
+const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { SNS } = require("@aws-sdk/client-sns");
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
+const sns = new SNS();
 
 // Handler
 exports.handler = async (event) => {
@@ -42,7 +47,7 @@ exports.handler = async (event) => {
 
   // Query all late orders from the table
   try {
-    const result = await ddb.query(params).promise();
+    const result = await ddb.query(params);
     // Extract the order JSON objects
     const orders = Array.from(result.Items);
     // Save the open orders to the array

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/close-out-service/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/close-out-service/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const sfn = new aws.StepFunctions();
+
+
+const { SFN } = require('@aws-sdk/client-sfn');
+
+const sfn = new SFN();
 
 // Handler
 exports.handler = async (event) => {
@@ -25,7 +28,7 @@ exports.handler = async (event) => {
   
   // Start the process
   try {
-    const res = await sfn.startExecution(params).promise();
+    const res = await sfn.startExecution(params);
     console.log(res);
     return {
       statusCode: 200,

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/create-report/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/create-report/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const s3 = new aws.S3();
+
+
+const { S3 } = require('@aws-sdk/client-s3');
+
+const s3 = new S3();
 const db_access = require('/opt/db-access');
 
 exports.handler = async (event) => {
@@ -60,7 +63,7 @@ exports.handler = async (event) => {
   
   // Save the report
   try {
-    await s3.putObject(s3_params).promise();
+    await s3.putObject(s3_params);
     console.log(`Successfully saved the report to "${process.env.S3_BUCKET_NAME}"`);
     console.log(`Report filename: "${s3_params.Key}"`);
   } catch (err) {

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/get-report/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/manager/get-report/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const s3 = new aws.S3();
+
+
+const { S3 } = require('@aws-sdk/client-s3');
+
+const s3 = new S3();
 
 exports.handler = async (event) => {
   
@@ -30,7 +33,7 @@ exports.handler = async (event) => {
   
   // Get the report
   try {
-    const res = await s3.getObject(params).promise();
+    const res = await s3.getObject(params);
     const parsed = res.Body.toString('utf-8');
     console.log(parsed);
     return {

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/create-order/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 const { v4: uuidv4 } = require('uuid');
 
 // Handler
@@ -40,7 +44,7 @@ exports.handler = async (event) => {
 
   // Add the item to the database
   try {
-    const res = await ddb.put(params).promise();
+    const res = await ddb.put(params);
     return {
       statusCode: 200,
       isBase64Encoded: false,

--- a/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/process-payment/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/lib/lambda/service-staff/process-payment/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 // Handler
 exports.handler = async (event) => {
@@ -37,7 +41,7 @@ exports.handler = async (event) => {
 
   // Add the item to the database
   try {
-    const result = await ddb.update(params).promise();
+    const result = await ddb.update(params);
     return {
       statusCode: 200,
       isBase64Encoded: false,

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.10564c98f41d5ddbd78ce6aa50e29a44184e170be4b504e0bdcdb341bf04f129/db-access.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.10564c98f41d5ddbd78ce6aa50e29a44184e170be4b504e0bdcdb341bf04f129/db-access.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 /**
  * Common function for scanning the database and getting all entries. Supports multiple functions within the system.
@@ -32,7 +36,7 @@ exports.scanTable = async () => {
   // Perform the scan
   try {
     do {
-        items = await ddb.scan(params).promise();
+        items = await ddb.scan(params);
         items.Items.forEach((item) => scanResults.push(item));
         params.ExclusiveStartKey = items.LastEvaluatedKey;
     } while (typeof items.LastEvaluatedKey != "undefined");

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.2fb39e0373d6f20a4401e739e60d1bdd11336524b9c11c1dab68ffbda0ecc8ac/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.2fb39e0373d6f20a4401e739e60d1bdd11336524b9c11c1dab68ffbda0ecc8ac/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const sns = new aws.SNS();
+
+
+const { SNS } = require('@aws-sdk/client-sns');
+
+const sns = new SNS();
 const db_access = require('/opt/db-access');
 
 // Handler

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.346587a19365916b741034524422c072ee85b4b82a0e01fb28ef8dc62bdb9737/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.346587a19365916b741034524422c072ee85b4b82a0e01fb28ef8dc62bdb9737/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 // Handler
 exports.handler = async (event) => {
@@ -34,7 +38,7 @@ exports.handler = async (event) => {
 
   // Add the item to the database
   try {
-    const res = await ddb.update(params).promise();
+    const res = await ddb.update(params);
     return {
       statusCode: 200,
       isBase64Encoded: false,

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.3839faae79dc98cb27aae54e5c7f0c281592853e7fb0f04238098ad02a25952c/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.3839faae79dc98cb27aae54e5c7f0c281592853e7fb0f04238098ad02a25952c/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 // Handler
 exports.handler = async (event) => {
@@ -32,7 +36,7 @@ exports.handler = async (event) => {
 
   // Perform the query
   try {
-    const result = await ddb.query(params).promise();
+    const result = await ddb.query(params);
     // Extract the order JSON objects
     const orders = Array.from(result.Items);
     // Return the open orders

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.4f68e3c9c9ef25dd3a0ab1b75b4ec4160f42d539455b8b740b30f1dd63a4279f/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.4f68e3c9c9ef25dd3a0ab1b75b4ec4160f42d539455b8b740b30f1dd63a4279f/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const s3 = new aws.S3();
+
+
+const { S3 } = require('@aws-sdk/client-s3');
+
+const s3 = new S3();
 
 exports.handler = async (event) => {
   
@@ -30,7 +33,7 @@ exports.handler = async (event) => {
   
   // Get the report
   try {
-    const res = await s3.getObject(params).promise();
+    const res = await s3.getObject(params);
     const parsed = res.Body.toString('utf-8');
     console.log(parsed);
     return {

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.7a6c4181d571838b594e6f6302b673b5a8b742ce7883564f8a999dfa1d7a127a/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.7a6c4181d571838b594e6f6302b673b5a8b742ce7883564f8a999dfa1d7a127a/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const sfn = new aws.StepFunctions();
+
+
+const { SFN } = require('@aws-sdk/client-sfn');
+
+const sfn = new SFN();
 
 // Handler
 exports.handler = async (event) => {
@@ -25,7 +28,7 @@ exports.handler = async (event) => {
   
   // Start the process
   try {
-    const res = await sfn.startExecution(params).promise();
+    const res = await sfn.startExecution(params);
     console.log(res);
     return {
       statusCode: 200,

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.88ec26b42a619db3e17e631a48cafc832846e38392a4c7dc37cfa1f8bbb60889/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.88ec26b42a619db3e17e631a48cafc832846e38392a4c7dc37cfa1f8bbb60889/index.js
@@ -12,8 +12,11 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const s3 = new aws.S3();
+
+
+const { S3 } = require('@aws-sdk/client-s3');
+
+const s3 = new S3();
 const db_access = require('/opt/db-access');
 
 exports.handler = async (event) => {
@@ -60,7 +63,7 @@ exports.handler = async (event) => {
   
   // Save the report
   try {
-    await s3.putObject(s3_params).promise();
+    await s3.putObject(s3_params);
     console.log(`Successfully saved the report to "${process.env.S3_BUCKET_NAME}"`);
     console.log(`Report filename: "${s3_params.Key}"`);
   } catch (err) {

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d7ef2fab3e8af1933261371cc1e90baab16122dc5fca1ca9e5ea26a4720f4eee/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d7ef2fab3e8af1933261371cc1e90baab16122dc5fca1ca9e5ea26a4720f4eee/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 const { v4: uuidv4 } = require('uuid');
 
 // Handler
@@ -40,7 +44,7 @@ exports.handler = async (event) => {
 
   // Add the item to the database
   try {
-    const res = await ddb.put(params).promise();
+    const res = await ddb.put(params);
     return {
       statusCode: 200,
       isBase64Encoded: false,

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d9c8ab1f5d6efbc37cfaab8bd8ee8265fbb94dd7feb78d837918fd6ab39b2ce5/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.d9c8ab1f5d6efbc37cfaab8bd8ee8265fbb94dd7feb78d837918fd6ab39b2ce5/index.js
@@ -12,9 +12,14 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const s3 = new aws.S3();
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+const { S3 } = require('@aws-sdk/client-s3');
+
+const s3 = new S3();
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 const db_access = require('/opt/db-access');
 
 exports.handler = async (event) => {
@@ -46,7 +51,7 @@ exports.handler = async (event) => {
   
   // Save the report
   try {
-    await s3.putObject(s3_params).promise();
+    await s3.putObject(s3_params);
     console.log(`Successfully saved the report to "${process.env.S3_BUCKET_NAME}"`);
     console.log(`Report filename: "${s3_params.Key}"`);
   } catch (err) {

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.f3fb724d107c92bcdc47f3123f612fd2cd0eecd312331259982cb439df89f4eb/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.f3fb724d107c92bcdc47f3123f612fd2cd0eecd312331259982cb439df89f4eb/index.js
@@ -12,8 +12,12 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
+
+
+const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
 
 // Handler
 exports.handler = async (event) => {
@@ -37,7 +41,7 @@ exports.handler = async (event) => {
 
   // Add the item to the database
   try {
-    const result = await ddb.update(params).promise();
+    const result = await ddb.update(params);
     return {
       statusCode: 200,
       isBase64Encoded: false,

--- a/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.f8a3cf841edc33c9e84f6d856e976e99961fe1fdfeccf41999021410ff1dd8b5/index.js
+++ b/source/use_cases/aws-restaurant-management-demo/test/integ.basic-deployment.js.snapshot/asset.f8a3cf841edc33c9e84f6d856e976e99961fe1fdfeccf41999021410ff1dd8b5/index.js
@@ -12,9 +12,14 @@
  */
 
 // Imports
-const aws = require('aws-sdk');
-const ddb = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
-const sns = new aws.SNS();
+
+
+const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { SNS } = require("@aws-sdk/client-sns");
+
+const ddb = DynamoDBDocument.from(new DynamoDB({apiVersion: '2012-08-10'}));
+const sns = new SNS();
 
 // Handler
 exports.handler = async (event) => {
@@ -42,7 +47,7 @@ exports.handler = async (event) => {
 
   // Query all late orders from the table
   try {
-    const result = await ddb.query(params).promise();
+    const result = await ddb.query(params);
     // Extract the order JSON objects
     const orders = Array.from(result.Items);
     // Save the open orders to the array


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/aws-solutions-constructs/issues/1145

*Description of changes:*
Migrates AWS SDK for JavaScript v2 APIs to v3

```console
$ npx aws-sdk-js-codemod@2.21 -t v2-to-v3 source/**/*.js
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.