### PR TITLE
chore(release): 2.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.66.0](https://github.com/awslabs/aws-solutions-constructs/compare/v2.65.0...v2.66.0) (2024-08-22)
+
 ## [2.65.0](https://github.com/awslabs/aws-solutions-constructs/compare/v2.64.0...v2.65.0) (2024-08-11)
 
 Built on CDK v2.150.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Built on CDK v2.145.0
 
 * **aws-constructs-factories:** add a factory for sqs queues ([#1131](https://github.com/awslabs/aws-solutions-constructs/issues/1131)) ([b35b9b8](https://github.com/awslabs/aws-solutions-constructs/commit/b35b9b86dcbda1d90dceac1cc539be816defe288))
 
+WARNING - This release changes the resource IDs of DLQs. As a result a stack update will delete the existing DLQ and create a new one. Before updating your stack, process all messages in your current DLQ.
+
 ## [2.59.0](https://github.com/awslabs/aws-solutions-constructs/compare/v2.58.1...v2.59.0) (2024-06-08)
 
 Built on CDK v2.143.0

--- a/deployment/v2/align-version.js
+++ b/deployment/v2/align-version.js
@@ -10,7 +10,7 @@ const nullVersionMarker = process.argv[2];
 const targetSolutionsConstructsVersion = process.argv[3];
 
 // these versions need to be sourced from a config file
-const awsCdkLibVersion = '2.150.0';
+const awsCdkLibVersion = '2.151.0';
 
 for (const file of process.argv.splice(4)) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());

--- a/source/lerna.json
+++ b/source/lerna.json
@@ -6,5 +6,5 @@
     "./patterns/@aws-solutions-constructs/*"
   ],
   "rejectCycles": "true",
-  "version": "2.65.0"
+  "version": "2.66.0"
 }


### PR DESCRIPTION
See [CHANGELOG](https://github.com/awslabs/aws-solutions-constructs/blob/bump/2.66.0/CHANGELOG.md)