### PR TITLE
chore(all): update to latest cdk, unlock from fixed version in source/package.json

### DIFF
--- a/deployment/v2/align-version.js
+++ b/deployment/v2/align-version.js
@@ -10,7 +10,7 @@ const nullVersionMarker = process.argv[2];
 const targetSolutionsConstructsVersion = process.argv[3];
 
 // these versions need to be sourced from a config file
-const awsCdkLibVersion = '2.163.1';
+const awsCdkLibVersion = '2.173.2';
 
 for (const file of process.argv.splice(4)) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());

--- a/source/package.json
+++ b/source/package.json
@@ -17,7 +17,7 @@
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@aws-cdk/integ-tests-alpha": "2.163.1-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "0.0.0-alpha.0",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "fs-extra": "^8.1.0",
@@ -34,7 +34,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-license-header": "^0.2.0",
     "constructs": "^10.0.0",
-    "aws-cdk-lib": "2.163.1"
+    "aws-cdk-lib": "0.0.0"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
A fixed version number slipped into source/package.json and prevented updating the CDK (this was a bug). It is removed to enable us to change CDK versions.