### PR TITLE
feat(aws-constructs-factories): add cloudwatch alarms to factory output

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/lib/openapi-helper.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/lib/openapi-helper.ts
@@ -163,8 +163,7 @@ export function ObtainApiDefinition(scope: Construct, props: ObtainApiDefinition
       apiDefinitionWriter.s3Key
     );
   } else if (apiRawInlineSpec) {
-    const apiInlineSpec = new apigateway.InlineApiDefinition(apiRawInlineSpec);
-    newApiDefinition = InlineTemplateWriter(apiInlineSpec.bind(scope), apiIntegrationUris);
+    newApiDefinition = InlineTemplateWriter(apiRawInlineSpec, apiIntegrationUris);
   } else {
     throw new Error("No definition provided (this code should be unreachable)");
   }
@@ -172,8 +171,8 @@ export function ObtainApiDefinition(scope: Construct, props: ObtainApiDefinition
   return newApiDefinition!;
 }
 
-function InlineTemplateWriter({ inlineDefinition }: apigateway.ApiDefinitionConfig, templateValues: resources.TemplateValue[]) {
-  let template = JSON.stringify(inlineDefinition);
+function InlineTemplateWriter(rawInlineSpec: any, templateValues: resources.TemplateValue[]) {
+  let template = JSON.stringify(rawInlineSpec);
 
   // This replicates logic in the template writer custom resource (resources/lib/template-writer-custom-resource/index.ts),
   // any logic changes should be made to both locations every time

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/test.openapigateway-lambda.test.ts
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/test/test.openapigateway-lambda.test.ts
@@ -625,14 +625,14 @@ test('ObtainApiDefinition from inline JSON spec', () => {
       tokenToFunctionMap: apiLambdaFunctions
     });
 
+  const template = Template.fromStack(stack);
+  template.resourceCountIs("Custom::TemplateWriter", 0);
+
   expect(api).toBeDefined();
   expect((api as any).definition).toBeDefined();
   expect((api as any).definition.openapi).toEqual("3.0.1");
   expect((api as any).definition.info).toBeDefined();
   expect((api as any).definition.paths).toBeDefined();
-
-  const template = Template.fromStack(stack);
-  template.resourceCountIs("Custom::TemplateWriter", 0);
 
 });
 


### PR DESCRIPTION
*Description of changes:*
All Step Functions constructs create default CloudWatch alarms, but at the construct level so they aren't created in the factory. This PR moves that functionality to the core helper functions so the Factory will also create these alarms.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.