### PR TITLE
chore(all): copyright headers in test lambda functions

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function (event) {
   console.log("request:", JSON.stringify(event, undefined, 2));
   return {

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 var AWS = require('aws-sdk');
 var path = require('path');
 

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     console.log('request:', JSON.stringify(event, undefined, 2));
     return {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     console.log('request:', JSON.stringify(event, undefined, 2));
     return {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function (event) {
   console.log(`request:${JSON.stringify(event, undefined, 2)}`);
   return {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 var AWS = require('aws-sdk');
 var path = require('path');
 

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     console.log('request:', JSON.stringify(event, undefined, 2));
     return {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 var AWS = require('aws-sdk');
 var path = require('path');
 

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     console.log('request:', JSON.stringify(event, undefined, 2));
     return {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     console.log('request:', JSON.stringify(event, undefined, 2));
     return {

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-task/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda-task/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async event => {
   // Log the event argument for debugging and for use in local development.
   console.log(JSON.stringify(event, undefined, 2));

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 const aws = require('aws-sdk');
 
 console.log('Loading function');

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     console.log('request:', JSON.stringify(event, undefined, 2));
     return {

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     console.log('request:', JSON.stringify(event, undefined, 2));
     return {

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-pipes-stepfunctions/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-pipes-stepfunctions/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async (event) => { 
   console.log(event); 
   const response = event.map((x) =>{

--- a/source/patterns/@aws-solutions-constructs/core/test/lambda-test/index.js
+++ b/source/patterns/@aws-solutions-constructs/core/test/lambda-test/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 exports.handler = async function(event) {
     return {
       statusCode: 200,

--- a/source/patterns/@aws-solutions-constructs/core/test/lambda/index.js
+++ b/source/patterns/@aws-solutions-constructs/core/test/lambda/index.js
@@ -1,3 +1,16 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
 console.log('Loading function');
 
 exports.handler = async (event, context) => {


### PR DESCRIPTION
The Lambda function source files for our unit and integration tests were missing some copyright/license headers - this PR addresses that.