### PR TITLE
docs: remove broken links from aws-apigateway-iot readme

### DIFF
--- a/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/README.md
+++ b/source/patterns/@aws-solutions-constructs/aws-apigateway-iot/README.md
@@ -99,13 +99,13 @@ Out of the box implementation of the Construct without any override will set the
 * Enable X-Ray Tracing
 * Creates a UsagePlan and associates to `prod` stage
 
-Below is a description of the different resources and methods exposed by the API Gateway after deploying the Construct. See the [Examples](#examples) section for more information on how to easily test these endpoints using `curl`.
+Below is a description of the different resources and methods exposed by the API Gateway after deploying the Construct.
 
 |Method         | Resource              | Query parameter(s) |  Return code(s)   |  Description|
 |-------------- | --------------------- | ------------------ | ----------------- | -----------------|
 |  **POST**     |  `/message/<topics>`  |      **qos**       |   `200/403/500`   | By calling this endpoint, you need to pass the topics on which you would like to publish (e.g `/message/device/foo`).|
-|  **POST**     | `/shadow/<thingName>` |      **None**      |   `200/403/500`   | This route allows to update the shadow document of a thing, given its `thingName` using Unnamed (classic) shadow type. The body shall comply with the standard shadow structure comprising a `state` node and associated `desired` and `reported` nodes. See the [Updating device shadows](#updating-device-shadows) section for an example.|
-|  **POST**     | `/shadow/<thingName>/<shadowName>` |      **None**      |   `200/403/500`   | This route allows to update the named shadow document of a thing, given its `thingName` and the `shadowName` using the Named shadow type. The body shall comply with the standard shadow structure comprising a `state` node and associated `desired` and `reported` nodes. See the [Updating named shadows](#updating-named-shadows) section for an example.|
+|  **POST**     | `/shadow/<thingName>` |      **None**      |   `200/403/500`   | This route allows to update the shadow document of a thing, given its `thingName` using Unnamed (classic) shadow type. The body shall comply with the standard shadow structure comprising a `state` node and associated `desired` and `reported` nodes.|
+|  **POST**     | `/shadow/<thingName>/<shadowName>` |      **None**      |   `200/403/500`   | This route allows to update the named shadow document of a thing, given its `thingName` and the `shadowName` using the Named shadow type. The body shall comply with the standard shadow structure comprising a `state` node and associated `desired` and `reported` nodes.|
 
 ## Architecture
 


### PR DESCRIPTION
*Issue #, if available:*
N/a

*Description of changes:*
This PR removes three (3) broken links from the aws-apigateway-iot README file. If the content that these links reference has been moved elsewhere, and they should be updated instead of deleted, please advise in the comments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.