### PR TITLE
chore(package.json): move proper packages to devDependencies

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -20,8 +20,6 @@ This software includes third party software subject to the following copyrights:
 aws-cdk under the Apache License Version 2.0
 aws-sdk under the Apache License Version 2.0
 aws-sdk-mock under the Apache License Version 2.0
-bootstrap under the Massachusetts Institute of Technology (MIT) license
-chai under the Massachusetts Institute of Technology (MIT) license
 color under the Massachusetts Institute of Technology (MIT) license
 color-name under the Massachusetts Institute of Technology (MIT) license
 deepmerge under the MIT License

--- a/source/THIRD-PARTY-LICENSES.txt
+++ b/source/THIRD-PARTY-LICENSES.txt
@@ -1,0 +1,522 @@
+** @aws-sdk/client-kms; version 3.687 -- https://github.com/aws/aws-sdk-js-v3.git
+** @aws-sdk/client-s3; version 3.689.0 -- https://github.com/aws/aws-sdk-js-v3.git
+ 
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+* For @aws-sdk/client-kms see also this required NOTICE:
+    /*
+     * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License").
+     * You may not use this file except in compliance with the License.
+     * A copy of the License is located at
+     *
+     *  http://aws.amazon.com/apache2.0
+     *
+     * or in the "license" file accompanying this file. This file is distributed
+     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+     * express or implied. See the License for the specific language governing
+     * permissions and limitations under the License.
+     */
+
+* For @aws-sdk/client-s3 see also this required NOTICE:
+    /*
+     * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License").
+     * You may not use this file except in compliance with the License.
+     * A copy of the License is located at
+     *
+     *  http://aws.amazon.com/apache2.0
+     *
+     * or in the "license" file accompanying this file. This file is distributed
+     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+     * express or implied. See the License for the specific language governing
+     * permissions and limitations under the License.
+     */
+
+
+------
+
+** Constructs; version 10.4.2 -- https://github.com/aws/constructs
+ 
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+* For Constructs see also this required NOTICE:
+    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+------
+
+** npmlog; version 7.0.1 -- https://github.com/npm/npmlog.git
+Copyright npm, Inc.
+ 
+<!-- This file is automatically added by @npmcli/template-oss. Do not edit. -->
+
+ISC License
+
+Copyright npm, Inc.
+
+Permission to use, copy, modify, and/or distribute this
+software for any purpose with or without fee is hereby
+granted, provided that the above copyright notice and this
+permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND NPM DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
+EVENT SHALL NPM BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------
+
+** deepmerge; version 4.3.1 -- https://github.com/TehShrike/deepmerge
+Copyright (c) 2012 James Halliday, Josh Duff, and other contributors
+ 
+The MIT License (MIT)
+
+Copyright (c) 2012 James Halliday, Josh Duff, and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------
+
+** deep-diff; version 1.0.2 -- git://github.com/flitbit/diff.git
+Copyright (c) 2011-2018 Phillip Clark
+ 
+Copyright (c) 2011-2018 Phillip Clark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/source/package.json
+++ b/source/package.json
@@ -14,27 +14,27 @@
   },
   "private": true,
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "2.163.1-alpha.0",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
-    "eslint": "^6.8.0",
-    "eslint-import-resolver-node": "^0.3.2",
-    "eslint-import-resolver-typescript": "^2.0.0",
-    "eslint-plugin-import": "^2.19.1",
-    "eslint-plugin-license-header": "^0.2.0",
     "fs-extra": "^8.1.0",
+    "typescript": "4.7.4",
     "jest": "^27.4.0",
     "jsii": "~5.4.26",
     "jsii-rosetta": "~5.4.25",
     "jsii-pacmak": "^1.92.0",
     "tslint": "^5.20.1",
-    "typescript": "4.7.4",
-    "constructs": "^10.0.0"
-  },
-  "devDependencies": {
     "lerna": "8.1.8",
+    "eslint": "^6.8.0",
+    "eslint-import-resolver-node": "^0.3.2",
+    "eslint-import-resolver-typescript": "^2.0.0",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-license-header": "^0.2.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "0.0.0"
+    "aws-cdk-lib": "2.163.1"
   },
   "workspaces": {
     "packages": [

--- a/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-fargate/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",

--- a/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-alb-lambda/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@types/node": "^10.3.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-dynamodb/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-kinesisstreams/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-lambda/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sagemakerendpoint/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-sqs/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-apigatewayv2websocket-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-apigatewayv2websocket-sqs/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway-lambda/package.json
@@ -53,12 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/aws-cloudfront-apigateway": "0.0.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-apigateway/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-mediastore/package.json
@@ -53,11 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cloudfront-s3/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-cognito-apigateway-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-constructs-factories/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-constructs-factories/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0",
     "constructs": "^10.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda-elasticsearch-kibana/package.json
@@ -53,14 +53,13 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-dynamodbstreams-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-elasticsearch-kibana": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-dynamodbstreams-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisfirehose-s3/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-kinesisstreams/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sns/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-sqs/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-eventbridge-stepfunctions/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-dynamodb/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-eventbridge/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisfirehose/package.json
@@ -53,17 +53,15 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
-    "aws-cdk-lib": "0.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.0.0",
+    "aws-cdk-lib": "0.0.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-kinesisstreams/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-opensearch/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-s3/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-secretsmanager/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sns/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-sqs/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-ssmstringparameter/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@aws-solutions-constructs/core": "0.0.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-fargate-stepfunctions/package.json
@@ -53,13 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@aws-solutions-constructs/core": "0.0.0",
-    "@types/jest": "^26.0.22",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisfirehose-s3/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-kinesisstreams/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda-dynamodb/package.json
@@ -53,14 +53,13 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-iot-lambda": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-dynamodb": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-s3/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-iot-sqs/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisfirehose-s3/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-gluejob/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3/package.json
@@ -53,14 +53,13 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisstreams-lambda": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-kinesisstreams-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-dynamodb/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticachememcached/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-elasticsearch-kibana/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-eventbridge/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kendra/package.json
@@ -49,12 +49,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0",
     "@aws-solutions-constructs/core": "0.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisfirehose/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-kinesisfirehose-s3": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-kinesisstreams/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-opensearch/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-s3/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sagemakerendpoint/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-secretsmanager/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.23",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sns/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs-lambda/package.json
@@ -53,14 +53,13 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-lambda-sqs": "0.0.0",
     "@aws-solutions-constructs/aws-sqs-lambda": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-sqs/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-ssmstringparameter/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.23",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-lambda-stepfunctions/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "eslint-plugin-import": "^2.22.0",
     "constructs": "^10.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-openapigateway-lambda/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "@aws-sdk/client-s3": "^3.0.0",
     "@types/aws-lambda": "^8.0.0",

--- a/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-alb/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0",
     "@types/node": "^10.3.0",

--- a/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-route53-apigateway/package.json
@@ -53,14 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
-    "prettier": "^2.5.1",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"
   },

--- a/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sns/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-sqs/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-s3-stepfunctions/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-eventbridge-stepfunctions": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sns-sqs/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-lambda/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-sqs-pipes-stepfunctions/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-sqs-pipes-stepfunctions/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/resources": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-alb/package.json
@@ -53,13 +53,12 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "@aws-solutions-constructs/aws-route53-alb": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-apigateway/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-appsync/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "aws-cdk-lib": "0.0.0",
     "constructs": "^10.0.0"

--- a/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
+++ b/source/patterns/@aws-solutions-constructs/aws-wafwebacl-cloudfront/package.json
@@ -53,12 +53,11 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-solutions-constructs/core": "0.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/core/package.json
+++ b/source/patterns/@aws-solutions-constructs/core/package.json
@@ -52,7 +52,6 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "deep-diff": "^1.0.2",
     "deepmerge": "^4.0.0",
     "npmlog": "^7.0.0",

--- a/source/patterns/@aws-solutions-constructs/resources/package.json
+++ b/source/patterns/@aws-solutions-constructs/resources/package.json
@@ -52,7 +52,6 @@
     }
   },
   "dependencies": {
-    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@aws-sdk/client-kms": "^3.478.0",
     "@aws-sdk/client-s3": "^3.478.0",
     "@aws-solutions-constructs/core": "0.0.0",
@@ -60,7 +59,7 @@
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
     "aws-cdk-lib": "0.0.0"

--- a/source/patterns/@aws-solutions-constructs/resources/package.json
+++ b/source/patterns/@aws-solutions-constructs/resources/package.json
@@ -55,10 +55,10 @@
     "@aws-sdk/client-kms": "^3.478.0",
     "@aws-sdk/client-s3": "^3.478.0",
     "@aws-solutions-constructs/core": "0.0.0",
-    "aws-sdk-client-mock": "^3.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "aws-sdk-client-mock": "^3.0.0",
     "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@types/node": "^10.3.0",
     "constructs": "^10.0.0",
@@ -80,8 +80,7 @@
   },
   "bundledDependencies": [
     "@aws-sdk/client-kms",
-    "@aws-sdk/client-s3",
-    "aws-sdk-client-mock"
+    "@aws-sdk/client-s3"
   ],
   "peerDependencies": {
     "@aws-solutions-constructs/core": "0.0.0",

--- a/source/use_cases/THIRD-PARTY-LICENSES.txt
+++ b/source/use_cases/THIRD-PARTY-LICENSES.txt
@@ -1,0 +1,894 @@
+** aws-cdk-lib; version 2.163.1 -- https://github.com/aws/aws-cdk.git
+ 
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+* For aws-cdk-lib see also this required NOTICE:
+    Copyright 2018-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+------
+
+** @aws-cdk/integ-tests-alpha; version 2.163.1 -- https://github.com/aws/aws-cdk.git
+ 
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+* For @aws-cdk/integ-tests-alpha see also this required NOTICE:
+    AWS Cloud Development Kit (AWS CDK)
+    Copyright 2018-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+------
+
+** typescript; version 4.9.5 -- https://www.typescriptlang.org/
+ 
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide, non-
+exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce,
+prepare Derivative Works of, publicly display, publicly perform, sublicense, and
+distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-
+charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License. You may add Your own copyright statement to Your
+modifications and may provide additional or different license terms and
+conditions for use, reproduction, or distribution of Your modifications, or for
+any such Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated in this
+License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any character
+arising as a result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility of such
+damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree to
+indemnify, defend, and hold each Contributor harmless for any liability incurred
+by, or claims asserted against, such Contributor by reason of your accepting any
+such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+* For typescript see also this required NOTICE:
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+------
+
+** Constructs; version 10.4.2 -- https://github.com/aws/constructs
+ 
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+* For Constructs see also this required NOTICE:
+    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+------
+
+** source-map-support; version 0.5.21 -- https://github.com/evanw/node-source-map-support
+Copyright (c) 2014 Evan Wallace
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+The MIT License (MIT)
+
+Copyright (c) 2014 Evan Wallace
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------
+
+** uuid; version 8.3.2 -- https://github.com/uuidjs/uuid
+Copyright (c) 2010-2020 Robert Kieffer and other contributors
+ 
+The MIT License (MIT)
+
+Copyright (c) 2010-2020 Robert Kieffer and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------
+
+** @types/jest; version 27.5.2 -- https://www.npmjs.com/package/@types/jest
+Copyright (c) Microsoft Corporation.
+** @types/node; version 10.17.60 -- https://www.npmjs.com/package/@types/node?activeTab=readme
+Copyright (c) Microsoft Corporation.
+ 
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE
+    SOFTWARE


### PR DESCRIPTION
Moving packages that are not distributed to devDependencies to remove them from package license reports.