### PR TITLE
fix(version): unpin constructs from specific cdk version

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-apigatewayv2websocket-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigatewayv2websocket-sqs/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-cloudfront-apigateway": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-constructs-factories/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-constructs-factories/package.json
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "^0.0.0",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
@@ -84,7 +84,7 @@
     "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
@@ -81,7 +81,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "^0.0.0",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
@@ -84,7 +84,7 @@
     "@aws-solutions-constructs/aws-iot-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-dynamodb": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
@@ -80,6 +80,6 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
@@ -80,6 +80,6 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
@@ -82,7 +82,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "^0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisstreams-lambda": "0.0.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "^0.0.0",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
@@ -84,7 +84,7 @@
     "@aws-solutions-constructs/aws-lambda-sqs": "0.0.0",
     "@aws-solutions-constructs/aws-sqs-lambda": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
@@ -81,6 +81,6 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
@@ -84,7 +84,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
@@ -82,7 +82,7 @@
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-route53-alb": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
-    "aws-cdk-lib": "0.0.0",
+    "aws-cdk-lib": "^0.0.0",
     "constructs": "^10.0.0"
   },
   "keywords": [

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/source/patterns/@aws-solutions-constructs/core/package.json
+++ b/source/patterns/@aws-solutions-constructs/core/package.json
@@ -88,6 +88,6 @@
   ],
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }

--- a/source/patterns/@aws-solutions-constructs/resources/package.json
+++ b/source/patterns/@aws-solutions-constructs/resources/package.json
@@ -87,6 +87,6 @@
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "^0.0.0"
   }
 }


### PR DESCRIPTION

*Description of changes:*
Constructs should be satisfied with the any version of CDK equal to or greater than the version upon which they were built. This PR restores that by putting the ^ back into the peerDependency version specification.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.