### PR TITLE
docs: correct spelling of solutions in index.html

### DIFF
--- a/source/use_cases/aws-s3-static-website/lib/website-dist/index.html
+++ b/source/use_cases/aws-s3-static-website/lib/website-dist/index.html
@@ -8,6 +8,6 @@
   <body>
     <div id="content">This web site was deployed with
       the <a href="https://docs.aws.amazon.com/cdk/v2/guide/home.html">AWS CDK</a>
-      and <a href="https://docs.aws.amazon.com/solutions/latest/constructs/welcome.html">AWS Solutios Constructs</a>!</div>
+      and <a href="https://docs.aws.amazon.com/solutions/latest/constructs/welcome.html">AWS Solutions Constructs</a>!</div>
   </body>
 </html>


### PR DESCRIPTION
*Issue #, if available:*

In the index.html file, the spelling of solutions is incorrect. There is an 'n' missing. 

*Description of changes:*

Correct the typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.